### PR TITLE
Fix the issue #527.

### DIFF
--- a/spring-cloud-alibaba-sentinel/src/main/java/org/springframework/cloud/alibaba/sentinel/endpoint/SentinelEndpointAutoConfiguration.java
+++ b/spring-cloud-alibaba-sentinel/src/main/java/org/springframework/cloud/alibaba/sentinel/endpoint/SentinelEndpointAutoConfiguration.java
@@ -20,6 +20,7 @@ import org.springframework.boot.actuate.autoconfigure.endpoint.condition.Conditi
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.alibaba.sentinel.SentinelProperties;
 import org.springframework.context.annotation.Bean;
@@ -29,6 +30,7 @@ import org.springframework.context.annotation.Bean;
  */
 @ConditionalOnClass(Endpoint.class)
 @EnableConfigurationProperties({ SentinelProperties.class })
+@ConditionalOnProperty(name = "spring.cloud.sentinel.enabled", matchIfMissing = true)
 public class SentinelEndpointAutoConfiguration {
 
 	@Bean


### PR DESCRIPTION
When disable sentinel, the endpoint fail to instantiated since missing
'sentinelDataSourceHandler'.

###
The request is to fix issue #527 . Which missing require bean when disalbe sentinel

###
The fix is to add the condition on 'SentinelEndpointAutoConfiguration' the same as 'SentinelWebAutoConfiguration', so that both configuation will be enable or disable at the same time.

###
To verify it just try the issue again then the error should be disappear.

