### PR TITLE
Use YamlMapFactoryBean for yaml config loading to keep config-item order

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,0 @@
--DaltSnapshotDeploymentRepository=repo.spring.io::default::https://repo.spring.io/libs-snapshot-local -P spring

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+<servers>
+	<server>
+		<id>nexus</id>
+		<username>admin</username>
+		<password>admin123</password>
+	</server>
+	<server>
+		<id>releases</id>
+		<username>admin</username>
+		<password>admin123</password>
+	</server>
+	<server>
+		<id>snapshots</id>
+		<username>admin</username>
+		<password>admin123</password>
+	</server>
+</servers>
+
+<mirrors>
+<mirror>
+      <id>nexus</id>
+      <mirrorOf>central</mirrorOf>
+      <url>http://nexus.zhenai.com:8081/content/groups/public/</url>
+   </mirror>
+</mirrors>
+
+<profiles>
+  	<profile>
+      <id>development</id>
+      <repositories>
+        <repository>
+          <id>central</id>
+          <url>http://central</url>
+          <releases><enabled>true</enabled></releases>
+          <snapshots><enabled>true</enabled></snapshots>
+        </repository>
+      </repositories>
+
+     	<pluginRepositories>
+        <pluginRepository>
+          <id>central</id>
+          <url>http://central</url>
+          <releases><enabled>true</enabled></releases>
+          <snapshots><enabled>true</enabled></snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+ 	<activeProfiles>
+    <activeProfile>development</activeProfile>
+  </activeProfiles>
+</settings>

--- a/pom.xml
+++ b/pom.xml
@@ -168,67 +168,75 @@
     </build>
 
     <profiles>
-        <profile>
-            <id>spring</id>
-            <repositories>
-                <repository>
-                    <id>spring-snapshots</id>
-                    <name>Spring Snapshots</name>
-                    <url>https://repo.spring.io/libs-snapshot-local</url>
-                    <snapshots>
-                        <enabled>true</enabled>
-                    </snapshots>
-                    <releases>
-                        <enabled>false</enabled>
-                    </releases>
-                </repository>
-                <repository>
-                    <id>spring-milestones</id>
-                    <name>Spring Milestones</name>
-                    <url>https://repo.spring.io/libs-milestone-local</url>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                </repository>
-                <repository>
-                    <id>spring-releases</id>
-                    <name>Spring Releases</name>
-                    <url>https://repo.spring.io/release</url>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                </repository>
-            </repositories>
-            <pluginRepositories>
-                <pluginRepository>
-                    <id>spring-snapshots</id>
-                    <name>Spring Snapshots</name>
-                    <url>https://repo.spring.io/libs-snapshot-local</url>
-                    <snapshots>
-                        <enabled>true</enabled>
-                    </snapshots>
-                    <releases>
-                        <enabled>false</enabled>
-                    </releases>
-                </pluginRepository>
-                <pluginRepository>
-                    <id>spring-milestones</id>
-                    <name>Spring Milestones</name>
-                    <url>https://repo.spring.io/libs-milestone-local</url>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                </pluginRepository>
-                <pluginRepository>
-                    <id>spring-releases</id>
-                    <name>Spring Releases</name>
-                    <url>https://repo.spring.io/libs-release-local</url>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                </pluginRepository>
-            </pluginRepositories>
-        </profile>
+        <!--<profile>-->
+            <!--<id>spring</id>-->
+            <!--<repositories>-->
+                <!--<repository>-->
+                    <!--<id>spring-snapshots</id>-->
+                    <!--<name>Spring Snapshots</name>-->
+                    <!--<url>https://repo.spring.io/libs-snapshot-local</url>-->
+                    <!--<snapshots>-->
+                        <!--<enabled>true</enabled>-->
+                    <!--</snapshots>-->
+                    <!--<releases>-->
+                        <!--<enabled>false</enabled>-->
+                    <!--</releases>-->
+                <!--</repository>-->
+                <!--<repository>-->
+                    <!--<id>spring-milestones</id>-->
+                    <!--<name>Spring Milestones</name>-->
+                    <!--<url>https://repo.spring.io/libs-milestone-local</url>-->
+                    <!--<snapshots>-->
+                        <!--<enabled>false</enabled>-->
+                    <!--</snapshots>-->
+                <!--</repository>-->
+                <!--<repository>-->
+                    <!--<id>spring-releases</id>-->
+                    <!--<name>Spring Releases</name>-->
+                    <!--<url>https://repo.spring.io/release</url>-->
+                    <!--<snapshots>-->
+                        <!--<enabled>false</enabled>-->
+                    <!--</snapshots>-->
+                <!--</repository>-->
+            <!--</repositories>-->
+            <!--<pluginRepositories>-->
+                <!--<pluginRepository>-->
+                    <!--<id>spring-snapshots</id>-->
+                    <!--<name>Spring Snapshots</name>-->
+                    <!--<url>https://repo.spring.io/libs-snapshot-local</url>-->
+                    <!--<snapshots>-->
+                        <!--<enabled>true</enabled>-->
+                    <!--</snapshots>-->
+                    <!--<releases>-->
+                        <!--<enabled>false</enabled>-->
+                    <!--</releases>-->
+                <!--</pluginRepository>-->
+                <!--<pluginRepository>-->
+                    <!--<id>spring-milestones</id>-->
+                    <!--<name>Spring Milestones</name>-->
+                    <!--<url>https://repo.spring.io/libs-milestone-local</url>-->
+                    <!--<snapshots>-->
+                        <!--<enabled>false</enabled>-->
+                    <!--</snapshots>-->
+                <!--</pluginRepository>-->
+                <!--<pluginRepository>-->
+                    <!--<id>spring-releases</id>-->
+                    <!--<name>Spring Releases</name>-->
+                    <!--<url>https://repo.spring.io/libs-release-local</url>-->
+                    <!--<snapshots>-->
+                        <!--<enabled>false</enabled>-->
+                    <!--</snapshots>-->
+                <!--</pluginRepository>-->
+            <!--</pluginRepositories>-->
+        <!--</profile>-->
     </profiles>
 
+    <distributionManagement>
+
+        <snapshotRepository>
+            <id>snapshots</id>
+            <url>http://nexus.zhenai.com:8081/content/repositories/snapshots/</url>
+        </snapshotRepository>
+
+    </distributionManagement>
 </project>

--- a/spring-cloud-alibaba-dependencies/pom.xml
+++ b/spring-cloud-alibaba-dependencies/pom.xml
@@ -366,58 +366,67 @@
         </dependencies>
     </dependencyManagement>
     <profiles>
-        <profile>
-            <id>spring</id>
-            <repositories>
-                <repository>
-                    <id>spring-snapshots</id>
-                    <name>Spring Snapshots</name>
-                    <url>https://repo.spring.io/libs-snapshot-local</url>
-                    <snapshots>
-                        <enabled>true</enabled>
-                    </snapshots>
-                    <releases>
-                        <enabled>false</enabled>
-                    </releases>
-                </repository>
-                <repository>
-                    <id>spring-milestones</id>
-                    <name>Spring Milestones</name>
-                    <url>https://repo.spring.io/libs-milestone-local</url>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                </repository>
-                <repository>
-                    <id>spring-releases</id>
-                    <name>Spring Releases</name>
-                    <url>https://repo.spring.io/release</url>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                </repository>
-            </repositories>
-            <pluginRepositories>
-                <pluginRepository>
-                    <id>spring-snapshots</id>
-                    <name>Spring Snapshots</name>
-                    <url>https://repo.spring.io/libs-snapshot-local</url>
-                    <snapshots>
-                        <enabled>true</enabled>
-                    </snapshots>
-                    <releases>
-                        <enabled>false</enabled>
-                    </releases>
-                </pluginRepository>
-                <pluginRepository>
-                    <id>spring-milestones</id>
-                    <name>Spring Milestones</name>
-                    <url>https://repo.spring.io/libs-milestone-local</url>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                </pluginRepository>
-            </pluginRepositories>
-        </profile>
+        <!--<profile>-->
+            <!--<id>spring</id>-->
+            <!--<repositories>-->
+                <!--<repository>-->
+                    <!--<id>spring-snapshots</id>-->
+                    <!--<name>Spring Snapshots</name>-->
+                    <!--<url>https://repo.spring.io/libs-snapshot-local</url>-->
+                    <!--<snapshots>-->
+                        <!--<enabled>true</enabled>-->
+                    <!--</snapshots>-->
+                    <!--<releases>-->
+                        <!--<enabled>false</enabled>-->
+                    <!--</releases>-->
+                <!--</repository>-->
+                <!--<repository>-->
+                    <!--<id>spring-milestones</id>-->
+                    <!--<name>Spring Milestones</name>-->
+                    <!--<url>https://repo.spring.io/libs-milestone-local</url>-->
+                    <!--<snapshots>-->
+                        <!--<enabled>false</enabled>-->
+                    <!--</snapshots>-->
+                <!--</repository>-->
+                <!--<repository>-->
+                    <!--<id>spring-releases</id>-->
+                    <!--<name>Spring Releases</name>-->
+                    <!--<url>https://repo.spring.io/release</url>-->
+                    <!--<snapshots>-->
+                        <!--<enabled>false</enabled>-->
+                    <!--</snapshots>-->
+                <!--</repository>-->
+            <!--</repositories>-->
+            <!--<pluginRepositories>-->
+                <!--<pluginRepository>-->
+                    <!--<id>spring-snapshots</id>-->
+                    <!--<name>Spring Snapshots</name>-->
+                    <!--<url>https://repo.spring.io/libs-snapshot-local</url>-->
+                    <!--<snapshots>-->
+                        <!--<enabled>true</enabled>-->
+                    <!--</snapshots>-->
+                    <!--<releases>-->
+                        <!--<enabled>false</enabled>-->
+                    <!--</releases>-->
+                <!--</pluginRepository>-->
+                <!--<pluginRepository>-->
+                    <!--<id>spring-milestones</id>-->
+                    <!--<name>Spring Milestones</name>-->
+                    <!--<url>https://repo.spring.io/libs-milestone-local</url>-->
+                    <!--<snapshots>-->
+                        <!--<enabled>false</enabled>-->
+                    <!--</snapshots>-->
+                <!--</pluginRepository>-->
+            <!--</pluginRepositories>-->
+        <!--</profile>-->
     </profiles>
+
+    <distributionManagement>
+
+        <snapshotRepository>
+            <id>snapshots</id>
+            <url>http://nexus.zhenai.com:8081/content/repositories/snapshots</url>
+        </snapshotRepository>
+
+    </distributionManagement>
 </project>


### PR DESCRIPTION
### Describe what this PR does / why we need it

The **spring-cloud-alibaba-nacos-config** use `YamlPropertiesFactoryBean` to load config in yaml format. That will load config item into a `Properties` which is unordered. There is some case we have to keep the config items order as we configured. 
e.g. When we configure `zuul routes` as follow:
```yaml
zuul.routes:
  service-1:
    path: /foo/**
  service-2:
    path: /bar/**
  service-x:
    path: /**
```
The order of the routes make sure when request a URI `/foo` will match `service-1` first.

### Does this pull request fix one issue?

NONE

### Describe how you did it

Use `YamlMapFactoryBean` instead, that load yaml config items into a `LinkedHashMap` as default.

### Describe how to verify it

Something like `zuul routes` config

### Special notes for reviews
