### PR TITLE
Fix acm-local-example

### DIFF
--- a/spring-cloud-alibaba-examples/acm-example/acm-local-example/src/main/java/com/alibaba/cloud/examples/EchoController.java
+++ b/spring-cloud-alibaba-examples/acm-example/acm-local-example/src/main/java/com/alibaba/cloud/examples/EchoController.java
@@ -19,6 +19,7 @@ package com.alibaba.cloud.examples;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -26,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
  * @author xiaolongzuo
  */
 @RestController
+@RefreshScope
 public class EchoController {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(EchoController.class);


### PR DESCRIPTION
Make the example app automatically refresh value from acm config server
by adding `@RefreshScope` annotation.


### Describe what this PR does / why we need it

As indicated by the readme-zh.md of acm-local-example in spring-cloud-alibaba-examples.  The example app should automatically refresh the value `user.id` which is fetched from acm server.  The original code failed to do that and this PR fixes it.

### Does this pull request fix one issue?

NONE

### Describe how you did it

Adding `@RefreshScope` annotation.

### Describe how to verify it

Just run acm-local-example, change the configurations from acm server and see if the value in the app changes.

### Special notes for reviews

NONE