### PR TITLE
View acm's health interface through the URL

### DIFF
--- a/spring-cloud-alibaba-examples/acm-example/acm-local-example/pom.xml
+++ b/spring-cloud-alibaba-examples/acm-example/acm-local-example/pom.xml
@@ -20,6 +20,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/spring-cloud-alibaba-examples/acm-example/acm-local-example/src/main/resources/bootstrap.properties
+++ b/spring-cloud-alibaba-examples/acm-example/acm-local-example/src/main/resources/bootstrap.properties
@@ -2,3 +2,4 @@ spring.application.name=acm-local
 server.port=18089
 spring.cloud.alicloud.acm.server-list=127.0.0.1
 spring.cloud.alicloud.acm.server-port=8080
+management.endpoints.web.exposure.include=*


### PR DESCRIPTION
### Describe what this PR does / why we need it

As indicated by the readme-zh.md of acm-local-example in spring-cloud-alibaba-examples.We can use localhost:18089/actuator/acm to vie health status of acm. The original cod failed to do that and this PR fixed it
### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
None
### Describe how you did it
Adding spring-boot-starter-actuator to pom.xml and adding management.endpoints.web.exposure.include=* to bootstrap.properties

### Describe how to verify it
Just start up your program and enter http://localhost:18089/actuator/acm

### Special notes for reviews
None