### PR TITLE
:sparkles: Introducing new features. Sentinel Support RedisDataSource…

### DIFF
--- a/spring-cloud-alibaba-dependencies/pom.xml
+++ b/spring-cloud-alibaba-dependencies/pom.xml
@@ -145,6 +145,11 @@
             </dependency>
             <dependency>
                 <groupId>com.alibaba.csp</groupId>
+                <artifactId>sentinel-datasource-redis</artifactId>
+                <version>${sentinel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.alibaba.csp</groupId>
                 <artifactId>sentinel-web-servlet</artifactId>
                 <version>${sentinel.version}</version>
             </dependency>

--- a/spring-cloud-alibaba-examples/sentinel-example/sentinel-core-example/pom.xml
+++ b/spring-cloud-alibaba-examples/sentinel-example/sentinel-core-example/pom.xml
@@ -43,6 +43,10 @@
         <!--<groupId>com.alibaba.csp</groupId>-->
         <!--<artifactId>sentinel-datasource-apollo</artifactId>-->
         <!--</dependency>-->
+        <!--<dependency>-->
+        <!--<groupId>com.alibaba.csp</groupId>-->
+        <!--<artifactId>sentinel-datasource-redis</artifactId>-->
+        <!--</dependency>-->
         <!-- define in spring-boot-autoconfigure module -->
         <!--<dependency>-->
         <!--<groupId>com.fasterxml.jackson.dataformat</groupId>-->

--- a/spring-cloud-alibaba-examples/sentinel-example/sentinel-core-example/readme-zh.md
+++ b/spring-cloud-alibaba-examples/sentinel-example/sentinel-core-example/readme-zh.md
@@ -214,9 +214,9 @@ spring.cloud.sentinel.datasource.ds2.nacos.data-type=json
 
 `ds1` 和 `ds2` 表示ReadableDataSource的名称，可随意编写。`ds1` 和 `ds2` 后面的 `file` 和 `nacos` 表示ReadableDataSource的类型。
 
-目前支持`file`, `nacos`, `zk`, `apollo` 这4种类型。
+目前支持`file`, `nacos`, `zk`, `apollo`，`redis` 这5种类型。
 
-其中`nacos`，`zk`，`apollo`这3种类型的使用需要加上对应的依赖`sentinel-datasource-nacos`, `sentinel-datasource-zookeeper`, `sentinel-datasource-apollo`。
+其中`nacos`，`zk`，`apollo`，`redis` 这4种类型的使用需要加上对应的依赖`sentinel-datasource-nacos`, `sentinel-datasource-zookeeper`, `sentinel-datasource-apollo`, `sentinel-datasource-redis`。
 
 当ReadableDataSource加载规则数据成功的时候，控制台会打印出相应的日志信息：
 

--- a/spring-cloud-alibaba-examples/sentinel-example/sentinel-core-example/readme.md
+++ b/spring-cloud-alibaba-examples/sentinel-example/sentinel-core-example/readme.md
@@ -189,9 +189,9 @@ spring.cloud.sentinel.datasource.ds2.nacos.data-type=json
 
 `ds1` and `ds2` means the name of ReadableDataSource, you can write whatever you want. The `file` and `nacos` after name `ds1` and `ds2` means the type of ReadableDataSource. 
 
-Now ReadableDataSource type support 4 categories: `file`, `nacos`, `zk` and `apollo`.
+Now ReadableDataSource type support 5 categories: `file`, `nacos`, `zk`, `apollo` and `redis`.
 
-If you want to use `nacos`, `zk` or `apollo` ReadableDataSource, you could add `sentinel-datasource-nacos`, `sentinel-datasource-zookeeper` or `sentinel-datasource-apollo` dependency.
+If you want to use `nacos`, `zk`, `apollo` or `redis` ReadableDataSource, you could add `sentinel-datasource-nacos`, `sentinel-datasource-zookeeper`,`sentinel-datasource-apollo` or `sentinel-datasource-redis` dependency.
 
 When ReadableDataSource load rule data successfully, console will print some logs:
 
@@ -204,4 +204,3 @@ When ReadableDataSource load rule data successfully, console will print some log
 For more information about Sentinel, see [Sentinel Project](https://github.com/alibaba/Sentinel).
 
 If you have any ideas or suggestions for Spring Cloud Sentinel starter, please don't hesitate to tell us by submitting github issues.
-

--- a/spring-cloud-alibaba-sentinel-datasource/pom.xml
+++ b/spring-cloud-alibaba-sentinel-datasource/pom.xml
@@ -54,6 +54,13 @@
         </dependency>
 
         <dependency>
+            <groupId>com.alibaba.csp</groupId>
+            <artifactId>sentinel-datasource-redis</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>provided</scope>

--- a/spring-cloud-alibaba-sentinel-datasource/src/main/java/com/alibaba/cloud/sentinel/datasource/config/DataSourcePropertiesConfiguration.java
+++ b/spring-cloud-alibaba-sentinel-datasource/src/main/java/com/alibaba/cloud/sentinel/datasource/config/DataSourcePropertiesConfiguration.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  * @see ApolloDataSourceProperties
  * @see ZookeeperDataSourceProperties
  * @see FileDataSourceProperties
+ * @see RedisDataSourceProperties
  */
 public class DataSourcePropertiesConfiguration {
 
@@ -43,6 +44,8 @@ public class DataSourcePropertiesConfiguration {
 	private ZookeeperDataSourceProperties zk;
 
 	private ApolloDataSourceProperties apollo;
+
+	private RedisDataSourceProperties redis;
 
 	public DataSourcePropertiesConfiguration() {
 	}
@@ -63,7 +66,11 @@ public class DataSourcePropertiesConfiguration {
 		this.apollo = apollo;
 	}
 
-	public FileDataSourceProperties getFile() {
+    public DataSourcePropertiesConfiguration(RedisDataSourceProperties redis) {
+        this.redis = redis;
+    }
+
+    public FileDataSourceProperties getFile() {
 		return file;
 	}
 
@@ -93,6 +100,14 @@ public class DataSourcePropertiesConfiguration {
 
 	public void setApollo(ApolloDataSourceProperties apollo) {
 		this.apollo = apollo;
+	}
+
+	public RedisDataSourceProperties getRedis() {
+		return redis;
+	}
+
+	public void setRedis(RedisDataSourceProperties redis) {
+		this.redis = redis;
 	}
 
 	@JsonIgnore

--- a/spring-cloud-alibaba-sentinel-datasource/src/main/java/com/alibaba/cloud/sentinel/datasource/config/RedisDataSourceProperties.java
+++ b/spring-cloud-alibaba-sentinel-datasource/src/main/java/com/alibaba/cloud/sentinel/datasource/config/RedisDataSourceProperties.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.alibaba.cloud.sentinel.datasource.config;
+
+import com.alibaba.cloud.sentinel.datasource.factorybean.RedisDataSourceFactoryBean;
+import org.springframework.util.StringUtils;
+
+import java.time.Duration;
+import java.util.List;
+
+/**
+ * Zookeeper Properties class Using by {@link DataSourcePropertiesConfiguration} and
+ * {@link RedisDataSourceFactoryBean}
+ *
+ * @author <a href="mailto:wangiegie@gmail.com">lengleng</a>
+ */
+public class RedisDataSourceProperties extends AbstractDataSourceProperties {
+
+    public RedisDataSourceProperties() {
+        super(RedisDataSourceFactoryBean.class.getName());
+    }
+
+    /**
+     * redis server host
+     */
+    private String host = "localhost";
+
+    /**
+     * redis server port
+     */
+    private int port = 6379;
+
+    /**
+     * redis server password
+     */
+    private String password;
+
+    /**
+     * redis server default select database
+     */
+    private int database;
+
+    /**
+     * redis server timeout
+     */
+    private Duration timeout;
+
+    /**
+     * Comma-separated list of "host:port" pairs.
+     */
+    private List<String> nodes;
+
+    /**
+     * data key in Redis
+     */
+    private String ruleKey;
+
+    /**
+     * channel to subscribe in Redis
+     */
+    private String channel;
+
+    /**
+     * redis sentinel model
+     */
+    private String masterId;
+
+    @Override
+    public void preCheck(String dataSourceName) {
+        super.preCheck(dataSourceName);
+        if (StringUtils.isEmpty(ruleKey)) {
+            throw new IllegalArgumentException(
+                    "RedisDataSource  ruleKey can not be empty");
+        }
+
+        if (StringUtils.isEmpty(channel)) {
+            throw new IllegalArgumentException(
+                    "RedisDataSource  channel can not be empty");
+        }
+
+        if (!StringUtils.isEmpty(masterId) && StringUtils.isEmpty(masterId)) {
+            throw new IllegalArgumentException(
+                    "RedisDataSource  sentinel model，masterId can not be empty");
+        }
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    public String getRuleKey() {
+        return ruleKey;
+    }
+
+    public void setRuleKey(String ruleKey) {
+        this.ruleKey = ruleKey;
+    }
+
+    public String getChannel() {
+        return channel;
+    }
+
+    public void setChannel(String channel) {
+        this.channel = channel;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public int getDatabase() {
+        return database;
+    }
+
+    public void setDatabase(int database) {
+        this.database = database;
+    }
+
+    public Duration getTimeout() {
+        return timeout;
+    }
+
+    public void setTimeout(Duration timeout) {
+        this.timeout = timeout;
+    }
+
+    public List<String> getNodes() {
+        return nodes;
+    }
+
+    public void setNodes(List<String> nodes) {
+        this.nodes = nodes;
+    }
+
+    public String getMasterId() {
+        return masterId;
+    }
+
+    public void setMasterId(String masterId) {
+        this.masterId = masterId;
+    }
+}

--- a/spring-cloud-alibaba-sentinel-datasource/src/main/java/com/alibaba/cloud/sentinel/datasource/factorybean/RedisDataSourceFactoryBean.java
+++ b/spring-cloud-alibaba-sentinel-datasource/src/main/java/com/alibaba/cloud/sentinel/datasource/factorybean/RedisDataSourceFactoryBean.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (C) 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.sentinel.datasource.factorybean;
+
+import com.alibaba.csp.sentinel.datasource.Converter;
+import com.alibaba.csp.sentinel.datasource.redis.RedisDataSource;
+import com.alibaba.csp.sentinel.datasource.redis.config.RedisConnectionConfig;
+import com.alibaba.csp.sentinel.slots.block.flow.FlowRule;
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+import java.time.Duration;
+import java.util.List;
+
+/**
+ * A {@link FactoryBean} for creating {@link RedisDataSource} instance.
+ *
+ * @author <a href="mailto:wangiegie@gmail.com">lengleng</a>
+ * @see RedisDataSource
+ */
+public class RedisDataSourceFactoryBean implements FactoryBean<RedisDataSource> {
+
+    private String host;
+
+    private int port;
+
+    private int database;
+
+    private Duration timeout;
+
+    /**
+     * Comma-separated list of "host:port" pairs.
+     */
+    private List<String> nodes;
+
+    private Converter converter;
+
+    /**
+     * data key in Redis
+     */
+    private String ruleKey;
+
+    /**
+     * channel to subscribe in Redis
+     */
+    private String channel;
+
+    /**
+     * redis server password
+     */
+    private String password;
+
+    private String masterId;
+
+    @Override
+    public RedisDataSource getObject() {
+        RedisConnectionConfig.Builder builder = RedisConnectionConfig.builder();
+
+        if (nodes == null || nodes.isEmpty()) {
+            builder.withHost(host)
+                    .withPort(port)
+                    .withDatabase(database);
+        } else {
+            nodes.forEach(node -> {
+                try {
+                    String[] parts = StringUtils.split(node, ":");
+                    Assert.state(parts.length == 2, "Must be defined as 'host:port'");
+                    builder.withRedisSentinel(parts[0], Integer.parseInt(parts[1]));
+                } catch (RuntimeException ex) {
+                    throw new IllegalStateException("Invalid redis sentinel property " + node, ex);
+                }
+            });
+            builder.withSentinelMasterId(masterId);
+        }
+
+        if (timeout != null) {
+            builder.withTimeout(timeout.toMillis());
+        }
+
+        if (StringUtils.hasText(password)) {
+            builder.withPassword(password);
+        }
+
+        return new RedisDataSource<List<FlowRule>>(builder.build(), ruleKey, channel, converter);
+    }
+
+    @Override
+    public Class<?> getObjectType() {
+        return RedisDataSource.class;
+    }
+
+    public Converter getConverter() {
+        return converter;
+    }
+
+    public void setConverter(Converter converter) {
+        this.converter = converter;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    public String getRuleKey() {
+        return ruleKey;
+    }
+
+    public void setRuleKey(String ruleKey) {
+        this.ruleKey = ruleKey;
+    }
+
+    public String getChannel() {
+        return channel;
+    }
+
+    public void setChannel(String channel) {
+        this.channel = channel;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public int getDatabase() {
+        return database;
+    }
+
+    public void setDatabase(int database) {
+        this.database = database;
+    }
+
+    public Duration getTimeout() {
+        return timeout;
+    }
+
+    public void setTimeout(Duration timeout) {
+        this.timeout = timeout;
+    }
+
+    public List<String> getNodes() {
+        return nodes;
+    }
+
+    public void setNodes(List<String> nodes) {
+        this.nodes = nodes;
+    }
+
+    public String getMasterId() {
+        return masterId;
+    }
+
+    public void setMasterId(String masterId) {
+        this.masterId = masterId;
+    }
+}

--- a/spring-cloud-alibaba-sentinel-datasource/src/main/resources/META-INF/sentinel-datasource.properties
+++ b/spring-cloud-alibaba-sentinel-datasource/src/main/resources/META-INF/sentinel-datasource.properties
@@ -2,3 +2,4 @@ nacos = com.alibaba.csp.sentinel.datasource.nacos.NacosDataSource
 file =com.alibaba.csp.sentinel.datasource.FileRefreshableDataSource
 apollo = com.alibaba.csp.sentinel.datasource.apollo.ApolloDataSource
 zk = com.alibaba.csp.sentinel.datasource.zookeeper.ZookeeperDataSource
+redis = com.alibaba.csp.sentinel.datasource.redis.RedisDataSource


### PR DESCRIPTION
… Dynamic Rule Configuration


### Describe what this PR does / why we need it
Sentinel support  redisdatasource , but spring cloud alibaba  don't support it

https://github.com/alibaba/Sentinel/tree/master/sentinel-extension/sentinel-datasource-redis

### Does this pull request fix one issue?

no , There are no related issue 
### Describe how you did it
- RedisDataSourceProperties.  Provide common redis-server attributes,support **SentinelMode/Standalone**

- RedisDataSourceFactoryBean. Construct the RedisDatasource, Sentinel required bean

- edit sentinel-core-demo 
### Describe how to verify it
- sentinel-core-example， add 
```
   <dependency>
        <groupId>com.alibaba.csp</groupId>
        <artifactId>sentinel-datasource-redis</artifactId>
   </dependency>
```
-  RedisDatasource, Standalone Model

```
spring.cloud.sentinel.datasource.ds1.redis.host=127.0.0.1
spring.cloud.sentinel.datasource.ds1.redis.port=6379
spring.cloud.sentinel.datasource.ds1.redis.rule-key=key
spring.cloud.sentinel.datasource.ds1.redis.channel=channel
spring.cloud.sentinel.datasource.ds1.redis.rule-type=param_flow
spring.cloud.sentinel.datasource.ds1.redis.data-type=json
```
-  RedisDatasource, Sentinel Model

```
spring.cloud.sentinel.datasource.ds2.redis.nodes=127.0.0.1:26379,127.0.0.1:26380,127.0.0.1:26381
spring.cloud.sentinel.datasource.ds2.redis.master-id=mymaster
spring.cloud.sentinel.datasource.ds2.redis.rule-key=key2
spring.cloud.sentinel.datasource.ds2.redis.channel=channel2
spring.cloud.sentinel.datasource.ds2.redis.rule-type=flow
spring.cloud.sentinel.datasource.ds2.redis.data-type=json
```

### Special notes for reviews

[Redis哨兵（Sentinel）模式
](https://www.jianshu.com/p/06ab9daf921d)
