### PR TITLE
fix #462 FileNotFoundException throws

### DIFF
--- a/spring-cloud-alibaba-sentinel-datasource/src/main/java/com/alibaba/cloud/sentinel/datasource/config/FileDataSourceProperties.java
+++ b/spring-cloud-alibaba-sentinel-datasource/src/main/java/com/alibaba/cloud/sentinel/datasource/config/FileDataSourceProperties.java
@@ -17,6 +17,8 @@
 package com.alibaba.cloud.sentinel.datasource.config;
 
 import java.io.IOException;
+import java.net.URL;
+import java.util.Arrays;
 
 import javax.validation.constraints.NotEmpty;
 
@@ -38,6 +40,10 @@ public class FileDataSourceProperties extends AbstractDataSourceProperties {
 	private String charset = "utf-8";
 	private long recommendRefreshMs = 3000L;
 	private int bufSize = 1024 * 1024;
+
+	private boolean inJar;
+	private String jarName;
+	private String fileInJarName;
 
 	public FileDataSourceProperties() {
 		super(FileRefreshableDataSourceFactoryBean.class.getName());
@@ -75,13 +81,53 @@ public class FileDataSourceProperties extends AbstractDataSourceProperties {
 		this.bufSize = bufSize;
 	}
 
+	public boolean isInJar() {
+		return inJar;
+	}
+
+	public void setInJar(boolean inJar) {
+		this.inJar = inJar;
+	}
+
+	public String getJarName() {
+		return jarName;
+	}
+
+	public void setJarName(String jarName) {
+		this.jarName = jarName;
+	}
+
+	public String getFileInJarName() {
+		return fileInJarName;
+	}
+
+	public void setFileInJarName(String fileInJarName) {
+		this.fileInJarName = fileInJarName;
+	}
+
 	@Override
 	public void preCheck(String dataSourceName) {
 		super.preCheck(dataSourceName);
 		try {
-			this.setFile(
-					ResourceUtils.getFile(StringUtils.trimAllWhitespace(this.getFile()))
-							.getAbsolutePath());
+			this.inJar = true;
+			URL jarFileURL = ResourceUtils
+					.getURL(StringUtils.trimAllWhitespace(this.getFile()));
+			if (jarFileURL.getProtocol().equals("jar")) {
+				String URLString = jarFileURL.toString();
+				if (!URLString.startsWith("jar:file:")) {
+					throw new IOException("No such file" + this.getFile());
+				}
+				String filePath = URLString.replace("jar:file:", "");
+				String[] separated = filePath.split("!/");
+				this.jarName = separated[0];
+				this.fileInJarName = String.join("/",
+						Arrays.copyOfRange(separated, 1, separated.length));
+			}
+			else {
+				this.setFile(ResourceUtils
+						.getFile(StringUtils.trimAllWhitespace(this.getFile()))
+						.getAbsolutePath());
+			}
 		}
 		catch (IOException e) {
 			throw new RuntimeException("[Sentinel Starter] DataSource " + dataSourceName

--- a/spring-cloud-alibaba-sentinel-datasource/src/main/java/com/alibaba/cloud/sentinel/datasource/factorybean/FileRefreshableDataSourceFactoryBean.java
+++ b/spring-cloud-alibaba-sentinel-datasource/src/main/java/com/alibaba/cloud/sentinel/datasource/factorybean/FileRefreshableDataSourceFactoryBean.java
@@ -19,6 +19,8 @@ package com.alibaba.cloud.sentinel.datasource.factorybean;
 import java.io.File;
 import java.nio.charset.Charset;
 
+import com.alibaba.csp.sentinel.datasource.AbstractDataSource;
+import com.alibaba.csp.sentinel.datasource.FileInJarReadableDataSource;
 import org.springframework.beans.factory.FactoryBean;
 
 import com.alibaba.csp.sentinel.datasource.Converter;
@@ -31,7 +33,7 @@ import com.alibaba.csp.sentinel.datasource.FileRefreshableDataSource;
  * @see FileRefreshableDataSource
  */
 public class FileRefreshableDataSourceFactoryBean
-		implements FactoryBean<FileRefreshableDataSource> {
+		implements FactoryBean<AbstractDataSource> {
 
 	private String file;
 	private String charset;
@@ -39,15 +41,30 @@ public class FileRefreshableDataSourceFactoryBean
 	private int bufSize;
 	private Converter converter;
 
+	private boolean inJar;
+	private String jarName;
+	private String fileInJarName;
+
 	@Override
-	public FileRefreshableDataSource getObject() throws Exception {
-		return new FileRefreshableDataSource(new File(file), converter,
-				recommendRefreshMs, bufSize, Charset.forName(charset));
+	public AbstractDataSource getObject() throws Exception {
+		if (inJar) {
+			return new FileInJarReadableDataSource(jarName, fileInJarName, converter,
+					bufSize, Charset.forName(charset));
+		}
+		else {
+			return new FileRefreshableDataSource(new File(file), converter,
+					recommendRefreshMs, bufSize, Charset.forName(charset));
+		}
 	}
 
 	@Override
 	public Class<?> getObjectType() {
-		return FileRefreshableDataSource.class;
+		if (inJar) {
+			return FileInJarReadableDataSource.class;
+		}
+		else {
+			return FileRefreshableDataSource.class;
+		}
 	}
 
 	public String getFile() {
@@ -88,5 +105,29 @@ public class FileRefreshableDataSourceFactoryBean
 
 	public void setConverter(Converter converter) {
 		this.converter = converter;
+	}
+
+	public boolean isInJar() {
+		return inJar;
+	}
+
+	public void setInJar(boolean inJar) {
+		this.inJar = inJar;
+	}
+
+	public String getJarName() {
+		return jarName;
+	}
+
+	public void setJarName(String jarName) {
+		this.jarName = jarName;
+	}
+
+	public String getFileInJarName() {
+		return fileInJarName;
+	}
+
+	public void setFileInJarName(String fileInJarName) {
+		this.fileInJarName = fileInJarName;
 	}
 }


### PR DESCRIPTION
FileNotFoundException throws when rules is provided by local
resources in classpath and executed in command line

### Describe what this PR does / why we need it
When we run the app in an IDE, everything is fine and the app is able to find
resource files.
When we pack our app into a jar with all the resource files in it and run it by 
`java -jar XXX.jar`, FileNotFoundException throws.
This PR makes sure that under both circumstances the app runs well.

### Does this pull request fix one issue?

Fixes #462 

### Describe how you did it

Modify `precheck` in `FileDataSourceProperties` to allow local files
in a jar.  Modify `FileRefreshableDataSourceFactoryBean` to return
different datasources according to file location---in the filesystem,
or in a jar.

### Describe how to verify it

**Rebuild** module `spring-cloud-alibaba-sentinel-datasource` and 
`sentinel-core-example` in `sentinel-examples` of `spring-cloud-alibaba-examples`.
Find the jar file under directory `sentinel-core-example/target` and run it by `java -jar XXX.jar`.
No exception is found and the rules are read from files in the jar.

### Special notes for reviews

The sentinel component offers the API which requests **name of the jar file** and **name of the file in  the jar**, which I found a little awkward(An API of `InputStream` will be far better and the internal implementation of current API is `InputStream`).  But anyway, I have to use string manipulation in `precheck` to extract **name of the jar file** and **name of the file in  the jar** from the URL.  Is there a better implementation?  Is there a better approach to handling exceptions?