### PR TITLE
Support sequential sending of messages and batch messages consumption

### DIFF
--- a/spring-cloud-stream-binder-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/RocketMQMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/RocketMQMessageChannelBinder.java
@@ -158,6 +158,7 @@ public class RocketMQMessageChannelBinder extends
 					instrumentationManager);
 			messageHandler.setBeanFactory(this.getApplicationContext().getBeanFactory());
 			messageHandler.setSync(producerProperties.getExtension().getSync());
+			messageHandler.setOrderly(producerProperties.getExtension().getOrderly());
 
 			if (errorChannel != null) {
 				messageHandler.setSendFailureChannel(errorChannel);

--- a/spring-cloud-stream-binder-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/consuming/RocketMQListenerBindingContainer.java
+++ b/spring-cloud-stream-binder-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/consuming/RocketMQListenerBindingContainer.java
@@ -57,366 +57,377 @@ import com.alibaba.cloud.stream.binder.rocketmq.properties.RocketMQConsumerPrope
  * @author <a href="mailto:fangjian0423@gmail.com">Jim</a>
  */
 public class RocketMQListenerBindingContainer
-		implements InitializingBean, RocketMQListenerContainer, SmartLifecycle {
-
-	private final static Logger log = LoggerFactory
-			.getLogger(RocketMQListenerBindingContainer.class);
-
-	private long suspendCurrentQueueTimeMillis = 1000;
-
-	/**
-	 * Message consume retry strategy<br>
-	 * -1,no retry,put into DLQ directly<br>
-	 * 0,broker control retry frequency<br>
-	 * >0,client control retry frequency.
-	 */
-	private int delayLevelWhenNextConsume = 0;
-
-	private String nameServer;
-
-	private String consumerGroup;
-
-	private String topic;
-
-	private int consumeThreadMax = 64;
-
-	private String charset = "UTF-8";
-
-	private RocketMQListener rocketMQListener;
-
-	private DefaultMQPushConsumer consumer;
-
-	private boolean running;
-
-	private final ExtendedConsumerProperties<RocketMQConsumerProperties> rocketMQConsumerProperties;
-
-	private final RocketMQMessageChannelBinder rocketMQMessageChannelBinder;
-	private final RocketMQBinderConfigurationProperties rocketBinderConfigurationProperties;
-
-	// The following properties came from RocketMQConsumerProperties.
-	private ConsumeMode consumeMode;
-	private SelectorType selectorType;
-	private String selectorExpression;
-	private MessageModel messageModel;
-
-	public RocketMQListenerBindingContainer(
-			ExtendedConsumerProperties<RocketMQConsumerProperties> rocketMQConsumerProperties,
-			RocketMQBinderConfigurationProperties rocketBinderConfigurationProperties,
-			RocketMQMessageChannelBinder rocketMQMessageChannelBinder) {
-		this.rocketMQConsumerProperties = rocketMQConsumerProperties;
-		this.rocketBinderConfigurationProperties = rocketBinderConfigurationProperties;
-		this.rocketMQMessageChannelBinder = rocketMQMessageChannelBinder;
-		this.consumeMode = rocketMQConsumerProperties.getExtension().getOrderly()
-				? ConsumeMode.ORDERLY
-				: ConsumeMode.CONCURRENTLY;
-		if (StringUtils.isEmpty(rocketMQConsumerProperties.getExtension().getSql())) {
-			this.selectorType = SelectorType.TAG;
-			this.selectorExpression = rocketMQConsumerProperties.getExtension().getTags();
-		}
-		else {
-			this.selectorType = SelectorType.SQL92;
-			this.selectorExpression = rocketMQConsumerProperties.getExtension().getSql();
-		}
-		this.messageModel = rocketMQConsumerProperties.getExtension().getBroadcasting()
-				? MessageModel.BROADCASTING
-				: MessageModel.CLUSTERING;
-	}
-
-	@Override
-	public void setupMessageListener(RocketMQListener<?> rocketMQListener) {
-		this.rocketMQListener = rocketMQListener;
-	}
-
-	@Override
-	public void destroy() throws Exception {
-		this.setRunning(false);
-		if (Objects.nonNull(consumer)) {
-			consumer.shutdown();
-		}
-		log.info("container destroyed, {}", this.toString());
-	}
-
-	@Override
-	public void afterPropertiesSet() throws Exception {
-		initRocketMQPushConsumer();
-	}
-
-	@Override
-	public boolean isAutoStartup() {
-		return true;
-	}
-
-	@Override
-	public void stop(Runnable callback) {
-		stop();
-		callback.run();
-	}
-
-	@Override
-	public void start() {
-		if (this.isRunning()) {
-			throw new IllegalStateException(
-					"container already running. " + this.toString());
-		}
-
-		try {
-			consumer.start();
-		}
-		catch (MQClientException e) {
-			throw new IllegalStateException("Failed to start RocketMQ push consumer", e);
-		}
-		this.setRunning(true);
-
-		log.info("running container: {}", this.toString());
-	}
-
-	@Override
-	public void stop() {
-		if (this.isRunning()) {
-			if (Objects.nonNull(consumer)) {
-				consumer.shutdown();
-			}
-			setRunning(false);
-		}
-	}
-
-	@Override
-	public boolean isRunning() {
-		return running;
-	}
-
-	private void setRunning(boolean running) {
-		this.running = running;
-	}
-
-	@Override
-	public int getPhase() {
-		return Integer.MAX_VALUE;
-	}
-
-	private void initRocketMQPushConsumer() throws MQClientException {
-		Assert.notNull(rocketMQListener, "Property 'rocketMQListener' is required");
-		Assert.notNull(consumerGroup, "Property 'consumerGroup' is required");
-		Assert.notNull(nameServer, "Property 'nameServer' is required");
-		Assert.notNull(topic, "Property 'topic' is required");
-
-		String ak = rocketBinderConfigurationProperties.getAccessKey();
-		String sk = rocketBinderConfigurationProperties.getSecretKey();
-		if (!StringUtils.isEmpty(ak) && !StringUtils.isEmpty(sk)) {
-			RPCHook rpcHook = new AclClientRPCHook(new SessionCredentials(ak, sk));
-			consumer = new DefaultMQPushConsumer(consumerGroup, rpcHook,
-					new AllocateMessageQueueAveragely(),
-					rocketBinderConfigurationProperties.isEnableMsgTrace(),
-					rocketBinderConfigurationProperties.getCustomizedTraceTopic());
-			consumer.setInstanceName(RocketMQUtil.getInstanceName(rpcHook,
-					topic + "|" + UtilAll.getPid()));
-			consumer.setVipChannelEnabled(false);
-		}
-		else {
-			consumer = new DefaultMQPushConsumer(consumerGroup,
-					rocketBinderConfigurationProperties.isEnableMsgTrace(),
-					rocketBinderConfigurationProperties.getCustomizedTraceTopic());
-		}
-
-		consumer.setNamesrvAddr(nameServer);
-		consumer.setConsumeThreadMax(rocketMQConsumerProperties.getConcurrency());
-		consumer.setConsumeThreadMin(rocketMQConsumerProperties.getConcurrency());
-
-		switch (messageModel) {
-		case BROADCASTING:
-			consumer.setMessageModel(
-					org.apache.rocketmq.common.protocol.heartbeat.MessageModel.BROADCASTING);
-			break;
-		case CLUSTERING:
-			consumer.setMessageModel(
-					org.apache.rocketmq.common.protocol.heartbeat.MessageModel.CLUSTERING);
-			break;
-		default:
-			throw new IllegalArgumentException("Property 'messageModel' was wrong.");
-		}
-
-		switch (selectorType) {
-		case TAG:
-			consumer.subscribe(topic, selectorExpression);
-			break;
-		case SQL92:
-			consumer.subscribe(topic, MessageSelector.bySql(selectorExpression));
-			break;
-		default:
-			throw new IllegalArgumentException("Property 'selectorType' was wrong.");
-		}
-
-		switch (consumeMode) {
-		case ORDERLY:
-			consumer.setMessageListener(new DefaultMessageListenerOrderly());
-			break;
-		case CONCURRENTLY:
-			consumer.setMessageListener(new DefaultMessageListenerConcurrently());
-			break;
-		default:
-			throw new IllegalArgumentException("Property 'consumeMode' was wrong.");
-		}
-
-		if (rocketMQListener instanceof RocketMQPushConsumerLifecycleListener) {
-			((RocketMQPushConsumerLifecycleListener) rocketMQListener)
-					.prepareStart(consumer);
-		}
-
-	}
-
-	@Override
-	public String toString() {
-		return "RocketMQListenerBindingContainer{" + "consumerGroup='" + consumerGroup
-				+ '\'' + ", nameServer='" + nameServer + '\'' + ", topic='" + topic + '\''
-				+ ", consumeMode=" + consumeMode + ", selectorType=" + selectorType
-				+ ", selectorExpression='" + selectorExpression + '\'' + ", messageModel="
-				+ messageModel + '}';
-	}
-
-	public long getSuspendCurrentQueueTimeMillis() {
-		return suspendCurrentQueueTimeMillis;
-	}
-
-	public void setSuspendCurrentQueueTimeMillis(long suspendCurrentQueueTimeMillis) {
-		this.suspendCurrentQueueTimeMillis = suspendCurrentQueueTimeMillis;
-	}
-
-	public int getDelayLevelWhenNextConsume() {
-		return delayLevelWhenNextConsume;
-	}
-
-	public void setDelayLevelWhenNextConsume(int delayLevelWhenNextConsume) {
-		this.delayLevelWhenNextConsume = delayLevelWhenNextConsume;
-	}
-
-	public String getNameServer() {
-		return nameServer;
-	}
-
-	public void setNameServer(String nameServer) {
-		this.nameServer = nameServer;
-	}
-
-	public String getConsumerGroup() {
-		return consumerGroup;
-	}
-
-	public void setConsumerGroup(String consumerGroup) {
-		this.consumerGroup = consumerGroup;
-	}
-
-	public String getTopic() {
-		return topic;
-	}
-
-	public void setTopic(String topic) {
-		this.topic = topic;
-	}
-
-	public int getConsumeThreadMax() {
-		return consumeThreadMax;
-	}
-
-	public void setConsumeThreadMax(int consumeThreadMax) {
-		this.consumeThreadMax = consumeThreadMax;
-	}
-
-	public String getCharset() {
-		return charset;
-	}
-
-	public void setCharset(String charset) {
-		this.charset = charset;
-	}
-
-	public RocketMQListener getRocketMQListener() {
-		return rocketMQListener;
-	}
-
-	public void setRocketMQListener(RocketMQListener rocketMQListener) {
-		this.rocketMQListener = rocketMQListener;
-	}
-
-	public DefaultMQPushConsumer getConsumer() {
-		return consumer;
-	}
-
-	public void setConsumer(DefaultMQPushConsumer consumer) {
-		this.consumer = consumer;
-	}
-
-	public ExtendedConsumerProperties<RocketMQConsumerProperties> getRocketMQConsumerProperties() {
-		return rocketMQConsumerProperties;
-	}
-
-	public ConsumeMode getConsumeMode() {
-		return consumeMode;
-	}
-
-	public SelectorType getSelectorType() {
-		return selectorType;
-	}
-
-	public String getSelectorExpression() {
-		return selectorExpression;
-	}
-
-	public MessageModel getMessageModel() {
-		return messageModel;
-	}
-
-	public class DefaultMessageListenerConcurrently
-			implements MessageListenerConcurrently {
-
-		@SuppressWarnings("unchecked")
-		@Override
-		public ConsumeConcurrentlyStatus consumeMessage(List<MessageExt> msgs,
-				ConsumeConcurrentlyContext context) {
-			for (MessageExt messageExt : msgs) {
-				log.debug("received msg: {}", messageExt);
-				try {
-					long now = System.currentTimeMillis();
-					rocketMQListener
-							.onMessage(RocketMQUtil.convertToSpringMessage(messageExt));
-					long costTime = System.currentTimeMillis() - now;
-					log.debug("consume {} cost: {} ms", messageExt.getMsgId(), costTime);
-				}
-				catch (Exception e) {
-					log.warn("consume message failed. messageExt:{}", messageExt, e);
-					context.setDelayLevelWhenNextConsume(delayLevelWhenNextConsume);
-					return ConsumeConcurrentlyStatus.RECONSUME_LATER;
-				}
-			}
-
-			return ConsumeConcurrentlyStatus.CONSUME_SUCCESS;
-		}
-	}
-
-	public class DefaultMessageListenerOrderly implements MessageListenerOrderly {
-
-		@SuppressWarnings("unchecked")
-		@Override
-		public ConsumeOrderlyStatus consumeMessage(List<MessageExt> msgs,
-				ConsumeOrderlyContext context) {
-			for (MessageExt messageExt : msgs) {
-				log.debug("received msg: {}", messageExt);
-				try {
-					long now = System.currentTimeMillis();
-					rocketMQListener
-							.onMessage(RocketMQUtil.convertToSpringMessage(messageExt));
-					long costTime = System.currentTimeMillis() - now;
-					log.info("consume {} cost: {} ms", messageExt.getMsgId(), costTime);
-				}
-				catch (Exception e) {
-					log.warn("consume message failed. messageExt:{}", messageExt, e);
-					context.setSuspendCurrentQueueTimeMillis(
-							suspendCurrentQueueTimeMillis);
-					return ConsumeOrderlyStatus.SUSPEND_CURRENT_QUEUE_A_MOMENT;
-				}
-			}
-
-			return ConsumeOrderlyStatus.SUCCESS;
-		}
-	}
+        implements InitializingBean, RocketMQListenerContainer, SmartLifecycle {
+
+    private final static Logger log = LoggerFactory
+            .getLogger(RocketMQListenerBindingContainer.class);
+
+    private long suspendCurrentQueueTimeMillis = 1000;
+
+    /**
+     * Message consume retry strategy<br>
+     * -1,no retry,put into DLQ directly<br>
+     * 0,broker control retry frequency<br>
+     * >0,client control retry frequency.
+     */
+    private int delayLevelWhenNextConsume = 0;
+
+    private String nameServer;
+
+    private String consumerGroup;
+
+    private String topic;
+
+    private int consumeThreadMax = 64;
+
+    private String charset = "UTF-8";
+
+    private RocketMQListener rocketMQListener;
+
+    private DefaultMQPushConsumer consumer;
+
+    private int consumeMessageBatchMaxSize;
+
+    private boolean running;
+
+    private final ExtendedConsumerProperties<RocketMQConsumerProperties> rocketMQConsumerProperties;
+
+    private final RocketMQMessageChannelBinder rocketMQMessageChannelBinder;
+    private final RocketMQBinderConfigurationProperties rocketBinderConfigurationProperties;
+
+    // The following properties came from RocketMQConsumerProperties.
+    private ConsumeMode consumeMode;
+    private SelectorType selectorType;
+    private String selectorExpression;
+    private MessageModel messageModel;
+
+    public RocketMQListenerBindingContainer(
+            ExtendedConsumerProperties<RocketMQConsumerProperties> rocketMQConsumerProperties,
+            RocketMQBinderConfigurationProperties rocketBinderConfigurationProperties,
+            RocketMQMessageChannelBinder rocketMQMessageChannelBinder) {
+        this.rocketMQConsumerProperties = rocketMQConsumerProperties;
+        this.rocketBinderConfigurationProperties = rocketBinderConfigurationProperties;
+        this.rocketMQMessageChannelBinder = rocketMQMessageChannelBinder;
+        this.consumeMode = rocketMQConsumerProperties.getExtension().getOrderly()
+                ? ConsumeMode.ORDERLY
+                : ConsumeMode.CONCURRENTLY;
+        if (StringUtils.isEmpty(rocketMQConsumerProperties.getExtension().getSql())) {
+            this.selectorType = SelectorType.TAG;
+            this.selectorExpression = rocketMQConsumerProperties.getExtension().getTags();
+        } else {
+            this.selectorType = SelectorType.SQL92;
+            this.selectorExpression = rocketMQConsumerProperties.getExtension().getSql();
+        }
+        this.messageModel = rocketMQConsumerProperties.getExtension().getBroadcasting()
+                ? MessageModel.BROADCASTING
+                : MessageModel.CLUSTERING;
+        this.consumeMessageBatchMaxSize = rocketMQConsumerProperties.getExtension().getConsumeMessageBatchMaxSize();
+    }
+
+    @Override
+    public void setupMessageListener(RocketMQListener<?> rocketMQListener) {
+        this.rocketMQListener = rocketMQListener;
+    }
+
+    @Override
+    public void destroy() throws Exception {
+        this.setRunning(false);
+        if (Objects.nonNull(consumer)) {
+            consumer.shutdown();
+        }
+        log.info("container destroyed, {}", this.toString());
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        initRocketMQPushConsumer();
+    }
+
+    @Override
+    public boolean isAutoStartup() {
+        return true;
+    }
+
+    @Override
+    public void stop(Runnable callback) {
+        stop();
+        callback.run();
+    }
+
+    @Override
+    public void start() {
+        if (this.isRunning()) {
+            throw new IllegalStateException(
+                    "container already running. " + this.toString());
+        }
+
+        try {
+            consumer.start();
+        } catch (MQClientException e) {
+            throw new IllegalStateException("Failed to start RocketMQ push consumer", e);
+        }
+        this.setRunning(true);
+
+        log.info("running container: {}", this.toString());
+    }
+
+    @Override
+    public void stop() {
+        if (this.isRunning()) {
+            if (Objects.nonNull(consumer)) {
+                consumer.shutdown();
+            }
+            setRunning(false);
+        }
+    }
+
+    @Override
+    public boolean isRunning() {
+        return running;
+    }
+
+    private void setRunning(boolean running) {
+        this.running = running;
+    }
+
+    @Override
+    public int getPhase() {
+        return Integer.MAX_VALUE;
+    }
+
+    private void initRocketMQPushConsumer() throws MQClientException {
+        Assert.notNull(rocketMQListener, "Property 'rocketMQListener' is required");
+        Assert.notNull(consumerGroup, "Property 'consumerGroup' is required");
+        Assert.notNull(nameServer, "Property 'nameServer' is required");
+        Assert.notNull(topic, "Property 'topic' is required");
+
+        String ak = rocketBinderConfigurationProperties.getAccessKey();
+        String sk = rocketBinderConfigurationProperties.getSecretKey();
+        if (!StringUtils.isEmpty(ak) && !StringUtils.isEmpty(sk)) {
+            RPCHook rpcHook = new AclClientRPCHook(new SessionCredentials(ak, sk));
+            consumer = new DefaultMQPushConsumer(consumerGroup, rpcHook,
+                    new AllocateMessageQueueAveragely(),
+                    rocketBinderConfigurationProperties.isEnableMsgTrace(),
+                    rocketBinderConfigurationProperties.getCustomizedTraceTopic());
+            consumer.setInstanceName(RocketMQUtil.getInstanceName(rpcHook,
+                    topic + "|" + UtilAll.getPid()));
+            consumer.setVipChannelEnabled(false);
+        } else {
+            consumer = new DefaultMQPushConsumer(consumerGroup,
+                    rocketBinderConfigurationProperties.isEnableMsgTrace(),
+                    rocketBinderConfigurationProperties.getCustomizedTraceTopic());
+        }
+
+        consumer.setNamesrvAddr(nameServer);
+        consumer.setConsumeThreadMax(rocketMQConsumerProperties.getConcurrency());
+        consumer.setConsumeThreadMin(rocketMQConsumerProperties.getConcurrency());
+
+        switch (messageModel) {
+            case BROADCASTING:
+                consumer.setMessageModel(
+                        org.apache.rocketmq.common.protocol.heartbeat.MessageModel.BROADCASTING);
+                break;
+            case CLUSTERING:
+                consumer.setMessageModel(
+                        org.apache.rocketmq.common.protocol.heartbeat.MessageModel.CLUSTERING);
+                break;
+            default:
+                throw new IllegalArgumentException("Property 'messageModel' was wrong.");
+        }
+
+        switch (selectorType) {
+            case TAG:
+                consumer.subscribe(topic, selectorExpression);
+                break;
+            case SQL92:
+                consumer.subscribe(topic, MessageSelector.bySql(selectorExpression));
+                break;
+            default:
+                throw new IllegalArgumentException("Property 'selectorType' was wrong.");
+        }
+
+        switch (consumeMode) {
+            case ORDERLY:
+                consumer.setMessageListener(new DefaultMessageListenerOrderly());
+                break;
+            case CONCURRENTLY:
+                consumer.setMessageListener(new DefaultMessageListenerConcurrently());
+                break;
+            default:
+                throw new IllegalArgumentException("Property 'consumeMode' was wrong.");
+        }
+
+        consumer.setConsumeMessageBatchMaxSize(this.getConsumeMessageBatchMaxSize());
+
+        if (rocketMQListener instanceof RocketMQPushConsumerLifecycleListener) {
+            ((RocketMQPushConsumerLifecycleListener) rocketMQListener)
+                    .prepareStart(consumer);
+        }
+
+    }
+
+    @Override
+    public String toString() {
+        return "RocketMQListenerBindingContainer{" + "consumerGroup='" + consumerGroup
+                + '\'' + ", nameServer='" + nameServer + '\'' + ", topic='" + topic + '\''
+                + ", consumeMode=" + consumeMode + ", selectorType=" + selectorType
+                + ", selectorExpression='" + selectorExpression + '\'' + ", messageModel="
+                + messageModel + '}';
+    }
+
+    public long getSuspendCurrentQueueTimeMillis() {
+        return suspendCurrentQueueTimeMillis;
+    }
+
+    public void setSuspendCurrentQueueTimeMillis(long suspendCurrentQueueTimeMillis) {
+        this.suspendCurrentQueueTimeMillis = suspendCurrentQueueTimeMillis;
+    }
+
+    public int getDelayLevelWhenNextConsume() {
+        return delayLevelWhenNextConsume;
+    }
+
+    public void setDelayLevelWhenNextConsume(int delayLevelWhenNextConsume) {
+        this.delayLevelWhenNextConsume = delayLevelWhenNextConsume;
+    }
+
+    public String getNameServer() {
+        return nameServer;
+    }
+
+    public void setNameServer(String nameServer) {
+        this.nameServer = nameServer;
+    }
+
+    public String getConsumerGroup() {
+        return consumerGroup;
+    }
+
+    public void setConsumerGroup(String consumerGroup) {
+        this.consumerGroup = consumerGroup;
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public void setTopic(String topic) {
+        this.topic = topic;
+    }
+
+    public int getConsumeThreadMax() {
+        return consumeThreadMax;
+    }
+
+    public void setConsumeThreadMax(int consumeThreadMax) {
+        this.consumeThreadMax = consumeThreadMax;
+    }
+
+    public String getCharset() {
+        return charset;
+    }
+
+    public void setCharset(String charset) {
+        this.charset = charset;
+    }
+
+    public RocketMQListener getRocketMQListener() {
+        return rocketMQListener;
+    }
+
+    public void setRocketMQListener(RocketMQListener rocketMQListener) {
+        this.rocketMQListener = rocketMQListener;
+    }
+
+    public DefaultMQPushConsumer getConsumer() {
+        return consumer;
+    }
+
+    public void setConsumer(DefaultMQPushConsumer consumer) {
+        this.consumer = consumer;
+    }
+
+    public void setConsumeMessageBatchMaxSize(int consumeMessageBatchMaxSize) {
+        this.consumeMessageBatchMaxSize = consumeMessageBatchMaxSize;
+    }
+
+    public ExtendedConsumerProperties<RocketMQConsumerProperties> getRocketMQConsumerProperties() {
+        return rocketMQConsumerProperties;
+    }
+
+    public ConsumeMode getConsumeMode() {
+        return consumeMode;
+    }
+
+    public SelectorType getSelectorType() {
+        return selectorType;
+    }
+
+    public String getSelectorExpression() {
+        return selectorExpression;
+    }
+
+    public MessageModel getMessageModel() {
+        return messageModel;
+    }
+
+    public int getConsumeMessageBatchMaxSize() {
+        return consumeMessageBatchMaxSize;
+    }
+
+
+    public class DefaultMessageListenerConcurrently
+            implements MessageListenerConcurrently {
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public ConsumeConcurrentlyStatus consumeMessage(List<MessageExt> msgs,
+                                                        ConsumeConcurrentlyContext context) {
+            System.out.println("concurrently messages size is " + msgs.size());
+            for (MessageExt messageExt : msgs) {
+                log.debug("received msg: {}", messageExt);
+                try {
+                    long now = System.currentTimeMillis();
+                    rocketMQListener
+                            .onMessage(RocketMQUtil.convertToSpringMessage(messageExt));
+                    long costTime = System.currentTimeMillis() - now;
+                    log.debug("consume {} cost: {} ms", messageExt.getMsgId(), costTime);
+                } catch (Exception e) {
+                    log.warn("consume message failed. messageExt:{}", messageExt, e);
+                    context.setDelayLevelWhenNextConsume(delayLevelWhenNextConsume);
+                    return ConsumeConcurrentlyStatus.RECONSUME_LATER;
+                }
+            }
+
+            return ConsumeConcurrentlyStatus.CONSUME_SUCCESS;
+        }
+    }
+
+    public class DefaultMessageListenerOrderly implements MessageListenerOrderly {
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public ConsumeOrderlyStatus consumeMessage(List<MessageExt> msgs,
+                                                   ConsumeOrderlyContext context) {
+            System.out.println("orderly messages size is " + msgs.size());
+            for (MessageExt messageExt : msgs) {
+                log.debug("received msg: {}", messageExt);
+                try {
+                    long now = System.currentTimeMillis();
+                    rocketMQListener
+                            .onMessage(RocketMQUtil.convertToSpringMessage(messageExt));
+                    long costTime = System.currentTimeMillis() - now;
+                    log.info("consume {} cost: {} ms", messageExt.getMsgId(), costTime);
+                } catch (Exception e) {
+                    log.warn("consume message failed. messageExt:{}", messageExt, e);
+                    context.setSuspendCurrentQueueTimeMillis(
+                            suspendCurrentQueueTimeMillis);
+                    return ConsumeOrderlyStatus.SUSPEND_CURRENT_QUEUE_A_MOMENT;
+                }
+            }
+
+            return ConsumeOrderlyStatus.SUCCESS;
+        }
+    }
 
 }

--- a/spring-cloud-stream-binder-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/integration/RocketMQMessageHandler.java
+++ b/spring-cloud-stream-binder-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/integration/RocketMQMessageHandler.java
@@ -47,187 +47,197 @@ import com.alibaba.cloud.stream.binder.rocketmq.metrics.InstrumentationManager;
  */
 public class RocketMQMessageHandler extends AbstractMessageHandler implements Lifecycle {
 
-	private final static Logger log = LoggerFactory
-			.getLogger(RocketMQMessageHandler.class);
+    private final static Logger log = LoggerFactory
+            .getLogger(RocketMQMessageHandler.class);
 
-	private ErrorMessageStrategy errorMessageStrategy = new DefaultErrorMessageStrategy();
+    private String DEFAULT_HASHKEY="0";
 
-	private MessageChannel sendFailureChannel;
+    private ErrorMessageStrategy errorMessageStrategy = new DefaultErrorMessageStrategy();
 
-	private final RocketMQTemplate rocketMQTemplate;
+    private MessageChannel sendFailureChannel;
 
-	private final Boolean transactional;
+    private final RocketMQTemplate rocketMQTemplate;
 
-	private final String destination;
+    private final Boolean transactional;
 
-	private final String groupName;
+    private final String destination;
 
-	private final InstrumentationManager instrumentationManager;
+    private final String groupName;
 
-	private boolean sync = false;
+    private final InstrumentationManager instrumentationManager;
 
-	private volatile boolean running = false;
+    private boolean sync = false;
 
-	public RocketMQMessageHandler(RocketMQTemplate rocketMQTemplate, String destination,
-			String groupName, Boolean transactional,
-			InstrumentationManager instrumentationManager) {
-		this.rocketMQTemplate = rocketMQTemplate;
-		this.destination = destination;
-		this.groupName = groupName;
-		this.transactional = transactional;
-		this.instrumentationManager = instrumentationManager;
-	}
+    private volatile boolean running = false;
 
-	@Override
-	public void start() {
-		if (!transactional) {
-			instrumentationManager
-					.addHealthInstrumentation(new Instrumentation(destination));
-			try {
-				rocketMQTemplate.afterPropertiesSet();
-				instrumentationManager.getHealthInstrumentation(destination)
-						.markStartedSuccessfully();
-			}
-			catch (Exception e) {
-				instrumentationManager.getHealthInstrumentation(destination)
-						.markStartFailed(e);
-				log.error("RocketMQTemplate startup failed, Caused by " + e.getMessage());
-				throw new MessagingException(MessageBuilder.withPayload(
-						"RocketMQTemplate startup failed, Caused by " + e.getMessage())
-						.build(), e);
-			}
-		}
-		running = true;
-	}
+    private Boolean orderly = false;
 
-	@Override
-	public void stop() {
-		if (!transactional) {
-			rocketMQTemplate.destroy();
-		}
-		running = false;
-	}
+    public Boolean getOrderly() {
+        return orderly;
+    }
 
-	@Override
-	public boolean isRunning() {
-		return running;
-	}
+    public void setOrderly(Boolean orderly) {
+        this.orderly = orderly;
+    }
 
-	@Override
-	protected void handleMessageInternal(org.springframework.messaging.Message<?> message)
-			throws Exception {
-		try {
-			final StringBuilder topicWithTags = new StringBuilder(destination);
-			String tags = Optional
-					.ofNullable(message.getHeaders().get(RocketMQHeaders.TAGS)).orElse("")
-					.toString();
-			if (!StringUtils.isEmpty(tags)) {
-				topicWithTags.append(":").append(tags);
-			}
-			SendResult sendRes = null;
-			if (transactional) {
-				sendRes = rocketMQTemplate.sendMessageInTransaction(groupName,
-						topicWithTags.toString(), message, message.getHeaders()
-								.get(RocketMQBinderConstants.ROCKET_TRANSACTIONAL_ARG));
-				log.debug("transactional send to topic " + topicWithTags + " " + sendRes);
-			}
-			else {
-				int delayLevel = 0;
-				try {
-					Object delayLevelObj = message.getHeaders()
-							.getOrDefault(MessageConst.PROPERTY_DELAY_TIME_LEVEL, 0);
-					if (delayLevelObj instanceof Number) {
-						delayLevel = ((Number) delayLevelObj).intValue();
-					}
-					else if (delayLevelObj instanceof String) {
-						delayLevel = Integer.parseInt((String) delayLevelObj);
-					}
-				}
-				catch (Exception e) {
-					// ignore
-				}
-				if (sync) {
-					sendRes = rocketMQTemplate.syncSend(topicWithTags.toString(), message,
-							rocketMQTemplate.getProducer().getSendMsgTimeout(),
-							delayLevel);
-					log.debug("sync send to topic " + topicWithTags + " " + sendRes);
-				}
-				else {
-					rocketMQTemplate.asyncSend(topicWithTags.toString(), message,
-							new SendCallback() {
-								@Override
-								public void onSuccess(SendResult sendResult) {
-									log.debug("async send to topic " + topicWithTags + " "
-											+ sendResult);
-								}
+    public RocketMQMessageHandler(RocketMQTemplate rocketMQTemplate, String destination,
+                                  String groupName, Boolean transactional,
+                                  InstrumentationManager instrumentationManager) {
+        this.rocketMQTemplate = rocketMQTemplate;
+        this.destination = destination;
+        this.groupName = groupName;
+        this.transactional = transactional;
+        this.instrumentationManager = instrumentationManager;
+    }
 
-								@Override
-								public void onException(Throwable e) {
-									log.error(
-											"RocketMQ Message hasn't been sent. Caused by "
-													+ e.getMessage());
-									if (getSendFailureChannel() != null) {
-										getSendFailureChannel().send(
-												RocketMQMessageHandler.this.errorMessageStrategy
-														.buildErrorMessage(
-																new MessagingException(
-																		message, e),
-																null));
-									}
-								}
-							});
-				}
-			}
-			if (sendRes != null && !sendRes.getSendStatus().equals(SendStatus.SEND_OK)) {
-				if (getSendFailureChannel() != null) {
-					this.getSendFailureChannel().send(message);
-				}
-				else {
-					throw new MessagingException(message,
-							new MQClientException("message hasn't been sent", null));
-				}
-			}
-		}
-		catch (Exception e) {
-			log.error("RocketMQ Message hasn't been sent. Caused by " + e.getMessage());
-			if (getSendFailureChannel() != null) {
-				getSendFailureChannel().send(this.errorMessageStrategy
-						.buildErrorMessage(new MessagingException(message, e), null));
-			}
-			else {
-				throw new MessagingException(message, e);
-			}
-		}
+    @Override
+    public void start() {
+        if (!transactional) {
+            instrumentationManager
+                    .addHealthInstrumentation(new Instrumentation(destination));
+            try {
+                rocketMQTemplate.afterPropertiesSet();
+                instrumentationManager.getHealthInstrumentation(destination)
+                        .markStartedSuccessfully();
+            } catch (Exception e) {
+                instrumentationManager.getHealthInstrumentation(destination)
+                        .markStartFailed(e);
+                log.error("RocketMQTemplate startup failed, Caused by " + e.getMessage());
+                throw new MessagingException(MessageBuilder.withPayload(
+                        "RocketMQTemplate startup failed, Caused by " + e.getMessage())
+                        .build(), e);
+            }
+        }
+        running = true;
+    }
 
-	}
+    @Override
+    public void stop() {
+        if (!transactional) {
+            rocketMQTemplate.destroy();
+        }
+        running = false;
+    }
 
-	/**
-	 * Set the failure channel. After a send failure, an {@link ErrorMessage} will be sent
-	 * to this channel with a payload of a {@link MessagingException} with the failed
-	 * message and cause.
-	 * @param sendFailureChannel the failure channel.
-	 * @since 0.2.2
-	 */
-	public void setSendFailureChannel(MessageChannel sendFailureChannel) {
-		this.sendFailureChannel = sendFailureChannel;
-	}
+    @Override
+    public boolean isRunning() {
+        return running;
+    }
 
-	/**
-	 * Set the error message strategy implementation to use when sending error messages
-	 * after send failures. Cannot be null.
-	 * @param errorMessageStrategy the implementation.
-	 * @since 0.2.2
-	 */
-	public void setErrorMessageStrategy(ErrorMessageStrategy errorMessageStrategy) {
-		Assert.notNull(errorMessageStrategy, "'errorMessageStrategy' cannot be null");
-		this.errorMessageStrategy = errorMessageStrategy;
-	}
+    @Override
+    protected void handleMessageInternal(org.springframework.messaging.Message<?> message)
+            throws Exception {
+        try {
+            final StringBuilder topicWithTags = new StringBuilder(destination);
+            String tags = Optional
+                    .ofNullable(message.getHeaders().get(RocketMQHeaders.TAGS)).orElse("")
+                    .toString();
+            if (!StringUtils.isEmpty(tags)) {
+                topicWithTags.append(":").append(tags);
+            }
+            SendResult sendRes = null;
+            if (transactional) {
+                sendRes = rocketMQTemplate.sendMessageInTransaction(groupName,
+                        topicWithTags.toString(), message, message.getHeaders()
+                                .get(RocketMQBinderConstants.ROCKET_TRANSACTIONAL_ARG));
+                log.debug("transactional send to topic " + topicWithTags + " " + sendRes);
+            } else {
+                int delayLevel = 0;
+                try {
+                    Object delayLevelObj = message.getHeaders()
+                            .getOrDefault(MessageConst.PROPERTY_DELAY_TIME_LEVEL, 0);
+                    if (delayLevelObj instanceof Number) {
+                        delayLevel = ((Number) delayLevelObj).intValue();
+                    } else if (delayLevelObj instanceof String) {
+                        delayLevel = Integer.parseInt((String) delayLevelObj);
+                    }
+                } catch (Exception e) {
+                    // ignore
+                }
+                if (sync) {
+                    if (orderly) {
+                        sendRes = rocketMQTemplate.syncSendOrderly(topicWithTags.toString(), message, DEFAULT_HASHKEY);
+                    } else {
+                        sendRes = rocketMQTemplate.syncSend(topicWithTags.toString(), message,
+                                rocketMQTemplate.getProducer().getSendMsgTimeout(),
+                                delayLevel);
+                    }
+                    log.debug("sync send to topic " + topicWithTags + " " + sendRes);
+                } else {
+                    rocketMQTemplate.asyncSend(topicWithTags.toString(), message,
+                            new SendCallback() {
+                                @Override
+                                public void onSuccess(SendResult sendResult) {
+                                    log.debug("async send to topic " + topicWithTags + " "
+                                            + sendResult);
+                                }
 
-	public MessageChannel getSendFailureChannel() {
-		return sendFailureChannel;
-	}
+                                @Override
+                                public void onException(Throwable e) {
+                                    log.error(
+                                            "RocketMQ Message hasn't been sent. Caused by "
+                                                    + e.getMessage());
+                                    if (getSendFailureChannel() != null) {
+                                        getSendFailureChannel().send(
+                                                RocketMQMessageHandler.this.errorMessageStrategy
+                                                        .buildErrorMessage(
+                                                                new MessagingException(
+                                                                        message, e),
+                                                                null));
+                                    }
+                                }
+                            });
+                }
+            }
+            if (sendRes != null && !sendRes.getSendStatus().equals(SendStatus.SEND_OK)) {
+                if (getSendFailureChannel() != null) {
+                    this.getSendFailureChannel().send(message);
+                } else {
+                    throw new MessagingException(message,
+                            new MQClientException("message hasn't been sent", null));
+                }
+            }
+        } catch (Exception e) {
+            log.error("RocketMQ Message hasn't been sent. Caused by " + e.getMessage());
+            if (getSendFailureChannel() != null) {
+                getSendFailureChannel().send(this.errorMessageStrategy
+                        .buildErrorMessage(new MessagingException(message, e), null));
+            } else {
+                throw new MessagingException(message, e);
+            }
+        }
 
-	public void setSync(boolean sync) {
-		this.sync = sync;
-	}
+    }
+
+    /**
+     * Set the failure channel. After a send failure, an {@link ErrorMessage} will be sent
+     * to this channel with a payload of a {@link MessagingException} with the failed
+     * message and cause.
+     *
+     * @param sendFailureChannel the failure channel.
+     * @since 0.2.2
+     */
+    public void setSendFailureChannel(MessageChannel sendFailureChannel) {
+        this.sendFailureChannel = sendFailureChannel;
+    }
+
+    /**
+     * Set the error message strategy implementation to use when sending error messages
+     * after send failures. Cannot be null.
+     *
+     * @param errorMessageStrategy the implementation.
+     * @since 0.2.2
+     */
+    public void setErrorMessageStrategy(ErrorMessageStrategy errorMessageStrategy) {
+        Assert.notNull(errorMessageStrategy, "'errorMessageStrategy' cannot be null");
+        this.errorMessageStrategy = errorMessageStrategy;
+    }
+
+    public MessageChannel getSendFailureChannel() {
+        return sendFailureChannel;
+    }
+
+    public void setSync(boolean sync) {
+        this.sync = sync;
+    }
 }

--- a/spring-cloud-stream-binder-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/properties/RocketMQConsumerProperties.java
+++ b/spring-cloud-stream-binder-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/properties/RocketMQConsumerProperties.java
@@ -65,6 +65,8 @@ public class RocketMQConsumerProperties {
 
 	private Boolean enabled = true;
 
+	private int consumeMessageBatchMaxSize=1;
+
 	// ------------ For Pull Consumer ------------
 
 	private long pullTimeout = 10 * 1000;
@@ -121,6 +123,10 @@ public class RocketMQConsumerProperties {
 		this.delayLevelWhenNextConsume = delayLevelWhenNextConsume;
 	}
 
+	public void setConsumeMessageBatchMaxSize(int consumeMessageBatchMaxSize) {
+		this.consumeMessageBatchMaxSize = consumeMessageBatchMaxSize;
+	}
+
 	public long getSuspendCurrentQueueTimeMillis() {
 		return suspendCurrentQueueTimeMillis;
 	}
@@ -131,6 +137,10 @@ public class RocketMQConsumerProperties {
 
 	public long getPullTimeout() {
 		return pullTimeout;
+	}
+
+	public int getConsumeMessageBatchMaxSize() {
+		return consumeMessageBatchMaxSize;
 	}
 
 	public void setPullTimeout(long pullTimeout) {

--- a/spring-cloud-stream-binder-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/properties/RocketMQProducerProperties.java
+++ b/spring-cloud-stream-binder-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/properties/RocketMQProducerProperties.java
@@ -23,7 +23,7 @@ import org.apache.rocketmq.client.producer.DefaultMQProducer;
  * @author <a href="mailto:fangjian0423@gmail.com">Jim</a>
  */
 public class RocketMQProducerProperties {
-    private Boolean orderly = true;
+    private Boolean orderly = false;
 
     public Boolean getOrderly() {
         return orderly;

--- a/spring-cloud-stream-binder-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/properties/RocketMQProducerProperties.java
+++ b/spring-cloud-stream-binder-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/properties/RocketMQProducerProperties.java
@@ -23,144 +23,154 @@ import org.apache.rocketmq.client.producer.DefaultMQProducer;
  * @author <a href="mailto:fangjian0423@gmail.com">Jim</a>
  */
 public class RocketMQProducerProperties {
+    private Boolean orderly = true;
 
-	private Boolean enabled = true;
+    public Boolean getOrderly() {
+        return orderly;
+    }
 
-	/**
-	 * Name of producer.
-	 */
-	private String group;
+    public void setOrderly(Boolean orderly) {
+        this.orderly = orderly;
+    }
 
-	/**
-	 * Maximum allowed message size in bytes {@link DefaultMQProducer#maxMessageSize}.
-	 */
-	private Integer maxMessageSize = 1024 * 1024 * 4;
 
-	private Boolean transactional = false;
+    private Boolean enabled = true;
 
-	private Boolean sync = false;
+    /**
+     * Name of producer.
+     */
+    private String group;
 
-	private Boolean vipChannelEnabled = true;
+    /**
+     * Maximum allowed message size in bytes {@link DefaultMQProducer#maxMessageSize}.
+     */
+    private Integer maxMessageSize = 1024 * 1024 * 4;
 
-	/**
-	 * Millis of send message timeout.
-	 */
-	private int sendMessageTimeout = 3000;
+    private Boolean transactional = false;
 
-	/**
-	 * Compress message body threshold, namely, message body larger than 4k will be
-	 * compressed on default.
-	 */
-	private int compressMessageBodyThreshold = 1024 * 4;
+    private Boolean sync = false;
 
-	/**
-	 * Maximum number of retry to perform internally before claiming sending failure in
-	 * synchronous mode. This may potentially cause message duplication which is up to
-	 * application developers to resolve.
-	 */
-	private int retryTimesWhenSendFailed = 2;
+    private Boolean vipChannelEnabled = true;
 
-	/**
-	 * <p>
-	 * Maximum number of retry to perform internally before claiming sending failure in
-	 * asynchronous mode.
-	 * </p>
-	 * This may potentially cause message duplication which is up to application
-	 * developers to resolve.
-	 */
-	private int retryTimesWhenSendAsyncFailed = 2;
+    /**
+     * Millis of send message timeout.
+     */
+    private int sendMessageTimeout = 3000;
 
-	/**
-	 * Indicate whether to retry another broker on sending failure internally.
-	 */
-	private boolean retryNextServer = false;
+    /**
+     * Compress message body threshold, namely, message body larger than 4k will be
+     * compressed on default.
+     */
+    private int compressMessageBodyThreshold = 1024 * 4;
 
-	public String getGroup() {
-		return group;
-	}
+    /**
+     * Maximum number of retry to perform internally before claiming sending failure in
+     * synchronous mode. This may potentially cause message duplication which is up to
+     * application developers to resolve.
+     */
+    private int retryTimesWhenSendFailed = 2;
 
-	public void setGroup(String group) {
-		this.group = group;
-	}
+    /**
+     * <p>
+     * Maximum number of retry to perform internally before claiming sending failure in
+     * asynchronous mode.
+     * </p>
+     * This may potentially cause message duplication which is up to application
+     * developers to resolve.
+     */
+    private int retryTimesWhenSendAsyncFailed = 2;
 
-	public Boolean getEnabled() {
-		return enabled;
-	}
+    /**
+     * Indicate whether to retry another broker on sending failure internally.
+     */
+    private boolean retryNextServer = false;
 
-	public void setEnabled(Boolean enabled) {
-		this.enabled = enabled;
-	}
+    public String getGroup() {
+        return group;
+    }
 
-	public Integer getMaxMessageSize() {
-		return maxMessageSize;
-	}
+    public void setGroup(String group) {
+        this.group = group;
+    }
 
-	public void setMaxMessageSize(Integer maxMessageSize) {
-		this.maxMessageSize = maxMessageSize;
-	}
+    public Boolean getEnabled() {
+        return enabled;
+    }
 
-	public Boolean getTransactional() {
-		return transactional;
-	}
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
 
-	public void setTransactional(Boolean transactional) {
-		this.transactional = transactional;
-	}
+    public Integer getMaxMessageSize() {
+        return maxMessageSize;
+    }
 
-	public Boolean getSync() {
-		return sync;
-	}
+    public void setMaxMessageSize(Integer maxMessageSize) {
+        this.maxMessageSize = maxMessageSize;
+    }
 
-	public void setSync(Boolean sync) {
-		this.sync = sync;
-	}
+    public Boolean getTransactional() {
+        return transactional;
+    }
 
-	public Boolean getVipChannelEnabled() {
-		return vipChannelEnabled;
-	}
+    public void setTransactional(Boolean transactional) {
+        this.transactional = transactional;
+    }
 
-	public void setVipChannelEnabled(Boolean vipChannelEnabled) {
-		this.vipChannelEnabled = vipChannelEnabled;
-	}
+    public Boolean getSync() {
+        return sync;
+    }
 
-	public int getSendMessageTimeout() {
-		return sendMessageTimeout;
-	}
+    public void setSync(Boolean sync) {
+        this.sync = sync;
+    }
 
-	public void setSendMessageTimeout(int sendMessageTimeout) {
-		this.sendMessageTimeout = sendMessageTimeout;
-	}
+    public Boolean getVipChannelEnabled() {
+        return vipChannelEnabled;
+    }
 
-	public int getCompressMessageBodyThreshold() {
-		return compressMessageBodyThreshold;
-	}
+    public void setVipChannelEnabled(Boolean vipChannelEnabled) {
+        this.vipChannelEnabled = vipChannelEnabled;
+    }
 
-	public void setCompressMessageBodyThreshold(int compressMessageBodyThreshold) {
-		this.compressMessageBodyThreshold = compressMessageBodyThreshold;
-	}
+    public int getSendMessageTimeout() {
+        return sendMessageTimeout;
+    }
 
-	public int getRetryTimesWhenSendFailed() {
-		return retryTimesWhenSendFailed;
-	}
+    public void setSendMessageTimeout(int sendMessageTimeout) {
+        this.sendMessageTimeout = sendMessageTimeout;
+    }
 
-	public void setRetryTimesWhenSendFailed(int retryTimesWhenSendFailed) {
-		this.retryTimesWhenSendFailed = retryTimesWhenSendFailed;
-	}
+    public int getCompressMessageBodyThreshold() {
+        return compressMessageBodyThreshold;
+    }
 
-	public int getRetryTimesWhenSendAsyncFailed() {
-		return retryTimesWhenSendAsyncFailed;
-	}
+    public void setCompressMessageBodyThreshold(int compressMessageBodyThreshold) {
+        this.compressMessageBodyThreshold = compressMessageBodyThreshold;
+    }
 
-	public void setRetryTimesWhenSendAsyncFailed(int retryTimesWhenSendAsyncFailed) {
-		this.retryTimesWhenSendAsyncFailed = retryTimesWhenSendAsyncFailed;
-	}
+    public int getRetryTimesWhenSendFailed() {
+        return retryTimesWhenSendFailed;
+    }
 
-	public boolean isRetryNextServer() {
-		return retryNextServer;
-	}
+    public void setRetryTimesWhenSendFailed(int retryTimesWhenSendFailed) {
+        this.retryTimesWhenSendFailed = retryTimesWhenSendFailed;
+    }
 
-	public void setRetryNextServer(boolean retryNextServer) {
-		this.retryNextServer = retryNextServer;
-	}
+    public int getRetryTimesWhenSendAsyncFailed() {
+        return retryTimesWhenSendAsyncFailed;
+    }
+
+    public void setRetryTimesWhenSendAsyncFailed(int retryTimesWhenSendAsyncFailed) {
+        this.retryTimesWhenSendAsyncFailed = retryTimesWhenSendAsyncFailed;
+    }
+
+    public boolean isRetryNextServer() {
+        return retryNextServer;
+    }
+
+    public void setRetryNextServer(boolean retryNextServer) {
+        this.retryNextServer = retryNextServer;
+    }
 
 }


### PR DESCRIPTION
### Describe what this PR does / why we need it

Support sending orderly messages via stream api and batch messages consumption.
### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
#667 and #209 
### Describe how you did it

Adding `enabled` property and sending orderly messages via `rocketMQTemplate` api in class `RocketMQMessageHandler`.
Adding `consumeMessageBatchMaxSize` to `RocketMQListenerBindingContainer` and `RocketMQConsumerProperties`, then add the property to `consumer`.
### Describe how to verify it

Adding `spring.cloud.stream.rocketmq.bingdings.output.producer.orderly=true` to application.properties in module  `rocketmq-produce-example` to use orderly messages production function.
Adding `spring.cloud.stream.rocketmq.bindings.input5.consumer.consumeMessageBatchMaxSize`=the batch message number you'd like to set in module `rocketmq-consume-example` to use batch messages consumption function.
