### PR TITLE
Fixes #831 

### DIFF
--- a/spring-cloud-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigProperties.java
+++ b/spring-cloud-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigProperties.java
@@ -26,11 +26,6 @@ import static com.alibaba.nacos.api.PropertyKeyConst.NAMESPACE;
 import static com.alibaba.nacos.api.PropertyKeyConst.SECRET_KEY;
 import static com.alibaba.nacos.api.PropertyKeyConst.SERVER_ADDR;
 
-import java.net.Inet4Address;
-import java.net.InetAddress;
-import java.net.NetworkInterface;
-import java.net.SocketException;
-import java.util.Enumeration;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
@@ -46,7 +41,6 @@ import org.springframework.util.StringUtils;
 
 import com.alibaba.nacos.api.NacosFactory;
 import com.alibaba.nacos.api.config.ConfigService;
-import com.alibaba.nacos.api.naming.PreservedMetadataKeys;
 
 /**
  * nacos properties
@@ -54,6 +48,7 @@ import com.alibaba.nacos.api.naming.PreservedMetadataKeys;
  * @author leijuan
  * @author xiaojing
  * @author pbting
+ * @author <a href="mailto:lyuzb@lyuzb.com">lyuzb</a>
  */
 @ConfigurationProperties(NacosConfigProperties.PREFIX)
 public class NacosConfigProperties {
@@ -63,7 +58,6 @@ public class NacosConfigProperties {
 	private static final Logger log = LoggerFactory
 			.getLogger(NacosConfigProperties.class);
 
-	//TODO config这里引入上层配置可否
 	@Autowired
 	private Environment environment;
 	

--- a/spring-cloud-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigProperties.java
+++ b/spring-cloud-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigProperties.java
@@ -26,16 +26,27 @@ import static com.alibaba.nacos.api.PropertyKeyConst.NAMESPACE;
 import static com.alibaba.nacos.api.PropertyKeyConst.SECRET_KEY;
 import static com.alibaba.nacos.api.PropertyKeyConst.SERVER_ADDR;
 
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.Enumeration;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
 
+import javax.annotation.PostConstruct;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.core.env.Environment;
+import org.springframework.util.StringUtils;
 
 import com.alibaba.nacos.api.NacosFactory;
 import com.alibaba.nacos.api.config.ConfigService;
+import com.alibaba.nacos.api.naming.PreservedMetadataKeys;
 
 /**
  * nacos properties
@@ -51,6 +62,25 @@ public class NacosConfigProperties {
 
 	private static final Logger log = LoggerFactory
 			.getLogger(NacosConfigProperties.class);
+
+	//TODO config这里引入上层配置可否
+	@Autowired
+	private Environment environment;
+	
+	@PostConstruct
+	public void init() {
+		this.overrideFromEnv();
+	}
+	
+	private void overrideFromEnv() {
+		if (StringUtils.isEmpty(this.getServerAddr())) {
+			String serverAddr = environment.resolvePlaceholders("${spring.cloud.nacos.config.server-addr:}");
+			if(StringUtils.isEmpty(serverAddr)) {
+				serverAddr = environment.resolvePlaceholders("${spring.cloud.nacos.server-addr}");
+			}
+			this.setServerAddr(serverAddr);
+		}
+	}
 
 	/**
 	 * nacos config server address.

--- a/spring-cloud-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
+++ b/spring-cloud-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
@@ -65,6 +65,8 @@ public class NacosDiscoveryProperties {
 	private static final Logger log = LoggerFactory
 			.getLogger(NacosDiscoveryProperties.class);
 
+	//TODO 这里引入上层配置可否？
+	
 	/**
 	 * nacos discovery server address.
 	 */
@@ -411,8 +413,11 @@ public class NacosDiscoveryProperties {
 	public void overrideFromEnv(Environment env) {
 
 		if (StringUtils.isEmpty(this.getServerAddr())) {
-			this.setServerAddr(env
-					.resolvePlaceholders("${spring.cloud.nacos.discovery.server-addr:}"));
+			String serverAddr = env.resolvePlaceholders("${spring.cloud.nacos.discovery.server-addr:}");
+			if(StringUtils.isEmpty(serverAddr)) {
+				serverAddr = env.resolvePlaceholders("${spring.cloud.nacos.server-addr}");
+			}
+			this.setServerAddr(serverAddr);
 		}
 		if (StringUtils.isEmpty(this.getNamespace())) {
 			this.setNamespace(env

--- a/spring-cloud-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
+++ b/spring-cloud-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
@@ -57,6 +57,7 @@ import com.alibaba.nacos.client.naming.utils.UtilAndComs;
  * @author dungu.zpf
  * @author xiaojing
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @author <a href="mailto:lyuzb@lyuzb.com">lyuzb</a>
  */
 
 @ConfigurationProperties("spring.cloud.nacos.discovery")
@@ -64,8 +65,6 @@ public class NacosDiscoveryProperties {
 
 	private static final Logger log = LoggerFactory
 			.getLogger(NacosDiscoveryProperties.class);
-
-	//TODO 这里引入上层配置可否？
 	
 	/**
 	 * nacos discovery server address.


### PR DESCRIPTION
### Describe what this PR does / why we need it
spring.cloud.nacos.server-addr can replace them if spring.cloud.nacos.discovery.server-addr or spring.cloud.nacos.config.server-addr not configure.

### Does this pull request fix one issue?
Fixes #831 

### Describe how you did it
If the spring.cloud.nacos.config.server-addr(spring.cloud.nacos.discovery.server-addr is also the same) is not set, the service address is obtained from spring.cloud.nacos.server-addr.

### Describe how to verify it
Tested as problematic with the nacos-discovery-example and nacos-config-example sample projects


### Special notes for reviews
