### PR TITLE
fix #831

### DIFF
--- a/spring-cloud-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigProperties.java
+++ b/spring-cloud-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigProperties.java
@@ -30,9 +30,14 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
 
+import javax.annotation.PostConstruct;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.core.env.Environment;
+import org.springframework.util.StringUtils;
 
 import com.alibaba.nacos.api.NacosFactory;
 import com.alibaba.nacos.api.config.ConfigService;
@@ -43,6 +48,7 @@ import com.alibaba.nacos.api.config.ConfigService;
  * @author leijuan
  * @author xiaojing
  * @author pbting
+ * @author <a href="mailto:lyuzb@lyuzb.com">lyuzb</a>
  */
 @ConfigurationProperties(NacosConfigProperties.PREFIX)
 public class NacosConfigProperties {
@@ -51,6 +57,24 @@ public class NacosConfigProperties {
 
 	private static final Logger log = LoggerFactory
 			.getLogger(NacosConfigProperties.class);
+
+	@Autowired
+	private Environment environment;
+	
+	@PostConstruct
+	public void init() {
+		this.overrideFromEnv();
+	}
+	
+	private void overrideFromEnv() {
+		if (StringUtils.isEmpty(this.getServerAddr())) {
+			String serverAddr = environment.resolvePlaceholders("${spring.cloud.nacos.config.server-addr:}");
+			if(StringUtils.isEmpty(serverAddr)) {
+				serverAddr = environment.resolvePlaceholders("${spring.cloud.nacos.server-addr}");
+			}
+			this.setServerAddr(serverAddr);
+		}
+	}
 
 	/**
 	 * nacos config server address.

--- a/spring-cloud-alibaba-nacos-config/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-alibaba-nacos-config/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,6 +1,17 @@
 {
   "properties": [
     {
+      "name": "spring.cloud.nacos.server-addr",
+      "type": "java.lang.String",
+      "description": "nacos server address."
+    },
+    {
+      "name": "spring.cloud.nacos.config.server-addr",
+      "type": "java.lang.String",
+      "defaultValue": "${spring.cloud.nacos.server-addr}",
+      "description": "nacos config server address."
+    },
+    {
       "name": "spring.cloud.nacos.config.encode",
       "type": "java.lang.String",
       "defaultValue": "UTF-8",

--- a/spring-cloud-alibaba-nacos-config/src/test/java/com/alibaba/cloud/nacos/NacosConfigPropertiesServerAddressBothLevelTests.java
+++ b/spring-cloud-alibaba-nacos-config/src/test/java/com/alibaba/cloud/nacos/NacosConfigPropertiesServerAddressBothLevelTests.java
@@ -1,0 +1,41 @@
+package com.alibaba.cloud.nacos;
+
+import static org.junit.Assert.assertEquals;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.alibaba.cloud.nacos.endpoint.NacosConfigEndpointAutoConfiguration;
+
+/**
+ * @author <a href="mailto:lyuzb@lyuzb.com">lyuzb</a>
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = NacosConfigPropertiesServerAddressBothLevelTests.TestConfig.class, properties = {
+		"spring.cloud.nacos.config.server-addr=321,321,321,321:8848",
+		"spring.cloud.nacos.server-addr=123.123.123.123:8848"
+		}, webEnvironment = RANDOM_PORT)
+public class NacosConfigPropertiesServerAddressBothLevelTests {
+
+	@Autowired
+	private NacosConfigProperties properties;
+	
+	@Test
+	public void testGetServerAddr() {
+		assertEquals("NacosConfigProperties server address was wrong","321,321,321,321:8848", properties.getServerAddr());
+	}
+	
+	@Configuration
+	@EnableAutoConfiguration
+	@ImportAutoConfiguration({ NacosConfigEndpointAutoConfiguration.class,
+			NacosConfigAutoConfiguration.class, NacosConfigBootstrapConfiguration.class })
+	public static class TestConfig {
+	}
+}

--- a/spring-cloud-alibaba-nacos-config/src/test/java/com/alibaba/cloud/nacos/NacosConfigPropertiesServerAddressTopLevelTests.java
+++ b/spring-cloud-alibaba-nacos-config/src/test/java/com/alibaba/cloud/nacos/NacosConfigPropertiesServerAddressTopLevelTests.java
@@ -1,0 +1,40 @@
+package com.alibaba.cloud.nacos;
+
+import static org.junit.Assert.assertEquals;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.alibaba.cloud.nacos.endpoint.NacosConfigEndpointAutoConfiguration;
+
+/**
+ * @author <a href="mailto:lyuzb@lyuzb.com">lyuzb</a>
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = NacosConfigPropertiesServerAddressTopLevelTests.TestConfig.class, properties = {
+		"spring.cloud.nacos.server-addr=123.123.123.123:8848"
+		}, webEnvironment = RANDOM_PORT)
+public class NacosConfigPropertiesServerAddressTopLevelTests {
+
+	@Autowired
+	private NacosConfigProperties properties;
+	
+	@Test
+	public void testGetServerAddr() {
+		assertEquals("NacosConfigProperties server address was wrong","123.123.123.123:8848", properties.getServerAddr());
+	}
+	
+	@Configuration
+	@EnableAutoConfiguration
+	@ImportAutoConfiguration({ NacosConfigEndpointAutoConfiguration.class,
+			NacosConfigAutoConfiguration.class, NacosConfigBootstrapConfiguration.class })
+	public static class TestConfig {
+	}
+}

--- a/spring-cloud-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
+++ b/spring-cloud-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
@@ -57,6 +57,7 @@ import com.alibaba.nacos.client.naming.utils.UtilAndComs;
  * @author dungu.zpf
  * @author xiaojing
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @author <a href="mailto:lyuzb@lyuzb.com">lyuzb</a>
  */
 
 @ConfigurationProperties("spring.cloud.nacos.discovery")
@@ -64,7 +65,7 @@ public class NacosDiscoveryProperties {
 
 	private static final Logger log = LoggerFactory
 			.getLogger(NacosDiscoveryProperties.class);
-
+	
 	/**
 	 * nacos discovery server address.
 	 */
@@ -411,8 +412,11 @@ public class NacosDiscoveryProperties {
 	public void overrideFromEnv(Environment env) {
 
 		if (StringUtils.isEmpty(this.getServerAddr())) {
-			this.setServerAddr(env
-					.resolvePlaceholders("${spring.cloud.nacos.discovery.server-addr:}"));
+			String serverAddr = env.resolvePlaceholders("${spring.cloud.nacos.discovery.server-addr:}");
+			if(StringUtils.isEmpty(serverAddr)) {
+				serverAddr = env.resolvePlaceholders("${spring.cloud.nacos.server-addr}");
+			}
+			this.setServerAddr(serverAddr);
 		}
 		if (StringUtils.isEmpty(this.getNamespace())) {
 			this.setNamespace(env

--- a/spring-cloud-alibaba-nacos-discovery/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-alibaba-nacos-discovery/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,5 +1,16 @@
 {"properties": [
     {
+      "name": "spring.cloud.nacos.server-addr",
+      "type": "java.lang.String",
+      "description": "nacos server address."
+    },
+    {
+      "name": "spring.cloud.nacos.discovery.server-addr",
+      "type": "java.lang.String",
+      "defaultValue": "${spring.cloud.nacos.server-addr}",
+      "description": "nacos discovery server address."
+    },
+    {
       "name": "spring.cloud.nacos.discovery.service",
       "type": "java.lang.String",
       "defaultValue": "${spring.application.name}",

--- a/spring-cloud-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/NacosDiscoveryPropertiesServerAddressBothLevelTests.java
+++ b/spring-cloud-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/NacosDiscoveryPropertiesServerAddressBothLevelTests.java
@@ -1,0 +1,45 @@
+package com.alibaba.cloud.nacos;
+
+import static org.junit.Assert.assertEquals;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.alibaba.cloud.nacos.NacosDiscoveryAutoConfiguration;
+import com.alibaba.cloud.nacos.NacosDiscoveryProperties;
+import com.alibaba.cloud.nacos.discovery.NacosDiscoveryClientAutoConfiguration;
+
+/**
+ * @author <a href="mailto:lyuzb@lyuzb.com">lyuzb</a>
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = NacosDiscoveryPropertiesServerAddressBothLevelTests.TestConfig.class, properties = {
+		"spring.cloud.nacos.discovery.server-addr=321.321.321.321:8848",
+		"spring.cloud.nacos.server-addr=123.123.123.123:8848"
+		}, webEnvironment = RANDOM_PORT)
+public class NacosDiscoveryPropertiesServerAddressBothLevelTests {
+
+	@Autowired
+	private NacosDiscoveryProperties properties;
+	
+	@Test
+	public void testGetServerAddr() {
+		assertEquals("NacosDiscoveryProperties server address was wrong","321.321.321.321:8848", properties.getServerAddr());
+	}
+	
+	@Configuration
+	@EnableAutoConfiguration
+	@ImportAutoConfiguration({ AutoServiceRegistrationConfiguration.class,
+			NacosDiscoveryClientAutoConfiguration.class,
+			NacosDiscoveryAutoConfiguration.class })
+	public static class TestConfig {
+	}
+}

--- a/spring-cloud-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/NacosDiscoveryPropertiesServerAddressTopLevelTests.java
+++ b/spring-cloud-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/NacosDiscoveryPropertiesServerAddressTopLevelTests.java
@@ -1,0 +1,47 @@
+package com.alibaba.cloud.nacos;
+
+import static org.junit.Assert.assertEquals;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.alibaba.cloud.nacos.NacosDiscoveryAutoConfiguration;
+import com.alibaba.cloud.nacos.NacosDiscoveryProperties;
+import com.alibaba.cloud.nacos.discovery.NacosDiscoveryClientAutoConfiguration;
+
+/**
+ * 
+ * @author <a href="mailto:lyuzb@lyuzb.com">lyuzb</a>
+ *
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = NacosDiscoveryPropertiesServerAddressTopLevelTests.TestConfig.class, properties = {
+		"spring.cloud.nacos.server-addr=123.123.123.123:8848"
+		}, webEnvironment = RANDOM_PORT)
+
+public class NacosDiscoveryPropertiesServerAddressTopLevelTests {
+
+	@Autowired
+	private NacosDiscoveryProperties properties;
+	
+	@Test
+	public void testGetServerAddr() {
+		assertEquals("NacosDiscoveryProperties server address was wrong","123.123.123.123:8848", properties.getServerAddr());
+	}
+	
+	@Configuration
+	@EnableAutoConfiguration
+	@ImportAutoConfiguration({ AutoServiceRegistrationConfiguration.class,
+			NacosDiscoveryClientAutoConfiguration.class,
+			NacosDiscoveryAutoConfiguration.class })
+	public static class TestConfig {
+	}
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it
spring.cloud.nacos.server-addr can replace them if spring.cloud.nacos.discovery.server-addr or spring.cloud.nacos.config.server-addr not configure.

### Does this pull request fix one issue?
Fixes #831 

### Describe how you did it
If the spring.cloud.nacos.config.server-addr(spring.cloud.nacos.discovery.server-addr is also the same) is not set, the service address is obtained from spring.cloud.nacos.server-addr.

### Describe how to verify it
Tested as problematic with the nacos-discovery-example and nacos-config-example sample projects


### Special notes for reviews
