### PR TITLE
fix #851

### DIFF
--- a/spring-cloud-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
+++ b/spring-cloud-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
@@ -190,7 +190,7 @@ public class NacosDiscoveryProperties {
 		}
 
 		serverAddr = Objects.toString(serverAddr, "");
-		if (serverAddr.lastIndexOf("/") != -1) {
+		if (serverAddr.endsWith("/")) {
 			serverAddr = serverAddr.substring(0, serverAddr.length() - 1);
 		}
 		endpoint = Objects.toString(endpoint, "");


### PR DESCRIPTION
### Describe what this PR does / why we need it
This is a bug. Failed when registering using http://dev.nacos.com. However, after testing, the above url can be successfully registered, but due to the wrong url truncation operation, the registered url address is "http://dev.nacos.co", so the registration fails.

### Does this pull request fix one issue?
fix #851 
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
Modify the judgment logic to determine whether the url ends with "/" to prevent the wrong url from being truncated.

### Describe how to verify it
The test requires a nacos server, I am using version 1.1.3. 
1、Locally build a nginx response agent nacos service and listen to the dev.nacos.com domain name. 
2、Modify local /etc/hosts to mimic NDS. 
3、Modify "spring.cloud.nacos.discovery.server-addr=http://dev.nacos.com" in application.properties in the nacos-discovery-provider-example project. 
4、Start nacos-discovery-provider-example and check the list of services in http://localhost:8848/nacos. Registration is successful.

### Special notes for reviews
nginx config:
upstream my_server {
    server 127.0.0.1:8848;
    keepalive 2000;
}
server {
    listen       80;
    server_name  dev.nacos.com;
    client_max_body_size 1024M;

    location /nacos/ {
        proxy_pass http://my_server/nacos/;
        proxy_set_header Host $host:$server_port;
    }
}
