### PR TITLE
Support OssStorage Resource as WritableResource and add related unittest cases

### DIFF
--- a/spring-cloud-alibaba-examples/oss-example/src/main/java/com/alibaba/cloud/examples/OssController.java
+++ b/spring-cloud-alibaba-examples/oss-example/src/main/java/com/alibaba/cloud/examples/OssController.java
@@ -1,6 +1,5 @@
 package com.alibaba.cloud.examples;
 
-import com.alibaba.alicloud.oss.resource.OssStorageResource;
 import com.aliyun.oss.OSS;
 import com.aliyun.oss.common.utils.IOUtils;
 import com.aliyun.oss.model.OSSObject;
@@ -8,6 +7,7 @@ import org.apache.commons.codec.CharEncoding;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
+import org.springframework.core.io.WritableResource;
 import org.springframework.util.StreamUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -74,15 +74,14 @@ public class OssController {
 
 	@GetMapping("/upload2")
 	public String uploadWithOutputStream() {
-		OssStorageResource ossStorageResource = new OssStorageResource(this.ossClient,
-			"oss://" + OssApplication.BUCKET_NAME + "/oss-test.json", true);
 		try {
-			InputStream inputStream = localFile.getInputStream();
-			OutputStream outputStream = ossStorageResource.getOutputStream();
-			StreamUtils.copy(inputStream, outputStream);
-			inputStream.close();
-			outputStream.close();
-		} catch (Exception ex) {
+			try (OutputStream outputStream = ((WritableResource) this.remoteFile)
+					.getOutputStream();
+					InputStream inputStream = localFile.getInputStream()) {
+				StreamUtils.copy(inputStream, outputStream);
+			}
+		}
+		catch (Exception ex) {
 			ex.printStackTrace();
 			return "upload with outputStream failed";
 		}

--- a/spring-cloud-alibaba-examples/oss-example/src/main/java/com/alibaba/cloud/examples/OssController.java
+++ b/spring-cloud-alibaba-examples/oss-example/src/main/java/com/alibaba/cloud/examples/OssController.java
@@ -1,7 +1,9 @@
 package com.alibaba.cloud.examples;
 
-import java.nio.charset.Charset;
-
+import com.alibaba.alicloud.oss.resource.OssStorageResource;
+import com.aliyun.oss.OSS;
+import com.aliyun.oss.common.utils.IOUtils;
+import com.aliyun.oss.model.OSSObject;
 import org.apache.commons.codec.CharEncoding;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -10,9 +12,9 @@ import org.springframework.util.StreamUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.aliyun.oss.OSS;
-import com.aliyun.oss.common.utils.IOUtils;
-import com.aliyun.oss.model.OSSObject;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
 
 /**
  * OSS Controller
@@ -25,8 +27,11 @@ public class OssController {
 	@Autowired
 	private OSS ossClient;
 
+	@Value("classpath:/oss-test.json")
+	private Resource localFile;
+
 	@Value("oss://" + OssApplication.BUCKET_NAME + "/oss-test.json")
-	private Resource file;
+	private Resource remoteFile;
 
 	@GetMapping("/upload")
 	public String upload() {
@@ -45,7 +50,7 @@ public class OssController {
 	public String fileResource() {
 		try {
 			return "get file resource success. content: " + StreamUtils.copyToString(
-					file.getInputStream(), Charset.forName(CharEncoding.UTF_8));
+					remoteFile.getInputStream(), Charset.forName(CharEncoding.UTF_8));
 		}
 		catch (Exception e) {
 			e.printStackTrace();
@@ -65,6 +70,23 @@ public class OssController {
 			e.printStackTrace();
 			return "download fail: " + e.getMessage();
 		}
+	}
+
+	@GetMapping("/upload2")
+	public String uploadWithOutputStream() {
+		OssStorageResource ossStorageResource = new OssStorageResource(this.ossClient,
+			"oss://" + OssApplication.BUCKET_NAME + "/oss-test.json", true);
+		try {
+			InputStream inputStream = localFile.getInputStream();
+			OutputStream outputStream = ossStorageResource.getOutputStream();
+			StreamUtils.copy(inputStream, outputStream);
+			inputStream.close();
+			outputStream.close();
+		} catch (Exception ex) {
+			ex.printStackTrace();
+			return "upload with outputStream failed";
+		}
+		return "upload success";
 	}
 
 }

--- a/spring-cloud-alicloud-oss/pom.xml
+++ b/spring-cloud-alicloud-oss/pom.xml
@@ -58,6 +58,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/spring-cloud-alicloud-oss/src/main/java/com/alibaba/alicloud/oss/OssAutoConfiguration.java
+++ b/spring-cloud-alicloud-oss/src/main/java/com/alibaba/alicloud/oss/OssAutoConfiguration.java
@@ -50,8 +50,9 @@ public class OssAutoConfiguration {
 	@Bean(name = OSS_TASK_EXECUTOR_BEAN_NAME)
 	@ConditionalOnMissingBean
 	public ExecutorService ossTaskExecutor() {
-		return new ThreadPoolExecutor(8, 128,
-			60, TimeUnit.SECONDS, new SynchronousQueue<>());
+		int coreSize = Runtime.getRuntime().availableProcessors();
+		return new ThreadPoolExecutor(coreSize, 128, 60, TimeUnit.SECONDS,
+				new SynchronousQueue<>());
 	}
 
 }

--- a/spring-cloud-alicloud-oss/src/main/java/com/alibaba/alicloud/oss/OssAutoConfiguration.java
+++ b/spring-cloud-alicloud-oss/src/main/java/com/alibaba/alicloud/oss/OssAutoConfiguration.java
@@ -25,6 +25,11 @@ import org.springframework.context.annotation.Configuration;
 import com.alibaba.alicloud.oss.resource.OssStorageProtocolResolver;
 
 import com.aliyun.oss.OSS;
+import org.springframework.context.annotation.Lazy;
+
+import java.util.concurrent.*;
+
+import static com.alibaba.alicloud.oss.OssConstants.OSS_TASK_EXECUTOR_BEAN_NAME;
 
 /**
  * OSS Auto {@link Configuration}
@@ -40,6 +45,13 @@ public class OssAutoConfiguration {
 	@ConditionalOnMissingBean
 	public OssStorageProtocolResolver ossStorageProtocolResolver() {
 		return new OssStorageProtocolResolver();
+	}
+
+	@Bean(name = OSS_TASK_EXECUTOR_BEAN_NAME)
+	@ConditionalOnMissingBean
+	public ExecutorService ossTaskExecutor() {
+		return new ThreadPoolExecutor(8, 128,
+			60, TimeUnit.SECONDS, new SynchronousQueue<>());
 	}
 
 }

--- a/spring-cloud-alicloud-oss/src/main/java/com/alibaba/alicloud/oss/OssConstants.java
+++ b/spring-cloud-alicloud-oss/src/main/java/com/alibaba/alicloud/oss/OssConstants.java
@@ -26,4 +26,6 @@ public interface OssConstants {
 	String PREFIX = "spring.cloud.alibaba.oss";
 	String ENABLED = PREFIX + ".enabled";
 
+	String OSS_TASK_EXECUTOR_BEAN_NAME = "ossTaskExecutor";
+
 }

--- a/spring-cloud-alicloud-oss/src/main/java/com/alibaba/alicloud/oss/resource/OssStorageProtocolResolver.java
+++ b/spring-cloud-alicloud-oss/src/main/java/com/alibaba/alicloud/oss/resource/OssStorageProtocolResolver.java
@@ -63,7 +63,7 @@ public class OssStorageProtocolResolver
 		if (!location.startsWith(PROTOCOL)) {
 			return null;
 		}
-		return new OssStorageResource(getOSS(), location);
+		return new OssStorageResource(getOSS(), location, beanFactory);
 	}
 
 	@Override

--- a/spring-cloud-alicloud-oss/src/main/java/com/alibaba/alicloud/oss/resource/OssStorageResource.java
+++ b/spring-cloud-alicloud-oss/src/main/java/com/alibaba/alicloud/oss/resource/OssStorageResource.java
@@ -216,6 +216,10 @@ public class OssStorageResource implements WritableResource {
 		}
 	}
 
+	/**
+	 * create a bucket.
+	 * @return
+	 */
 	public Bucket createBucket() {
 		return this.oss.createBucket(this.bucketName);
 	}
@@ -226,33 +230,37 @@ public class OssStorageResource implements WritableResource {
 	}
 
 	/**
-     * 获取一个OutputStream用于写操作。
-	 * 注意：写完成后必须关闭该流
+	 * acquire an OutputStream for write.
+	 * Note: please close the stream after writing is done
 	 * @return
-     * @throws IOException
+	 * @throws IOException
 	 */
 	@Override
 	public OutputStream getOutputStream() throws IOException {
 		if (isBucket()) {
 			throw new IllegalStateException(
-				"Cannot open an output stream to a bucket: '" + getURI() + "'");
+					"Cannot open an output stream to a bucket: '" + getURI() + "'");
 		}
 		else {
 			OSSObject ossObject;
 
-		    try {
+			try {
 				ossObject = this.getOSSObject();
-			} catch (OSSException ex) {
-		    	if (ex.getMessage() != null && ex.getMessage().startsWith(MESSAGE_KEY_NOT_EXIST)) {
-		    		ossObject = null;
-				} else {
-		    		throw ex;
+			}
+			catch (OSSException ex) {
+				if (ex.getMessage() != null
+						&& ex.getMessage().startsWith(MESSAGE_KEY_NOT_EXIST)) {
+					ossObject = null;
+				}
+				else {
+					throw ex;
 				}
 			}
 
-			if (ossObject == null ) {
+			if (ossObject == null) {
 				if (!this.autoCreateFiles) {
-					throw new FileNotFoundException("The object was not found: " + getURI());
+					throw new FileNotFoundException(
+							"The object was not found: " + getURI());
 				}
 
 			}
@@ -263,7 +271,8 @@ public class OssStorageResource implements WritableResource {
 			executorService.submit(() -> {
 				try {
 					OssStorageResource.this.oss.putObject(bucketName, objectKey, in);
-				} catch (Exception ex) {
+				}
+				catch (Exception ex) {
 					logger.error("Failed to put object", ex);
 				}
 			});

--- a/spring-cloud-alicloud-oss/src/main/java/com/alibaba/alicloud/oss/resource/OssStorageResource.java
+++ b/spring-cloud-alicloud-oss/src/main/java/com/alibaba/alicloud/oss/resource/OssStorageResource.java
@@ -58,7 +58,8 @@ public class OssStorageResource implements WritableResource {
 	private final URI location;
 	private final boolean autoCreateFiles;
 
-	private final ExecutorService executorService;
+	private static final ExecutorService executorService = new ThreadPoolExecutor(8, 128,
+			60, TimeUnit.SECONDS, new SynchronousQueue<>());
 
 	public OssStorageResource(OSS oss, String location) {
 		this(oss, location, false);
@@ -86,9 +87,6 @@ public class OssStorageResource implements WritableResource {
 			throw new IllegalArgumentException("Invalid location: " + location, e);
 		}
 
-		this.executorService = new ThreadPoolExecutor(
-			1, 1, 60, TimeUnit.SECONDS,
-			new SynchronousQueue<>());
 	}
 
 	public boolean isAutoCreateFiles() {

--- a/spring-cloud-alicloud-oss/src/test/java/com/alibaba/alicloud/oss/resource/DummyOssClient.java
+++ b/spring-cloud-alicloud-oss/src/test/java/com/alibaba/alicloud/oss/resource/DummyOssClient.java
@@ -1,0 +1,80 @@
+package com.alibaba.alicloud.oss.resource;
+
+import com.aliyun.oss.model.Bucket;
+import com.aliyun.oss.model.OSSObject;
+import com.aliyun.oss.model.ObjectMetadata;
+import com.aliyun.oss.model.PutObjectResult;
+import org.springframework.util.StreamUtils;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author lich
+ * @date 2019/8/30
+ */
+public class DummyOssClient {
+
+    private Map<String, byte[]> storeMap = new ConcurrentHashMap<>();
+
+    private Map<String, Bucket> bucketSet = new HashMap<>();
+
+    public String getStoreKey(String bucketName, String objectKey) {
+        return String.join(".", bucketName, objectKey);
+    }
+
+    public PutObjectResult putObject(String bucketName, String objectKey, InputStream inputStream) {
+
+        try {
+            byte[] result = StreamUtils.copyToByteArray(inputStream);
+            storeMap.put(getStoreKey(bucketName, objectKey), result);
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        } finally {
+            try {
+                inputStream.close();
+            } catch (IOException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+
+
+        return new PutObjectResult();
+    }
+
+    public OSSObject getOSSObject(String bucketName, String objectKey) {
+        byte[] value = storeMap.get(this.getStoreKey(bucketName, objectKey));
+        if (value == null) {
+            return null;
+        }
+        OSSObject ossObject = new OSSObject();
+        ossObject.setBucketName(bucketName);
+        ossObject.setKey(objectKey);
+        InputStream inputStream = new ByteArrayInputStream(value);
+        ossObject.setObjectContent(inputStream);
+
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentLength(value.length);
+        ossObject.setObjectMetadata(objectMetadata);
+
+        return ossObject;
+    }
+
+    public Bucket createBucket(String bucketName) {
+        if (bucketSet.containsKey(bucketName)) {
+            return bucketSet.get(bucketName);
+        }
+        Bucket bucket = new Bucket();
+        bucket.setCreationDate(new Date());
+        bucket.setName(bucketName);
+        bucketSet.put(bucketName, bucket);
+        return bucket;
+    }
+
+    public List<Bucket> bucketList() {
+        return new ArrayList<>(bucketSet.values());
+    }
+}

--- a/spring-cloud-alicloud-oss/src/test/java/com/alibaba/alicloud/oss/resource/DummyOssClient.java
+++ b/spring-cloud-alicloud-oss/src/test/java/com/alibaba/alicloud/oss/resource/DummyOssClient.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.alibaba.alicloud.oss.resource;
 
 import com.aliyun.oss.model.Bucket;
@@ -14,67 +30,69 @@ import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * @author lich
- * @date 2019/8/30
  */
 public class DummyOssClient {
 
-    private Map<String, byte[]> storeMap = new ConcurrentHashMap<>();
+	private Map<String, byte[]> storeMap = new ConcurrentHashMap<>();
 
-    private Map<String, Bucket> bucketSet = new HashMap<>();
+	private Map<String, Bucket> bucketSet = new HashMap<>();
 
-    public String getStoreKey(String bucketName, String objectKey) {
-        return String.join(".", bucketName, objectKey);
-    }
+	public String getStoreKey(String bucketName, String objectKey) {
+		return String.join(".", bucketName, objectKey);
+	}
 
-    public PutObjectResult putObject(String bucketName, String objectKey, InputStream inputStream) {
+	public PutObjectResult putObject(String bucketName, String objectKey,
+			InputStream inputStream) {
 
-        try {
-            byte[] result = StreamUtils.copyToByteArray(inputStream);
-            storeMap.put(getStoreKey(bucketName, objectKey), result);
-        } catch (IOException ex) {
-            throw new RuntimeException(ex);
-        } finally {
-            try {
-                inputStream.close();
-            } catch (IOException ex) {
-                throw new RuntimeException(ex);
-            }
-        }
+		try {
+			byte[] result = StreamUtils.copyToByteArray(inputStream);
+			storeMap.put(getStoreKey(bucketName, objectKey), result);
+		}
+		catch (IOException ex) {
+			throw new RuntimeException(ex);
+		}
+		finally {
+			try {
+				inputStream.close();
+			}
+			catch (IOException ex) {
+				throw new RuntimeException(ex);
+			}
+		}
 
+		return new PutObjectResult();
+	}
 
-        return new PutObjectResult();
-    }
+	public OSSObject getOSSObject(String bucketName, String objectKey) {
+		byte[] value = storeMap.get(this.getStoreKey(bucketName, objectKey));
+		if (value == null) {
+			return null;
+		}
+		OSSObject ossObject = new OSSObject();
+		ossObject.setBucketName(bucketName);
+		ossObject.setKey(objectKey);
+		InputStream inputStream = new ByteArrayInputStream(value);
+		ossObject.setObjectContent(inputStream);
 
-    public OSSObject getOSSObject(String bucketName, String objectKey) {
-        byte[] value = storeMap.get(this.getStoreKey(bucketName, objectKey));
-        if (value == null) {
-            return null;
-        }
-        OSSObject ossObject = new OSSObject();
-        ossObject.setBucketName(bucketName);
-        ossObject.setKey(objectKey);
-        InputStream inputStream = new ByteArrayInputStream(value);
-        ossObject.setObjectContent(inputStream);
+		ObjectMetadata objectMetadata = new ObjectMetadata();
+		objectMetadata.setContentLength(value.length);
+		ossObject.setObjectMetadata(objectMetadata);
 
-        ObjectMetadata objectMetadata = new ObjectMetadata();
-        objectMetadata.setContentLength(value.length);
-        ossObject.setObjectMetadata(objectMetadata);
+		return ossObject;
+	}
 
-        return ossObject;
-    }
+	public Bucket createBucket(String bucketName) {
+		if (bucketSet.containsKey(bucketName)) {
+			return bucketSet.get(bucketName);
+		}
+		Bucket bucket = new Bucket();
+		bucket.setCreationDate(new Date());
+		bucket.setName(bucketName);
+		bucketSet.put(bucketName, bucket);
+		return bucket;
+	}
 
-    public Bucket createBucket(String bucketName) {
-        if (bucketSet.containsKey(bucketName)) {
-            return bucketSet.get(bucketName);
-        }
-        Bucket bucket = new Bucket();
-        bucket.setCreationDate(new Date());
-        bucket.setName(bucketName);
-        bucketSet.put(bucketName, bucket);
-        return bucket;
-    }
-
-    public List<Bucket> bucketList() {
-        return new ArrayList<>(bucketSet.values());
-    }
+	public List<Bucket> bucketList() {
+		return new ArrayList<>(bucketSet.values());
+	}
 }

--- a/spring-cloud-alicloud-oss/src/test/java/com/alibaba/alicloud/oss/resource/OssStorageResourceTest.java
+++ b/spring-cloud-alicloud-oss/src/test/java/com/alibaba/alicloud/oss/resource/OssStorageResourceTest.java
@@ -1,7 +1,22 @@
+/*
+ * Copyright (C) 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.alibaba.alicloud.oss.resource;
 
 import com.aliyun.oss.OSS;
-import com.aliyun.oss.common.utils.IOUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -19,7 +34,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.StreamUtils;
 
 import java.io.*;
-import java.nio.charset.Charset;
 import java.util.Random;
 
 import static org.junit.Assert.*;
@@ -28,200 +42,205 @@ import static org.mockito.Mockito.mock;
 
 /**
  * @author lich
- * @date 2019/8/29
  */
-
 @SpringBootTest
 @RunWith(SpringRunner.class)
 public class OssStorageResourceTest {
 
-    /**
-     * Used to test exception messages and types.
-     */
-    @Rule
-    public ExpectedException expectedEx = ExpectedException.none();
+	/**
+	 * Used to test exception messages and types.
+	 */
+	@Rule
+	public ExpectedException expectedEx = ExpectedException.none();
 
-    @Autowired
-    private OSS oss;
+	@Autowired
+	private OSS oss;
 
-    @Value("oss://aliyun-test-bucket/")
-    private Resource bucketResource;
+	@Value("oss://aliyun-test-bucket/")
+	private Resource bucketResource;
 
-    @Value("oss://aliyun-test-bucket/myfilekey")
-    private Resource remoteResource;
+	@Value("oss://aliyun-test-bucket/myfilekey")
+	private Resource remoteResource;
 
-    public static byte[] generateRandomBytes(int blen) {
-        byte[] array = new byte[blen];
-        new Random().nextBytes(array);
-        return array;
-    }
+	public static byte[] generateRandomBytes(int blen) {
+		byte[] array = new byte[blen];
+		new Random().nextBytes(array);
+		return array;
+	}
 
-    @Test
-    public void testResourceType() {
-        assertEquals(OssStorageResource.class, remoteResource.getClass());
-        OssStorageResource ossStorageResource = (OssStorageResource)remoteResource;
-        assertEquals("myfilekey", ossStorageResource.getFilename());
-        assertFalse(ossStorageResource.isBucket());
-    }
+	@Test
+	public void testResourceType() {
+		assertEquals(OssStorageResource.class, remoteResource.getClass());
+		OssStorageResource ossStorageResource = (OssStorageResource) remoteResource;
+		assertEquals("myfilekey", ossStorageResource.getFilename());
+		assertFalse(ossStorageResource.isBucket());
+	}
 
-    @Test
-    public void testValidObject() throws Exception {
-        assertTrue(remoteResource.exists());
-        OssStorageResource ossStorageResource = (OssStorageResource)remoteResource;
-        assertTrue(ossStorageResource.bucketExists());
-        assertEquals(4096L, remoteResource.contentLength());
-        assertEquals("oss://aliyun-test-bucket/myfilekey", remoteResource.getURI().toString());
-        assertEquals("myfilekey", remoteResource.getFilename());
-    }
+	@Test
+	public void testValidObject() throws Exception {
+		assertTrue(remoteResource.exists());
+		OssStorageResource ossStorageResource = (OssStorageResource) remoteResource;
+		assertTrue(ossStorageResource.bucketExists());
+		assertEquals(4096L, remoteResource.contentLength());
+		assertEquals("oss://aliyun-test-bucket/myfilekey",
+				remoteResource.getURI().toString());
+		assertEquals("myfilekey", remoteResource.getFilename());
+	}
 
-    @Test
-    public void testBucketResource() throws Exception {
-        assertTrue(bucketResource.exists());
-        assertTrue(((OssStorageResource)this.bucketResource).isBucket());
-        assertTrue(((OssStorageResource)this.bucketResource).bucketExists());
-        assertEquals("oss://aliyun-test-bucket/", bucketResource.getURI().toString());
-        assertEquals("aliyun-test-bucket", this.bucketResource.getFilename());
-    }
+	@Test
+	public void testBucketResource() throws Exception {
+		assertTrue(bucketResource.exists());
+		assertTrue(((OssStorageResource) this.bucketResource).isBucket());
+		assertTrue(((OssStorageResource) this.bucketResource).bucketExists());
+		assertEquals("oss://aliyun-test-bucket/", bucketResource.getURI().toString());
+		assertEquals("aliyun-test-bucket", this.bucketResource.getFilename());
+	}
 
-    @Test
-    public void testBucketNotEndingInSlash() {
-        assertTrue(new OssStorageResource(this.oss, "oss://aliyun-test-bucket").isBucket());
-    }
+	@Test
+	public void testBucketNotEndingInSlash() {
+		assertTrue(
+				new OssStorageResource(this.oss, "oss://aliyun-test-bucket").isBucket());
+	}
 
-    @Test
-    public void testSpecifyPathCorrect() {
-        OssStorageResource ossStorageResource = new OssStorageResource (
-            this.oss, "oss://aliyun-test-bucket/myfilekey", false);
+	@Test
+	public void testSpecifyPathCorrect() {
+		OssStorageResource ossStorageResource = new OssStorageResource(this.oss,
+				"oss://aliyun-test-bucket/myfilekey", false);
 
-        assertTrue(ossStorageResource.exists());
-    }
+		assertTrue(ossStorageResource.exists());
+	}
 
-    @Test
-    public void testSpecifyBucketCorrect() {
-        OssStorageResource ossStorageResource = new OssStorageResource(
-            this.oss, "oss://aliyun-test-bucket", false);
+	@Test
+	public void testSpecifyBucketCorrect() {
+		OssStorageResource ossStorageResource = new OssStorageResource(this.oss,
+				"oss://aliyun-test-bucket", false);
 
-        assertTrue(ossStorageResource.isBucket());
-        assertEquals("aliyun-test-bucket", ossStorageResource.getBucket().getName());
-        assertTrue(ossStorageResource.exists());
-    }
+		assertTrue(ossStorageResource.isBucket());
+		assertEquals("aliyun-test-bucket", ossStorageResource.getBucket().getName());
+		assertTrue(ossStorageResource.exists());
+	}
 
-    @Test
-    public void testBucketOutputStream() throws IOException {
-        this.expectedEx.expect(IllegalStateException.class);
-        this.expectedEx.expectMessage("Cannot open an output stream to a bucket: 'oss://aliyun-test-bucket/'");
-        ((WritableResource) this.bucketResource).getOutputStream();
-    }
+	@Test
+	public void testBucketOutputStream() throws IOException {
+		this.expectedEx.expect(IllegalStateException.class);
+		this.expectedEx.expectMessage(
+				"Cannot open an output stream to a bucket: 'oss://aliyun-test-bucket/'");
+		((WritableResource) this.bucketResource).getOutputStream();
+	}
 
-    @Test
-    public void testBucketInputStream() throws IOException {
-        this.expectedEx.expect(IllegalStateException.class);
-        this.expectedEx.expectMessage("Cannot open an input stream to a bucket: 'oss://aliyun-test-bucket/'");
-        this.bucketResource.getInputStream();
-    }
+	@Test
+	public void testBucketInputStream() throws IOException {
+		this.expectedEx.expect(IllegalStateException.class);
+		this.expectedEx.expectMessage(
+				"Cannot open an input stream to a bucket: 'oss://aliyun-test-bucket/'");
+		this.bucketResource.getInputStream();
+	}
 
-    @Test
-    public void testBucketContentLength() throws IOException {
-        this.expectedEx.expect(FileNotFoundException.class);
-        this.expectedEx.expectMessage("OSSObject not existed.");
-        this.bucketResource.contentLength();
-    }
+	@Test
+	public void testBucketContentLength() throws IOException {
+		this.expectedEx.expect(FileNotFoundException.class);
+		this.expectedEx.expectMessage("OSSObject not existed.");
+		this.bucketResource.contentLength();
+	}
 
-    @Test
-    public void testBucketFile() throws IOException {
-        this.expectedEx.expect(UnsupportedOperationException.class);
-        this.expectedEx.expectMessage("oss://aliyun-test-bucket/ cannot be resolved to absolute file path");
-        this.bucketResource.getFile();
-    }
+	@Test
+	public void testBucketFile() throws IOException {
+		this.expectedEx.expect(UnsupportedOperationException.class);
+		this.expectedEx.expectMessage(
+				"oss://aliyun-test-bucket/ cannot be resolved to absolute file path");
+		this.bucketResource.getFile();
+	}
 
-    @Test
-    public void testBucketLastModified() throws IOException {
-        this.expectedEx.expect(FileNotFoundException.class);
-        this.expectedEx.expectMessage("OSSObject not existed.");
-        this.bucketResource.lastModified();
-    }
+	@Test
+	public void testBucketLastModified() throws IOException {
+		this.expectedEx.expect(FileNotFoundException.class);
+		this.expectedEx.expectMessage("OSSObject not existed.");
+		this.bucketResource.lastModified();
+	}
 
-    @Test
-    public void testBucketResourceStatuses() {
-        assertFalse(this.bucketResource.isOpen());
-        assertFalse(((WritableResource) this.bucketResource).isWritable());
-        assertTrue(this.bucketResource.exists());
-    }
+	@Test
+	public void testBucketResourceStatuses() {
+		assertFalse(this.bucketResource.isOpen());
+		assertFalse(((WritableResource) this.bucketResource).isWritable());
+		assertTrue(this.bucketResource.exists());
+	}
 
-    @Test
-    public void testWritable() throws Exception {
-        assertTrue(this.remoteResource instanceof WritableResource);
-        WritableResource writableResource = (WritableResource) this.remoteResource;
-        assertTrue(writableResource.isWritable());
-        writableResource.getOutputStream();
-    }
+	@Test
+	public void testWritable() throws Exception {
+		assertTrue(this.remoteResource instanceof WritableResource);
+		WritableResource writableResource = (WritableResource) this.remoteResource;
+		assertTrue(writableResource.isWritable());
+		writableResource.getOutputStream();
+	}
 
-    @Test
-    public void testWritableOutputStream() throws Exception {
-        String location = "oss://aliyun-test-bucket/test";
-        OssStorageResource resource = new OssStorageResource(this.oss, location, true);
-        OutputStream os = resource.getOutputStream();
-        assertNotNull(os);
+	@Test
+	public void testWritableOutputStream() throws Exception {
+		String location = "oss://aliyun-test-bucket/test";
+		OssStorageResource resource = new OssStorageResource(this.oss, location, true);
+		OutputStream os = resource.getOutputStream();
+		assertNotNull(os);
 
-        byte[] randomBytes = generateRandomBytes(1203);
-        String expectedString = new String(randomBytes);
+		byte[] randomBytes = generateRandomBytes(1203);
+		String expectedString = new String(randomBytes);
 
-        os.write(randomBytes);
-        os.close();
+		os.write(randomBytes);
+		os.close();
 
-        InputStream in = resource.getInputStream();
+		InputStream in = resource.getInputStream();
 
-        byte[] result = StreamUtils.copyToByteArray(in);
-        String actualString = new String(result);
+		byte[] result = StreamUtils.copyToByteArray(in);
+		String actualString = new String(result);
 
-        assertEquals(expectedString, actualString);
-    }
+		assertEquals(expectedString, actualString);
+	}
 
+	@Test
+	public void testCreateBucket() {
+		String location = "oss://my-new-test-bucket/";
+		OssStorageResource resource = new OssStorageResource(this.oss, location, true);
 
+		resource.createBucket();
 
-    /**
-     * Configuration for the tests.
-     */
-    @Configuration
-    @Import(OssStorageProtocolResolver.class)
-    static class TestConfiguration {
+		assertTrue(resource.bucketExists());
 
-        @Bean
-        public static OSS mockOSS() {
-            DummyOssClient dummyOssStub = new DummyOssClient();
-            OSS oss = mock(OSS.class);
+	}
 
-            doAnswer(invocation ->
-                dummyOssStub.putObject(
-                    invocation.getArgument(0),
-                    invocation.getArgument(1),
-                    invocation.getArgument(2)
-                ))
-                .when(oss).putObject(Mockito.anyString(), Mockito.anyString(), Mockito.any(InputStream.class));
+	/**
+	 * Configuration for the tests.
+	 */
+	@Configuration
+	@Import(OssStorageProtocolResolver.class)
+	static class TestConfiguration {
 
-            doAnswer(invocation ->
-                dummyOssStub.getOSSObject(
-                    invocation.getArgument(0),
-                    invocation.getArgument(1)
-                ))
-                .when(oss).getObject(Mockito.anyString(), Mockito.anyString());
+		@Bean
+		public static OSS mockOSS() {
+			DummyOssClient dummyOssStub = new DummyOssClient();
+			OSS oss = mock(OSS.class);
 
-            doAnswer(invocation -> dummyOssStub.bucketList())
-                .when(oss).listBuckets();
+			doAnswer(invocation -> dummyOssStub.putObject(invocation.getArgument(0),
+					invocation.getArgument(1), invocation.getArgument(2))).when(oss)
+							.putObject(Mockito.anyString(), Mockito.anyString(),
+									Mockito.any(InputStream.class));
 
-            doAnswer(invocation -> dummyOssStub.createBucket(invocation.getArgument(0)))
-                .when(oss).createBucket(Mockito.anyString());
+			doAnswer(invocation -> dummyOssStub.getOSSObject(invocation.getArgument(0),
+					invocation.getArgument(1))).when(oss).getObject(Mockito.anyString(),
+							Mockito.anyString());
 
-            // prepare object
-            dummyOssStub.createBucket("aliyun-test-bucket");
+			doAnswer(invocation -> dummyOssStub.bucketList()).when(oss).listBuckets();
 
-            byte[] content = generateRandomBytes(4096);
-            ByteArrayInputStream inputStream = new ByteArrayInputStream(content);
-            dummyOssStub.putObject("aliyun-test-bucket", "myfilekey", inputStream);
+			doAnswer(invocation -> dummyOssStub.createBucket(invocation.getArgument(0)))
+					.when(oss).createBucket(Mockito.anyString());
 
-            return oss;
-        }
+			// prepare object
+			dummyOssStub.createBucket("aliyun-test-bucket");
 
-    }
+			byte[] content = generateRandomBytes(4096);
+			ByteArrayInputStream inputStream = new ByteArrayInputStream(content);
+			dummyOssStub.putObject("aliyun-test-bucket", "myfilekey", inputStream);
+
+			return oss;
+		}
+
+	}
 
 }

--- a/spring-cloud-alicloud-oss/src/test/java/com/alibaba/alicloud/oss/resource/OssStorageResourceTest.java
+++ b/spring-cloud-alicloud-oss/src/test/java/com/alibaba/alicloud/oss/resource/OssStorageResourceTest.java
@@ -1,0 +1,227 @@
+package com.alibaba.alicloud.oss.resource;
+
+import com.aliyun.oss.OSS;
+import com.aliyun.oss.common.utils.IOUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.WritableResource;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.util.StreamUtils;
+
+import java.io.*;
+import java.nio.charset.Charset;
+import java.util.Random;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author lich
+ * @date 2019/8/29
+ */
+
+@SpringBootTest
+@RunWith(SpringRunner.class)
+public class OssStorageResourceTest {
+
+    /**
+     * Used to test exception messages and types.
+     */
+    @Rule
+    public ExpectedException expectedEx = ExpectedException.none();
+
+    @Autowired
+    private OSS oss;
+
+    @Value("oss://aliyun-test-bucket/")
+    private Resource bucketResource;
+
+    @Value("oss://aliyun-test-bucket/myfilekey")
+    private Resource remoteResource;
+
+    public static byte[] generateRandomBytes(int blen) {
+        byte[] array = new byte[blen];
+        new Random().nextBytes(array);
+        return array;
+    }
+
+    @Test
+    public void testResourceType() {
+        assertEquals(OssStorageResource.class, remoteResource.getClass());
+        OssStorageResource ossStorageResource = (OssStorageResource)remoteResource;
+        assertEquals("myfilekey", ossStorageResource.getFilename());
+        assertFalse(ossStorageResource.isBucket());
+    }
+
+    @Test
+    public void testValidObject() throws Exception {
+        assertTrue(remoteResource.exists());
+        OssStorageResource ossStorageResource = (OssStorageResource)remoteResource;
+        assertTrue(ossStorageResource.bucketExists());
+        assertEquals(4096L, remoteResource.contentLength());
+        assertEquals("oss://aliyun-test-bucket/myfilekey", remoteResource.getURI().toString());
+        assertEquals("myfilekey", remoteResource.getFilename());
+    }
+
+    @Test
+    public void testBucketResource() throws Exception {
+        assertTrue(bucketResource.exists());
+        assertTrue(((OssStorageResource)this.bucketResource).isBucket());
+        assertTrue(((OssStorageResource)this.bucketResource).bucketExists());
+        assertEquals("oss://aliyun-test-bucket/", bucketResource.getURI().toString());
+        assertEquals("aliyun-test-bucket", this.bucketResource.getFilename());
+    }
+
+    @Test
+    public void testBucketNotEndingInSlash() {
+        assertTrue(new OssStorageResource(this.oss, "oss://aliyun-test-bucket").isBucket());
+    }
+
+    @Test
+    public void testSpecifyPathCorrect() {
+        OssStorageResource ossStorageResource = new OssStorageResource (
+            this.oss, "oss://aliyun-test-bucket/myfilekey", false);
+
+        assertTrue(ossStorageResource.exists());
+    }
+
+    @Test
+    public void testSpecifyBucketCorrect() {
+        OssStorageResource ossStorageResource = new OssStorageResource(
+            this.oss, "oss://aliyun-test-bucket", false);
+
+        assertTrue(ossStorageResource.isBucket());
+        assertEquals("aliyun-test-bucket", ossStorageResource.getBucket().getName());
+        assertTrue(ossStorageResource.exists());
+    }
+
+    @Test
+    public void testBucketOutputStream() throws IOException {
+        this.expectedEx.expect(IllegalStateException.class);
+        this.expectedEx.expectMessage("Cannot open an output stream to a bucket: 'oss://aliyun-test-bucket/'");
+        ((WritableResource) this.bucketResource).getOutputStream();
+    }
+
+    @Test
+    public void testBucketInputStream() throws IOException {
+        this.expectedEx.expect(IllegalStateException.class);
+        this.expectedEx.expectMessage("Cannot open an input stream to a bucket: 'oss://aliyun-test-bucket/'");
+        this.bucketResource.getInputStream();
+    }
+
+    @Test
+    public void testBucketContentLength() throws IOException {
+        this.expectedEx.expect(FileNotFoundException.class);
+        this.expectedEx.expectMessage("OSSObject not existed.");
+        this.bucketResource.contentLength();
+    }
+
+    @Test
+    public void testBucketFile() throws IOException {
+        this.expectedEx.expect(UnsupportedOperationException.class);
+        this.expectedEx.expectMessage("oss://aliyun-test-bucket/ cannot be resolved to absolute file path");
+        this.bucketResource.getFile();
+    }
+
+    @Test
+    public void testBucketLastModified() throws IOException {
+        this.expectedEx.expect(FileNotFoundException.class);
+        this.expectedEx.expectMessage("OSSObject not existed.");
+        this.bucketResource.lastModified();
+    }
+
+    @Test
+    public void testBucketResourceStatuses() {
+        assertFalse(this.bucketResource.isOpen());
+        assertFalse(((WritableResource) this.bucketResource).isWritable());
+        assertTrue(this.bucketResource.exists());
+    }
+
+    @Test
+    public void testWritable() throws Exception {
+        assertTrue(this.remoteResource instanceof WritableResource);
+        WritableResource writableResource = (WritableResource) this.remoteResource;
+        assertTrue(writableResource.isWritable());
+        writableResource.getOutputStream();
+    }
+
+    @Test
+    public void testWritableOutputStream() throws Exception {
+        String location = "oss://aliyun-test-bucket/test";
+        OssStorageResource resource = new OssStorageResource(this.oss, location, true);
+        OutputStream os = resource.getOutputStream();
+        assertNotNull(os);
+
+        byte[] randomBytes = generateRandomBytes(1203);
+        String expectedString = new String(randomBytes);
+
+        os.write(randomBytes);
+        os.close();
+
+        InputStream in = resource.getInputStream();
+
+        byte[] result = StreamUtils.copyToByteArray(in);
+        String actualString = new String(result);
+
+        assertEquals(expectedString, actualString);
+    }
+
+
+
+    /**
+     * Configuration for the tests.
+     */
+    @Configuration
+    @Import(OssStorageProtocolResolver.class)
+    static class TestConfiguration {
+
+        @Bean
+        public static OSS mockOSS() {
+            DummyOssClient dummyOssStub = new DummyOssClient();
+            OSS oss = mock(OSS.class);
+
+            doAnswer(invocation ->
+                dummyOssStub.putObject(
+                    invocation.getArgument(0),
+                    invocation.getArgument(1),
+                    invocation.getArgument(2)
+                ))
+                .when(oss).putObject(Mockito.anyString(), Mockito.anyString(), Mockito.any(InputStream.class));
+
+            doAnswer(invocation ->
+                dummyOssStub.getOSSObject(
+                    invocation.getArgument(0),
+                    invocation.getArgument(1)
+                ))
+                .when(oss).getObject(Mockito.anyString(), Mockito.anyString());
+
+            doAnswer(invocation -> dummyOssStub.bucketList())
+                .when(oss).listBuckets();
+
+            doAnswer(invocation -> dummyOssStub.createBucket(invocation.getArgument(0)))
+                .when(oss).createBucket(Mockito.anyString());
+
+            // prepare object
+            dummyOssStub.createBucket("aliyun-test-bucket");
+
+            byte[] content = generateRandomBytes(4096);
+            ByteArrayInputStream inputStream = new ByteArrayInputStream(content);
+            dummyOssStub.putObject("aliyun-test-bucket", "myfilekey", inputStream);
+
+            return oss;
+        }
+
+    }
+
+}


### PR DESCRIPTION

### Describe what this PR does / why we need it
Allow the OssStorageResource to support WritableResource so that we could get an OutputStream and directly upload binary from the resource.


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
NONE

### Describe how you did it
As the java oss sdk only provide putObject with an InputStream to upload file, we use "Pipe OutputStream and InputStream" to associate the input stream to the output stream to be returned from the method.
We have to use an fixed thread pool to allow async read things from the inputStream, to which the outter outputStream write, as the putObject is sync.

### Describe how to verify it
1. Deliberately create mocked unittest cases to verify this.
2. In the examples project, add a sample code to demo the usage.

### Special notes for reviews
Please kindly let me know had there be any problem concerning the usage of oss.
