### PR TITLE
Some optimizations about Dubbo Spring Cloud

### DIFF
--- a/spring-cloud-alibaba-dubbo/src/main/java/com/alibaba/cloud/dubbo/metadata/repository/DubboServiceMetadataRepository.java
+++ b/spring-cloud-alibaba-dubbo/src/main/java/com/alibaba/cloud/dubbo/metadata/repository/DubboServiceMetadataRepository.java
@@ -289,9 +289,7 @@ public class DubboServiceMetadataRepository
 							serviceName);
 				}
 
-				// Keep the order in following invocations
 				initSubscribedDubboMetadataService(serviceName);
-				initDubboRestServiceMetadataRepository(serviceName);
 				// mark this service name having been initialized
 				initializedServices.add(serviceName);
 			}
@@ -392,9 +390,11 @@ public class DubboServiceMetadataRepository
 			return emptyList();
 		}
 
-		return hasText(protocol) ? urls.stream()
-				.filter(url -> url.getProtocol().equalsIgnoreCase(protocol))
-				.collect(Collectors.toList()) : unmodifiableList(urls);
+		return hasText(protocol)
+				? urls.stream()
+						.filter(url -> url.getProtocol().equalsIgnoreCase(protocol))
+						.collect(Collectors.toList())
+				: unmodifiableList(urls);
 	}
 
 	/**
@@ -630,6 +630,7 @@ public class DubboServiceMetadataRepository
 						}
 					});
 				});
+		initDubboRestServiceMetadataRepository(serviceName);
 	}
 
 	private void initSubscribedDubboMetadataServiceURL(URL dubboMetadataServiceURL) {

--- a/spring-cloud-alibaba-dubbo/src/main/java/com/alibaba/cloud/dubbo/metadata/repository/DubboServiceMetadataRepository.java
+++ b/spring-cloud-alibaba-dubbo/src/main/java/com/alibaba/cloud/dubbo/metadata/repository/DubboServiceMetadataRepository.java
@@ -645,8 +645,9 @@ public class DubboServiceMetadataRepository
 		dubboMetadataConfigServiceProxy.initProxy(serviceName, version);
 	}
 
-	public void removeServiceMetadata(String serviceName) {
+	public void removeMetadata(String serviceName) {
 		dubboRestServiceMetadataRepository.remove(serviceName);
+		subscribedDubboMetadataServiceURLs.remove(serviceName);
 	}
 
 	@Override

--- a/spring-cloud-alibaba-dubbo/src/main/java/com/alibaba/cloud/dubbo/registry/SpringCloudRegistry.java
+++ b/spring-cloud-alibaba-dubbo/src/main/java/com/alibaba/cloud/dubbo/registry/SpringCloudRegistry.java
@@ -17,6 +17,7 @@
 package com.alibaba.cloud.dubbo.registry;
 
 import com.alibaba.cloud.dubbo.metadata.repository.DubboServiceMetadataRepository;
+import com.alibaba.cloud.dubbo.service.DubboGenericServiceFactory;
 import com.alibaba.cloud.dubbo.service.DubboMetadataServiceProxy;
 import com.alibaba.cloud.dubbo.util.JSONUtils;
 import org.apache.dubbo.common.URL;
@@ -38,9 +39,11 @@ public class SpringCloudRegistry extends AbstractSpringCloudRegistry {
 	public SpringCloudRegistry(URL url, DiscoveryClient discoveryClient,
 			DubboServiceMetadataRepository dubboServiceMetadataRepository,
 			DubboMetadataServiceProxy dubboMetadataConfigServiceProxy,
-			JSONUtils jsonUtils, ConfigurableApplicationContext applicationContext) {
+			JSONUtils jsonUtils, DubboGenericServiceFactory dubboGenericServiceFactory,
+			ConfigurableApplicationContext applicationContext) {
 		super(url, discoveryClient, dubboServiceMetadataRepository,
-				dubboMetadataConfigServiceProxy, jsonUtils, applicationContext);
+				dubboMetadataConfigServiceProxy, jsonUtils, dubboGenericServiceFactory,
+				applicationContext);
 		this.dubboServiceMetadataRepository = dubboServiceMetadataRepository;
 	}
 

--- a/spring-cloud-alibaba-dubbo/src/main/java/com/alibaba/cloud/dubbo/registry/SpringCloudRegistryFactory.java
+++ b/spring-cloud-alibaba-dubbo/src/main/java/com/alibaba/cloud/dubbo/registry/SpringCloudRegistryFactory.java
@@ -17,6 +17,7 @@
 package com.alibaba.cloud.dubbo.registry;
 
 import com.alibaba.cloud.dubbo.metadata.repository.DubboServiceMetadataRepository;
+import com.alibaba.cloud.dubbo.service.DubboGenericServiceFactory;
 import com.alibaba.cloud.dubbo.service.DubboMetadataServiceProxy;
 import com.alibaba.cloud.dubbo.util.JSONUtils;
 import org.apache.dubbo.common.URL;
@@ -62,6 +63,8 @@ public class SpringCloudRegistryFactory implements RegistryFactory {
 
 	private JSONUtils jsonUtils;
 
+	private DubboGenericServiceFactory dubboGenericServiceFactory;
+
 	private volatile boolean initialized = false;
 
 	public SpringCloudRegistryFactory() {
@@ -82,6 +85,8 @@ public class SpringCloudRegistryFactory implements RegistryFactory {
 		this.dubboMetadataConfigServiceProxy = applicationContext
 				.getBean(DubboMetadataServiceProxy.class);
 		this.jsonUtils = applicationContext.getBean(JSONUtils.class);
+		this.dubboGenericServiceFactory = applicationContext
+				.getBean(DubboGenericServiceFactory.class);
 	}
 
 	@Override
@@ -89,7 +94,7 @@ public class SpringCloudRegistryFactory implements RegistryFactory {
 		init();
 		return new SpringCloudRegistry(url, discoveryClient,
 				dubboServiceMetadataRepository, dubboMetadataConfigServiceProxy,
-				jsonUtils, applicationContext);
+				jsonUtils, dubboGenericServiceFactory, applicationContext);
 	}
 
 }


### PR DESCRIPTION
- fix https://github.com/alibaba/spring-cloud-alibaba/issues/904: resolve a series of problems caused by restarting providers when no provider instances exists.
- resolve the problems that `ServiceRestMetadata` will never be accessible in the case of failed generalization calls.