### PR TITLE
add validation on nameServer

### DIFF
--- a/spring-cloud-stream-binder-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/properties/RocketMQBinderConfigurationProperties.java
+++ b/spring-cloud-stream-binder-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/properties/RocketMQBinderConfigurationProperties.java
@@ -16,21 +16,27 @@
 
 package com.alibaba.cloud.stream.binder.rocketmq.properties;
 
+import javax.validation.constraints.Pattern;
+
 import com.alibaba.cloud.stream.binder.rocketmq.RocketMQBinderConstants;
 import org.apache.rocketmq.common.MixAll;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
 /**
  * @author Timur Valiev
  * @author <a href="mailto:fangjian0423@gmail.com">Jim</a>
  */
 @ConfigurationProperties(prefix = "spring.cloud.stream.rocketmq.binder")
+@Validated
 public class RocketMQBinderConfigurationProperties {
 
 	/**
 	 * The name server for rocketMQ, formats: `host:port;host:port`.
 	 */
+	@Pattern(regexp = "^[\\d.:;]+$",
+			message = "nameServer needs to match expression \"host:port;host:port\"")
 	private String nameServer = RocketMQBinderConstants.DEFAULT_NAME_SERVER;
 
 	/**


### PR DESCRIPTION
add validation on nameServer

Fixes #977

use `@Validated` add `@Pattern(regexp = "^[\\d.:;]+$")` to verify can only use "0-9", "." , ":" and ";"

use RocketMQAutoConfigurationTests 
