### PR TITLE
add equals method to nacosServiceInstance

### DIFF
--- a/spring-cloud-alibaba-nacos-discovery/src/main/java/org/springframework/cloud/alibaba/nacos/NacosServiceInstance.java
+++ b/spring-cloud-alibaba-nacos-discovery/src/main/java/org/springframework/cloud/alibaba/nacos/NacosServiceInstance.java
@@ -21,6 +21,7 @@ import org.springframework.cloud.client.ServiceInstance;
 
 import java.net.URI;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * @author xiaojing
@@ -82,4 +83,34 @@ public class NacosServiceInstance implements ServiceInstance {
 		this.metadata = metadata;
 	}
 
+
+    @Override
+    public String toString() {
+        return "NacosServiceInstance{" + ", serviceId='" + this.serviceId + '\'' + ", host='" + this.host + '\''
+                + ", port=" + this.port + ", secure=" + this.secure + ", metadata="
+                + this.metadata + '}';
+    }
+
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        NacosServiceInstance that = (NacosServiceInstance) o;
+        return this.port == that.port && this.secure == that.secure
+                && Objects.equals(this.serviceId, that.serviceId)
+                && Objects.equals(this.host, that.host)
+                && Objects.equals(this.metadata, that.metadata);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.serviceId, this.host, this.port,
+                this.secure, this.metadata);
+    }
 }


### PR DESCRIPTION
### Describe what this PR does / why we need it
When I replace config server by nacos, I can't compare the class of NacosServiceInstance.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
Add equals and hashCode mthod to NacosServiceInstance just like org.springframework.cloud.client.DefaultServiceInstance.

### Describe how to verify it


### Special notes for reviews
