### PR TITLE
Support discovery different groups service instances

### DIFF
--- a/spring-cloud-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
+++ b/spring-cloud-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
@@ -114,6 +114,11 @@ public class NacosDiscoveryProperties {
 	private String group = "DEFAULT_GROUP";
 
 	/**
+	 * discovery external group name for naocs.
+	 */
+	private String externalGroups;
+
+	/**
 	 * naming load from local cache at application start. true is load.
 	 */
 	private String namingLoadCacheAtStart = "false";
@@ -406,6 +411,14 @@ public class NacosDiscoveryProperties {
 
 	public void setGroup(String group) {
 		this.group = group;
+	}
+
+	public String getExternalGroups() {
+		return externalGroups;
+	}
+
+	public void setExternalGroups(String externalGroups) {
+		this.externalGroups = externalGroups;
 	}
 
 	@Override

--- a/spring-cloud-alibaba-nacos-discovery/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-alibaba-nacos-discovery/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -33,5 +33,11 @@
       "type": "java.lang.Boolean",
       "defaultValue": "true",
       "description": "enable nacos discovery watch or not ."
+    },
+    {
+      "name": "spring.cloud.nacos.discovery.external-groups",
+      "type": "java.lang.String",
+      "defaultValue": "",
+      "description": "discovery external group name for naocs."
     }
 ]}


### PR DESCRIPTION
### Describe what this PR does / why we need it
Provide a configuration item `spring.cloud.nacos.discovery.external-groups` to discovery external groups service instances.

example:
 `spring.cloud.nacos.discovery.external-groups=group_a,group_b`

### Does this pull request fix one issue?
fix #1075

