### PR TITLE
Fix #1156, handle the scenario where the registed bean name is null

### DIFF
--- a/spring-cloud-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/custom/SentinelBeanPostProcessor.java
+++ b/spring-cloud-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/custom/SentinelBeanPostProcessor.java
@@ -66,7 +66,7 @@ public class SentinelBeanPostProcessor implements MergedBeanDefinitionPostProces
 	@Override
 	public void postProcessMergedBeanDefinition(RootBeanDefinition beanDefinition,
 			Class<?> beanType, String beanName) {
-		if (checkSentinelProtect(beanDefinition, beanType)) {
+		if (checkSentinelProtect(beanDefinition, beanType, beanName)) {
 			SentinelRestTemplate sentinelRestTemplate;
 			if (beanDefinition.getSource() instanceof StandardMethodMetadata) {
 				sentinelRestTemplate = ((StandardMethodMetadata) beanDefinition
@@ -166,8 +166,8 @@ public class SentinelBeanPostProcessor implements MergedBeanDefinitionPostProces
 	}
 
 	private boolean checkSentinelProtect(RootBeanDefinition beanDefinition,
-			Class<?> beanType) {
-		return beanType == RestTemplate.class
+			Class<?> beanType, String beanName) {
+		return beanName != null && beanType == RestTemplate.class
 				&& checkMethodMetadataReadingVisitor(beanDefinition);
 	}
 
@@ -180,7 +180,7 @@ public class SentinelBeanPostProcessor implements MergedBeanDefinitionPostProces
 	@Override
 	public Object postProcessAfterInitialization(Object bean, String beanName)
 			throws BeansException {
-		if (cache.containsKey(beanName)) {
+		if (beanName != null && cache.containsKey(beanName)) {
 			// add interceptor for each RestTemplate with @SentinelRestTemplate annotation
 			StringBuilder interceptorBeanNamePrefix = new StringBuilder();
 			SentinelRestTemplate sentinelRestTemplate = cache.get(beanName);


### PR DESCRIPTION
When someone init a bean with a name of null, the program will end with NullPointerException
Handle the scenario where the registed bean name is null
Fix #1156