### PR TITLE
Enhance SentinelProperties Config

### DIFF
--- a/spring-cloud-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/SentinelProperties.java
+++ b/spring-cloud-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/SentinelProperties.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.TreeMap;
 
 import com.alibaba.cloud.sentinel.datasource.config.DataSourcePropertiesConfiguration;
+import com.alibaba.csp.sentinel.adapter.servlet.config.WebServletConfig;
 import com.alibaba.csp.sentinel.config.SentinelConfig;
 import com.alibaba.csp.sentinel.log.LogBase;
 import com.alibaba.csp.sentinel.transport.config.TransportConfig;
@@ -326,6 +327,13 @@ public class SentinelProperties {
 		 */
 		private boolean enabled = true;
 
+		/**
+		 * If enabled, use the URL path as the context name, or else use the default
+		 * {@link WebServletConfig#WEB_SERVLET_CONTEXT_NAME}. Please pay attention to the number of context (EntranceNode),
+		 * which may affect the memory footprint.
+		 */
+		private boolean webContextUnify = true;
+
 		public int getOrder() {
 			return this.order;
 		}
@@ -349,6 +357,10 @@ public class SentinelProperties {
 		public void setEnabled(boolean enabled) {
 			this.enabled = enabled;
 		}
+
+		public boolean isWebContextUnify() { return webContextUnify; }
+
+		public void setWebContextUnify(boolean webContextUnify) { this.webContextUnify = webContextUnify; }
 	}
 
 	public static class Log {

--- a/spring-cloud-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/SentinelWebAutoConfiguration.java
+++ b/spring-cloud-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/SentinelWebAutoConfiguration.java
@@ -92,8 +92,10 @@ public class SentinelWebAutoConfiguration {
 		Filter filter = new CommonFilter();
 		registration.setFilter(filter);
 		registration.setOrder(filterConfig.getOrder());
-		registration.addInitParameter("HTTP_METHOD_SPECIFY",
+		registration.addInitParameter(CommonFilter.HTTP_METHOD_SPECIFY,
 				String.valueOf(properties.getHttpMethodSpecify()));
+		registration.addInitParameter(CommonFilter.WEB_CONTEXT_UNIFY,
+				String.valueOf(filterConfig.isWebContextUnify()));
 		log.info(
 				"[Sentinel Starter] register Sentinel CommonFilter with urlPatterns: {}.",
 				filterConfig.getUrlPatterns());


### PR DESCRIPTION
### Describe what this PR does / why we need it
Enhance SentinelProperties.Filter support to config CommonFilter WEB_CONTEXT_UNIFY property.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #1138
### Describe how you did it
1.SentinelProperties.Filter add webContextUnify property,

2.SentinelWebAutoConfiguration sentinelFilter modify: registration.addInitParameter(CommonFilter.HTTP_METHOD_SPECIFY,
String.valueOf(properties.getHttpMethodSpecify()));
registration.addInitParameter(CommonFilter.WEB_CONTEXT_UNIFY,
String.valueOf(filterConfig.isWebContextUnify()));
### Describe how to verify it
CommonFilter.init work well

### Special notes for reviews
no