### PR TITLE
[fix #1204]fix mistake load @Bean when use config dubbo.registries

### DIFF
--- a/spring-cloud-alibaba-dubbo/src/main/java/com/alibaba/cloud/dubbo/autoconfigure/condition/MissingSpringCloudRegistryConfigPropertyCondition.java
+++ b/spring-cloud-alibaba-dubbo/src/main/java/com/alibaba/cloud/dubbo/autoconfigure/condition/MissingSpringCloudRegistryConfigPropertyCondition.java
@@ -67,7 +67,7 @@ public class MissingSpringCloudRegistryConfigPropertyCondition
 		boolean found = properties.entrySet().stream().anyMatch(entry -> {
 			String key = entry.getKey();
 			String value = String.valueOf(entry.getValue());
-			return (key.endsWith(".address") && value.startsWith(PROTOCOL))
+			return (key.endsWith("address") && value.startsWith(PROTOCOL))
 					|| (key.endsWith(".protocol") && PROTOCOL.equals(value));
 
 		});


### PR DESCRIPTION
#1204 
### Describe what this PR does / why we need it
When we use config in *.yaml like this:
```yaml
dubbo:
  registries:
    address: spring-cloud://localhost
```
the @Bean method in DubboServiceRegistrationAutoConfiguration class
```java
        @Bean
	@Conditional({ MissingSpringCloudRegistryConfigPropertyCondition.class })
	public RegistryConfig defaultSpringCloudRegistryConfig() {
		return new RegistryConfig(ADDRESS, PROTOCOL);
	}
```
should not be load

### Does this pull request fix one issue?

yes

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
