### PR TITLE
Modify the sentinelInterceptor default interception rule and backward…

### DIFF
--- a/spring-cloud-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/SentinelProperties.java
+++ b/spring-cloud-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/SentinelProperties.java
@@ -343,9 +343,9 @@ public class SentinelProperties {
 		private int order = Ordered.HIGHEST_PRECEDENCE;
 
 		/**
-		 * URL pattern for SentinelWebInterceptor, default is /*.
+		 * URL pattern for SentinelWebInterceptor, default is /**.
 		 */
-		private List<String> urlPatterns = Arrays.asList("/*");
+		private List<String> urlPatterns = Arrays.asList("/**");
 
 		/**
 		 * Enable to instance

--- a/spring-cloud-alibaba-sentinel/src/test/java/com/alibaba/cloud/sentinel/SentinelBeanAutowiredTests.java
+++ b/spring-cloud-alibaba-sentinel/src/test/java/com/alibaba/cloud/sentinel/SentinelBeanAutowiredTests.java
@@ -74,7 +74,7 @@ public class SentinelBeanAutowiredTests {
 		assertThat(sentinelProperties.getFilter().getOrder()).isEqualTo(111);
 		assertThat(sentinelProperties.getFilter().getUrlPatterns().size()).isEqualTo(1);
 		assertThat(sentinelProperties.getFilter().getUrlPatterns().get(0))
-				.isEqualTo("/*");
+				.isEqualTo("/**");
 	}
 
 	@Test

--- a/spring-cloud-alibaba-sentinel/src/test/java/com/alibaba/cloud/sentinel/SentinelDataSourceTests.java
+++ b/spring-cloud-alibaba-sentinel/src/test/java/com/alibaba/cloud/sentinel/SentinelDataSourceTests.java
@@ -70,7 +70,7 @@ public class SentinelDataSourceTests {
 				.isEqualTo(Integer.MIN_VALUE);
 		assertThat(sentinelProperties.getFilter().getUrlPatterns().size()).isEqualTo(1);
 		assertThat(sentinelProperties.getFilter().getUrlPatterns().get(0))
-				.isEqualTo("/*");
+				.isEqualTo("/**");
 	}
 
 	@Test


### PR DESCRIPTION
### Describe what this PR does / why we need it
version 2.2.0  spring.cloud.sentinel.filter.url-patterns default /*

if not configured, most requests will not be processed by sentinel

I think it should default to `/**` not  `/*` ,  backward compatibility

### Does this pull request fix one issue?
like  this issue  
https://github.com/alibaba/Sentinel/issues/1279

### Describe how you did it

Modified `SentinelProperties.Filter.urlPatterns`default value  /**

### Describe how to verify it

```

    @GetMapping("/get/{id}")
    public Integer get(@PathVariable Integer id){
        return id;
    }

    @GetMapping("/get/get1")
    public String get1(){
        return "get1";
    }

    @GetMapping("/get2")
    public String get2(){
        return "get1";
    }
```
edit before
![](http://pigx.vip/20200218163754_ZOoiMJ_Screenshot.jpeg)

edit after
![](http://pigx.vip/20200218164106_9SHctp_Screenshot.jpeg)
### Special notes for reviews
