### PR TITLE
shutdown the taskScheduler when the NacosWatch bean is destroyed.

### DIFF
--- a/spring-cloud-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/NacosWatch.java
+++ b/spring-cloud-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/NacosWatch.java
@@ -106,13 +106,17 @@ public class NacosWatch implements ApplicationEventPublisherAware, SmartLifecycl
 	@Override
 	public void stop() {
 		if (this.running.compareAndSet(true, false) && this.watchFuture != null) {
+			// shutdown current user-thread,
+			// then the other daemon-threads will terminate automatic.
+			((ThreadPoolTaskScheduler)this.taskScheduler).shutdown();
+			
 			this.watchFuture.cancel(true);
 		}
 	}
 
 	@Override
 	public boolean isRunning() {
-		return false;
+		return this.running.get();
 	}
 
 	@Override


### PR DESCRIPTION
### Describe what this PR does / why we need it
There is a problem in module “spring-cloud-alibaba-nacos-discovery”. At first, I thought the problem was caused by Nacos, see the issue of nacos: [https://github.com/alibaba/nacos/issues/1596](https://github.com/alibaba/nacos/issues/1596)，although the application is closed, but the java process is still alive。Later, I found that the problem was caused in the project “spring-cloud-alibaba-nacos-discovery”。
Because the **NacosWatch** bean did not call its close() method when it was destroyed, and did not shtdown the "**taskScheduler**" thread pool object which it created. The other daemon-threads could not be automatically terminated because there was still a user thread, finally graceful shutdown application failed.
![graceful_shutdown_fail_in_nacos](https://github.com/xht555/public-images/blob/5fe99cc62d6b6bd570a17fa2329877a1f25c3cff/graceful_shutdown_fail_in_nacos.png?raw=true)

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
NONE

### Describe how you did it
com.alibaba.cloud.nacos.discovery.NacosWatch.java
```
@Override
public void stop() {
	if (this.running.compareAndSet(true, false) && this.watchFuture != null) {
		// shutdown current user-thread,
		// then the other daemon-threads will terminate automatic.
		((ThreadPoolTaskScheduler)this.taskScheduler).shutdown();
			
		this.watchFuture.cancel(true);
	}
}

@Override
public boolean isRunning() {
	return this.running.get();
}
```

### Describe how to verify it

1. Add the dependency in the project's pom.xml:
```
<dependency>
    <groupId>org.springframework.boot</groupId>
    <artifactId>spring-boot-starter-actuator</artifactId>
</dependency>
```
2. Add some config in the project's application.yml:
```
management:
  endpoint:
    shutdown:
      enabled: true
  endpoints:
    web:
      exposure:
        include: health, info, shutdown
```
3. Start your demo project，visit url: http://ip:port/actuator/shutdown, for example
```
curl -X POST http://ip:port/actuator/shutdown
```
### Special notes for reviews
