### PR TITLE
local config health check

### DIFF
--- a/spring-cloud-starter-alibaba/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/endpoint/NacosConfigEndpointAutoConfiguration.java
+++ b/spring-cloud-starter-alibaba/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/endpoint/NacosConfigEndpointAutoConfiguration.java
@@ -51,8 +51,19 @@ public class NacosConfigEndpointAutoConfiguration {
 	}
 
 	@Bean
+	@ConditionalOnProperty(name = "spring.cloud.nacos.config.health-check.enabled",
+			matchIfMissing = true)
 	public NacosConfigHealthIndicator nacosConfigHealthIndicator() {
 		return new NacosConfigHealthIndicator(nacosConfigManager.getConfigService());
+	}
+
+	@Bean
+	@ConditionalOnProperty(name = "spring.cloud.nacos.config.local-health-check.enabled",
+			matchIfMissing = false)
+	public NacosLocalConfigHealthIndicator nacosLocalConfigHealthIndicator() {
+		return new NacosLocalConfigHealthIndicator(
+				nacosConfigManager.getNacosConfigProperties(),
+				nacosConfigManager.getConfigService());
 	}
 
 }

--- a/spring-cloud-starter-alibaba/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/endpoint/NacosLocalConfigHealthIndicator.java
+++ b/spring-cloud-starter-alibaba/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/endpoint/NacosLocalConfigHealthIndicator.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.nacos.endpoint;
+
+import com.alibaba.cloud.nacos.NacosConfigProperties;
+import com.alibaba.cloud.nacos.NacosPropertySourceRepository;
+import com.alibaba.cloud.nacos.client.NacosPropertySource;
+import com.alibaba.nacos.api.config.ConfigService;
+import org.springframework.boot.actuate.health.AbstractHealthIndicator;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The {@link HealthIndicator} for Local Nacos Config.
+ *
+ * @author illlight
+ */
+public class NacosLocalConfigHealthIndicator extends AbstractHealthIndicator {
+
+	private final NacosConfigProperties nacosConfigProperties;
+
+	private final List<String> dataIds;
+
+	private final ConfigService configService;
+
+	public NacosLocalConfigHealthIndicator(NacosConfigProperties nacosConfigProperties, ConfigService configService) {
+		this.nacosConfigProperties = nacosConfigProperties;
+		this.configService = configService;
+
+		this.dataIds = new ArrayList<>();
+		for (NacosPropertySource nacosPropertySource : NacosPropertySourceRepository.getAll()) {
+			this.dataIds.add(nacosPropertySource.getDataId());
+		}
+	}
+
+	@Override
+	protected void doHealthCheck(Health.Builder builder) throws Exception {
+		boolean find = false;
+		for (String dataId : dataIds) {
+			try {
+				String config = configService.getConfig(dataId,
+						nacosConfigProperties.getGroup(),
+						nacosConfigProperties.getTimeout());
+				if (StringUtils.isEmpty(config)) {
+					builder.withDetail(String.format("dataId: '%s', group: '%s'",
+							dataId, nacosConfigProperties.getGroup()), "config isEmpty");
+				} else {
+					find = true;
+					builder.withDetail(String.format("dataId: '%s', group: '%s'",
+							dataId, nacosConfigProperties.getGroup()), "config exist");
+				}
+			} catch (Exception e) {
+				builder.withDetail(String.format("dataId: '%s', group: '%s'",
+						dataId, nacosConfigProperties.getGroup()), "get config exception");
+			}
+		}
+		if (find) {
+			builder.up();
+		} else {
+			builder.down();
+		}
+	}
+
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it
add the health check exist in version < 1.5.1, 2.0.0 as an option.

we use the health check for k8s readnessprobe, find out that the new implement in version >= 1.5.1,2.0.0 make the status down because of unstable network, and the deployments restart.

applicaion works fine once get the configs from the nacos server, so i think there should have a switch to close the health check, and add back the old implement as an option with which the status will be up after the applicaion store the configuration in local cache.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
