### PR TITLE
fix #753 https://github.com/alibaba/spring-cloud-alibaba/issues/753

### DIFF
--- a/spring-cloud-starter-alibaba/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/registry/AbstractSpringCloudRegistry.java
+++ b/spring-cloud-starter-alibaba/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/registry/AbstractSpringCloudRegistry.java
@@ -222,7 +222,7 @@ public abstract class AbstractSpringCloudRegistry extends FailbackRegistry {
 		Collection<ServiceInstance> serviceInstances = serviceInstancesFunction
 				.apply(serviceName);
 
-		// issue : restart consumer and provider together
+		// issue : ReStarting a consumer and then starting a provider does not automatically discover the registration
 		// fix https://github.com/alibaba/spring-cloud-alibaba/issues/753
 		// Re-obtain the latest list of available metadata address here, ip or port may change.
 		dubboMetadataConfigServiceProxy.removeProxy(serviceName);

--- a/spring-cloud-starter-alibaba/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/registry/AbstractSpringCloudRegistry.java
+++ b/spring-cloud-starter-alibaba/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/registry/AbstractSpringCloudRegistry.java
@@ -222,10 +222,14 @@ public abstract class AbstractSpringCloudRegistry extends FailbackRegistry {
 		Collection<ServiceInstance> serviceInstances = serviceInstancesFunction
 				.apply(serviceName);
 
+		// issue : restart consumer and provider together
+		// fix https://github.com/alibaba/spring-cloud-alibaba/issues/753
+		// Re-obtain the latest list of available metadata address here, ip or port may change.
+		dubboMetadataConfigServiceProxy.removeProxy(serviceName);
+		repository.removeMetadataAndInitializedService(serviceName);
+		dubboGenericServiceFactory.destroy(serviceName);
+		repository.initializeMetadata(serviceName);
 		if (CollectionUtils.isEmpty(serviceInstances)) {
-			dubboMetadataConfigServiceProxy.removeProxy(serviceName);
-			repository.removeMetadataAndInitializedService(serviceName);
-			dubboGenericServiceFactory.destroy(serviceName);
 			if (logger.isWarnEnabled()) {
 				logger.warn(
 						"There is no instance from service[name : {}], and then Dubbo Service[key : {}] will not be "
@@ -246,18 +250,6 @@ public abstract class AbstractSpringCloudRegistry extends FailbackRegistry {
 
 		DubboMetadataService dubboMetadataService = dubboMetadataConfigServiceProxy
 				.getProxy(serviceName);
-
-		if (dubboMetadataService == null) { // If not found, try to initialize
-			if (logger.isInfoEnabled()) {
-				logger.info(
-						"The metadata of Dubbo service[key : {}] can't be found when the subscribed service[name : {}], "
-								+ "and then try to initialize it",
-						url.getServiceKey(), serviceName);
-			}
-			repository.initializeMetadata(serviceName);
-			dubboMetadataService = dubboMetadataConfigServiceProxy.getProxy(serviceName);
-		}
-
 		if (dubboMetadataService == null) { // It makes sure not-found, return immediately
 			if (logger.isWarnEnabled()) {
 				logger.warn(


### PR DESCRIPTION
### Describe what this PR does / why we need it

ReStarting a consumer and then starting a provider does not automatically discover the registration

### Does this pull request fix one issue?
https://github.com/alibaba/spring-cloud-alibaba/issues/753
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

// issue : ReStarting a consumer and then starting a provider does not automatically discover the registration

	
		// Re-obtain the latest list of available metadata address here, ip or port may change.
		dubboMetadataConfigServiceProxy.removeProxy(serviceName);
		repository.removeMetadataAndInitializedService(serviceName);
		dubboGenericServiceFactory.destroy(serviceName);
		repository.initializeMetadata(serviceName);


### Describe how to verify it


### Special notes for reviews
