### PR TITLE
增加ServerList与Nacos共存，优先读取配置文件

### DIFF
--- a/spring-cloud-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/ribbon/NacosRibbonClientConfiguration.java
+++ b/spring-cloud-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/ribbon/NacosRibbonClientConfiguration.java
@@ -27,24 +27,25 @@ import org.springframework.context.annotation.Configuration;
 
 /**
  * integrated Ribbon by default
+ *
  * @author xiaojing
  */
 @Configuration
 @ConditionalOnRibbonNacos
 public class NacosRibbonClientConfiguration {
 
-	@Bean
-	@ConditionalOnMissingBean
-	public ServerList<?> ribbonServerList(IClientConfig config,
-			NacosDiscoveryProperties nacosDiscoveryProperties) {
-		NacosServerList serverList = new NacosServerList(nacosDiscoveryProperties);
-		serverList.initWithNiwsConfig(config);
-		return serverList;
-	}
+    @Bean
+    @ConditionalOnMissingBean
+    public ServerList<?> ribbonServerList(IClientConfig config,
+                                          NacosDiscoveryProperties nacosDiscoveryProperties) {
+        NacosServerList serverList = new NacosServerList(nacosDiscoveryProperties, config);
+        serverList.initWithNiwsConfig(config);
+        return serverList;
+    }
 
-	@Bean
-	@ConditionalOnMissingBean
-	public NacosServerIntrospector nacosServerIntrospector() {
-		return new NacosServerIntrospector();
-	}
+    @Bean
+    @ConditionalOnMissingBean
+    public NacosServerIntrospector nacosServerIntrospector() {
+        return new NacosServerIntrospector();
+    }
 }

--- a/spring-cloud-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/ribbon/NacosServerList.java
+++ b/spring-cloud-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/ribbon/NacosServerList.java
@@ -23,65 +23,93 @@ import com.alibaba.cloud.nacos.NacosDiscoveryProperties;
 import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.client.naming.utils.CollectionUtils;
 
+import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
+import com.netflix.client.config.CommonClientConfigKey;
 import com.netflix.client.config.IClientConfig;
 import com.netflix.loadbalancer.AbstractServerList;
+import com.netflix.loadbalancer.Server;
 
 /**
  * @author xiaojing
  * @author renhaojun
  */
-public class NacosServerList extends AbstractServerList<NacosServer> {
+public class NacosServerList extends AbstractServerList<Server> {
 
-	private NacosDiscoveryProperties discoveryProperties;
+    private IClientConfig clientConfig;
+    private NacosDiscoveryProperties discoveryProperties;
 
-	private String serviceId;
+    private String serviceId;
 
-	public NacosServerList(NacosDiscoveryProperties discoveryProperties) {
-		this.discoveryProperties = discoveryProperties;
-	}
+    public NacosServerList(NacosDiscoveryProperties discoveryProperties) {
+        this.discoveryProperties = discoveryProperties;
+    }
 
-	@Override
-	public List<NacosServer> getInitialListOfServers() {
-		return getServers();
-	}
+    public NacosServerList(NacosDiscoveryProperties discoveryProperties, IClientConfig clientConfig) {
+        this.clientConfig = clientConfig;
+        this.discoveryProperties = discoveryProperties;
+    }
 
-	@Override
-	public List<NacosServer> getUpdatedListOfServers() {
-		return getServers();
-	}
 
-	private List<NacosServer> getServers() {
-		try {
-			String group = discoveryProperties.getGroup();
-			List<Instance> instances = discoveryProperties.namingServiceInstance()
-					.selectInstances(serviceId, group, true);
-			return instancesToServerList(instances);
-		}
-		catch (Exception e) {
-			throw new IllegalStateException(
-					"Can not get service instances from nacos, serviceId=" + serviceId,
-					e);
-		}
-	}
+    @Override
+    public List<Server> getInitialListOfServers() {
+        return getServers();
+    }
 
-	private List<NacosServer> instancesToServerList(List<Instance> instances) {
-		List<NacosServer> result = new ArrayList<>();
-		if (CollectionUtils.isEmpty(instances)) {
-			return result;
-		}
-		for (Instance instance : instances) {
-			result.add(new NacosServer(instance));
-		}
+    @Override
+    public List<Server> getUpdatedListOfServers() {
+        return getServers();
+    }
 
-		return result;
-	}
+    private List<Server> getServers() {
+        //先寻找配置文件中的地址
+        String listOfServers = clientConfig.get(CommonClientConfigKey.ListOfServers);
 
-	public String getServiceId() {
-		return serviceId;
-	}
+        List<Server> serverList = derive(listOfServers);
+        if (serverList != null && serverList.size() != 0) {
+            return serverList;
+        }
+        // 如果配置文件找不到，在nacos中继续寻找
+        try {
+            String group = discoveryProperties.getGroup();
+            List<Instance> instances = discoveryProperties.namingServiceInstance()
+                    .selectInstances(serviceId, group, true);
+            return instancesToServerList(instances);
+        } catch (Exception e) {
+            throw new IllegalStateException(
+                    "Can not get service instances from nacos, serviceId=" + serviceId,
+                    e);
+        }
+    }
 
-	@Override
-	public void initWithNiwsConfig(IClientConfig iClientConfig) {
-		this.serviceId = iClientConfig.getClientName();
-	}
+    private List<Server> instancesToServerList(List<Instance> instances) {
+        List<Server> result = new ArrayList<>();
+        if (CollectionUtils.isEmpty(instances)) {
+            return result;
+        }
+        for (Instance instance : instances) {
+            result.add(new NacosServer(instance));
+        }
+
+        return result;
+    }
+
+    public String getServiceId() {
+        return serviceId;
+    }
+
+    @Override
+    public void initWithNiwsConfig(IClientConfig iClientConfig) {
+        this.serviceId = iClientConfig.getClientName();
+    }
+
+    protected List<Server> derive(String value) {
+        List<Server> list = Lists.newArrayList();
+        if (!Strings.isNullOrEmpty(value)) {
+            for (String s : value.split(",")) {
+                list.add(new Server(s.trim()));
+            }
+        }
+        return list;
+    }
 }


### PR DESCRIPTION
### Describe what this PR does / why we need it
Nacos 在本地调试时使用不太方便，需要完整的微服务环境，期待自动发现和配置共存

### Does this pull request fix one issue?
https://github.com/alibaba/spring-cloud-alibaba/issues/1263
Nacos 与 配置文件中  xxx.ribbon.listOfServers=http://127.0.0.1:8000

### Describe how you did it
NacosServerList 中先读取配置中的listOfServers，如果不存在在读取nacos中的server

### Describe how to verify it
listOfServers 有无时都可以正常使用
