### PR TITLE
[fix #753] https://github.com/alibaba/spring-cloud-alibaba/issues/753 #1250

### DIFF
--- a/spring-cloud-starter-alibaba/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/registry/AbstractSpringCloudRegistry.java
+++ b/spring-cloud-starter-alibaba/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/registry/AbstractSpringCloudRegistry.java
@@ -222,7 +222,7 @@ public abstract class AbstractSpringCloudRegistry extends FailbackRegistry {
 		Collection<ServiceInstance> serviceInstances = serviceInstancesFunction
 				.apply(serviceName);
 
-		// issue : restart consumer and provider together
+		// issue : ReStarting a consumer and then starting a provider does not automatically discover the registration
 		// fix https://github.com/alibaba/spring-cloud-alibaba/issues/753
 		// Re-obtain the latest list of available metadata address here, ip or port may change.
 		dubboMetadataConfigServiceProxy.removeProxy(serviceName);

--- a/spring-cloud-starter-alibaba/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/registry/AbstractSpringCloudRegistry.java
+++ b/spring-cloud-starter-alibaba/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/registry/AbstractSpringCloudRegistry.java
@@ -222,10 +222,14 @@ public abstract class AbstractSpringCloudRegistry extends FailbackRegistry {
 		Collection<ServiceInstance> serviceInstances = serviceInstancesFunction
 				.apply(serviceName);
 
+		// issue : restart consumer and provider together
+		// fix https://github.com/alibaba/spring-cloud-alibaba/issues/753
+		// Re-obtain the latest list of available metadata address here, ip or port may change.
+		dubboMetadataConfigServiceProxy.removeProxy(serviceName);
+		repository.removeMetadataAndInitializedService(serviceName);
+		dubboGenericServiceFactory.destroy(serviceName);
+		repository.initializeMetadata(serviceName);
 		if (CollectionUtils.isEmpty(serviceInstances)) {
-			dubboMetadataConfigServiceProxy.removeProxy(serviceName);
-			repository.removeMetadataAndInitializedService(serviceName);
-			dubboGenericServiceFactory.destroy(serviceName);
 			if (logger.isWarnEnabled()) {
 				logger.warn(
 						"There is no instance from service[name : {}], and then Dubbo Service[key : {}] will not be "
@@ -246,18 +250,6 @@ public abstract class AbstractSpringCloudRegistry extends FailbackRegistry {
 
 		DubboMetadataService dubboMetadataService = dubboMetadataConfigServiceProxy
 				.getProxy(serviceName);
-
-		if (dubboMetadataService == null) { // If not found, try to initialize
-			if (logger.isInfoEnabled()) {
-				logger.info(
-						"The metadata of Dubbo service[key : {}] can't be found when the subscribed service[name : {}], "
-								+ "and then try to initialize it",
-						url.getServiceKey(), serviceName);
-			}
-			repository.initializeMetadata(serviceName);
-			dubboMetadataService = dubboMetadataConfigServiceProxy.getProxy(serviceName);
-		}
-
 		if (dubboMetadataService == null) { // It makes sure not-found, return immediately
 			if (logger.isWarnEnabled()) {
 				logger.warn(


### PR DESCRIPTION
### Describe what this PR does / why we need it
ReStarting a consumer and then starting a provider does not automatically discover the registration

### Does this pull request fix one issue?
Fixes  https://github.com/alibaba/spring-cloud-alibaba/issues/753

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it

		// Re-obtain the latest list of available metadata address here, ip or port may change.
		dubboMetadataConfigServiceProxy.removeProxy(serviceName);
		repository.removeMetadataAndInitializedService(serviceName);
		dubboGenericServiceFactory.destroy(serviceName);
		repository.initializeMetadata(serviceName);

### Special notes for reviews

大家好, 我已经提交了改正的代码, 请过目. 已经在公司内部的k8s生产环境实验通过了.

使用随机端口或者k8s应用都可以复现这个问题.


* 解决注册中心推送新IP的时候，dubbo服务一直不替换老IP或端口的BUG。


nacos刷新dubbo客户端对象的逻辑是，先去元数据服务查询接口定义信息， 再用接口信息去重建客户端内部的Invoker对象 {@link Invoker}

但是如果元数据服务的IP或端口发生了变化，那么就无法获取接口信息，客户端Invoker对象也就无法重建。

我提交的这个代码就是在执行查询元数据前，先把元数据服务的实例重建, 新的元数据对象会去注册中心获取最新的实例列表， 这样查询元数据就能正常获取到元数据了。