### PR TITLE
Fix #1310 Compatible with Dubbo 2.7.5

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/autoconfigure/condition/MissingSpringCloudRegistryConfigPropertyCondition.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/autoconfigure/condition/MissingSpringCloudRegistryConfigPropertyCondition.java
@@ -29,7 +29,7 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 import org.springframework.util.StringUtils;
 
 import static com.alibaba.cloud.dubbo.registry.SpringCloudRegistryFactory.PROTOCOL;
-import static org.apache.dubbo.config.spring.util.PropertySourcesUtils.getPrefixedProperties;
+import static com.alibaba.spring.util.PropertySourcesUtils.getSubProperties;
 
 /**
  * Missing {@link SpringCloudRegistry} Property {@link Condition}.
@@ -61,7 +61,7 @@ public class MissingSpringCloudRegistryConfigPropertyCondition
 					"'spring-cloud' protocol was found from 'dubbo.registry.address'");
 		}
 
-		Map<String, Object> properties = getPrefixedProperties(
+		Map<String, Object> properties = getSubProperties(
 				environment.getPropertySources(), "dubbo.registries.");
 
 		boolean found = properties.entrySet().stream().anyMatch(entry -> {

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/env/DubboNonWebApplicationEnvironmentPostProcessor.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/env/DubboNonWebApplicationEnvironmentPostProcessor.java
@@ -34,8 +34,8 @@ import org.springframework.core.env.PropertySource;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
-import static org.apache.dubbo.common.constants.CommonConstants.DEFAULT_PROTOCOL;
 import static com.alibaba.spring.util.PropertySourcesUtils.getSubProperties;
+import static org.apache.dubbo.common.constants.CommonConstants.DEFAULT_PROTOCOL;
 
 /**
  * Dubbo {@link WebApplicationType#NONE Non-Web Application}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/env/DubboNonWebApplicationEnvironmentPostProcessor.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/env/DubboNonWebApplicationEnvironmentPostProcessor.java
@@ -35,7 +35,7 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
 import static org.apache.dubbo.common.constants.CommonConstants.DEFAULT_PROTOCOL;
-import static org.apache.dubbo.config.spring.util.PropertySourcesUtils.getPrefixedProperties;
+import static com.alibaba.spring.util.PropertySourcesUtils.getSubProperties;
 
 /**
  * Dubbo {@link WebApplicationType#NONE Non-Web Application}
@@ -149,7 +149,7 @@ public class DubboNonWebApplicationEnvironmentPostProcessor
 
 		String restPort = null;
 
-		Map<String, Object> subProperties = getPrefixedProperties(
+		Map<String, Object> subProperties = getSubProperties(
 				environment.getPropertySources(), PROTOCOLS_PROPERTY_NAME_PREFIX);
 
 		Properties properties = new Properties();


### PR DESCRIPTION
### Describe what this PR does / why we need it

修复使用dubbo2.7.5错误
Fix use Dubbo 2.7.5 error，#1310

### Does this pull request fix one issue?

Fixes #1310

### Describe how you did it

MissingSpringCloudRegistryConfigPropertyCondition类以及DubboNonWebApplicationEnvironmentPostProcessor类在获取属性的时候使用了dubbo的工具类org.apache.dubbo.config.spring.util.PropertySourcesUtils.getPrefixedProperties，这个类在2.7.5已经不存在了，可以使用com.alibaba.spring.util.PropertySourcesUtils.getSubProperties代替，如dubbo2.7.5自己使用的那样。

修改后，同时兼容2.7.4.1

Missingspringcloudregistryconfigpropertycondition class and dubbononwebapplicationenvironmentpostprocessor class used Dubbo's tool class org.apache.dubbo.config.spring.util.propertysourcesutils.getprefixedproperties when getting properties. This class no longer exists in 2.7.5. You can use com.alibaba.spring.util.propertysourcesutils.getsubproperties Instead, as Dubbo 2.7.5 uses on its own.

After modification, it is compatible with 2.7.4.1

### Describe how to verify it

使用代码覆盖的方法，修改pom分别使用dubbo2.7.5和2.7.4.1，进行测试。均正常启动，业务也正常

Using the method of code coverage, modify POM to use Dubbo 2.7.5 and 2.7.4.1, respectively, to test. Normal startup and normal business


### Special notes for reviews
此修复依赖com.alibaba.spring的spring-context-support包，不清楚其他分支是否包含了此包
This fix relies on the spring context support package of com.alibaba.spring. It is not clear whether the package is included in other branches
