### PR TITLE
fix #1325 the register-enabled configuration doesn't work in non-web …

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosServiceRegistry.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosServiceRegistry.java
@@ -50,6 +50,11 @@ public class NacosServiceRegistry implements ServiceRegistry<Registration> {
 	@Override
 	public void register(Registration registration) {
 
+		// Fix #1325 the register-enabled configuration doesn't work in non-web environment
+		if (!nacosDiscoveryProperties.isRegisterEnabled()) {
+			return;
+		}
+
 		if (StringUtils.isEmpty(registration.getServiceId())) {
 			log.warn("No service to register for nacos client...");
 			return;


### PR DESCRIPTION
…environment


### Describe what this PR does / why we need it

the register-enabled configuration doesn't work in non-web environment

### Does this pull request fix one issue?

Fixes #1325

### Describe how you did it

Add judgment on register enabled configuration item in com.alibaba.cloud.nacos.registry.NacosServiceRegistry#register 

### Describe how to verify it

set spring.main.web-application-type=none and spring.cloud.nacos.discovery.register-enabled=false, then run, The service is not registered in the Nacos server.

### Special notes for reviews
