### PR TITLE
多注册中心动态切换serverAddr配置还是保留旧注册中心地址

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
@@ -64,7 +64,7 @@ import static com.alibaba.nacos.api.PropertyKeyConst.USERNAME;
  * @author xiaojing
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
  * @author <a href="mailto:lyuzb@lyuzb.com">lyuzb</a>
- * @author <a href="mailto:78552423@qq.com">esun</a>
+ * @author <a href="mailto:78552423@qq.com">eshun</a>
  */
 @ConfigurationProperties("spring.cloud.nacos.discovery")
 public class NacosDiscoveryProperties {

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
@@ -64,7 +64,7 @@ import static com.alibaba.nacos.api.PropertyKeyConst.USERNAME;
  * @author xiaojing
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
  * @author <a href="mailto:lyuzb@lyuzb.com">lyuzb</a>
- * @author eshun
+ * @author <a href="mailto:78552423@qq.com">eshun</a>
  */
 @ConfigurationProperties("spring.cloud.nacos.discovery")
 public class NacosDiscoveryProperties {

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
@@ -64,6 +64,7 @@ import static com.alibaba.nacos.api.PropertyKeyConst.USERNAME;
  * @author xiaojing
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
  * @author <a href="mailto:lyuzb@lyuzb.com">lyuzb</a>
+ * @author <a href="mailto:78552423@qq.com">esun</a>
  */
 
 @ConfigurationProperties("spring.cloud.nacos.discovery")
@@ -211,6 +212,7 @@ public class NacosDiscoveryProperties {
 
 	@PostConstruct
 	public void init() throws SocketException {
+		namingService = null;
 
 		metadata.put(PreservedMetadataKeys.REGISTER_SOURCE, "SPRING_CLOUD");
 		if (secure) {
@@ -229,8 +231,7 @@ public class NacosDiscoveryProperties {
 			// traversing network interfaces if didn't specify a interface
 			if (StringUtils.isEmpty(networkInterface)) {
 				ip = inetUtils.findFirstNonLoopbackHostInfo().getIpAddress();
-			}
-			else {
+			} else {
 				NetworkInterface netInterface = NetworkInterface
 						.getByName(networkInterface);
 				if (null == netInterface) {

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
@@ -64,7 +64,7 @@ import static com.alibaba.nacos.api.PropertyKeyConst.USERNAME;
  * @author xiaojing
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
  * @author <a href="mailto:lyuzb@lyuzb.com">lyuzb</a>
- * @author <a href="mailto:78552423@qq.com">eshun</a>
+ * @author eshun
  */
 @ConfigurationProperties("spring.cloud.nacos.discovery")
 public class NacosDiscoveryProperties {

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
@@ -66,7 +66,6 @@ import static com.alibaba.nacos.api.PropertyKeyConst.USERNAME;
  * @author <a href="mailto:lyuzb@lyuzb.com">lyuzb</a>
  * @author <a href="mailto:78552423@qq.com">esun</a>
  */
-
 @ConfigurationProperties("spring.cloud.nacos.discovery")
 public class NacosDiscoveryProperties {
 
@@ -231,7 +230,8 @@ public class NacosDiscoveryProperties {
 			// traversing network interfaces if didn't specify a interface
 			if (StringUtils.isEmpty(networkInterface)) {
 				ip = inetUtils.findFirstNonLoopbackHostInfo().getIpAddress();
-			} else {
+			}
+			else {
 				NetworkInterface netInterface = NetworkInterface
 						.getByName(networkInterface);
 				if (null == netInterface) {

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosServiceRegistry.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosServiceRegistry.java
@@ -33,7 +33,7 @@ import static org.springframework.util.ReflectionUtils.rethrowRuntimeException;
 /**
  * @author xiaojing
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
- * @author <a href="mailto:78552423@qq.com">esun</a>
+ * @author <a href="mailto:78552423@qq.com">eshun</a>
  */
 public class NacosServiceRegistry implements ServiceRegistry<Registration> {
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosServiceRegistry.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosServiceRegistry.java
@@ -33,7 +33,7 @@ import static org.springframework.util.ReflectionUtils.rethrowRuntimeException;
 /**
  * @author xiaojing
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
- * @author eshun
+ * @author <a href="mailto:78552423@qq.com">eshun</a>
  */
 public class NacosServiceRegistry implements ServiceRegistry<Registration> {
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosServiceRegistry.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosServiceRegistry.java
@@ -33,7 +33,7 @@ import static org.springframework.util.ReflectionUtils.rethrowRuntimeException;
 /**
  * @author xiaojing
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
- * @author <a href="mailto:78552423@qq.com">eshun</a>
+ * @author eshun
  */
 public class NacosServiceRegistry implements ServiceRegistry<Registration> {
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosServiceRegistry.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosServiceRegistry.java
@@ -53,16 +53,18 @@ public class NacosServiceRegistry implements ServiceRegistry<Registration> {
 			return;
 		}
 
+		NamingService namingService = namingService();
 		String serviceId = registration.getServiceId();
 		String group = nacosDiscoveryProperties.getGroup();
 
 		Instance instance = getNacosInstanceFromRegistration(registration);
 
 		try {
-			namingService().registerInstance(serviceId, group, instance);
+			namingService.registerInstance(serviceId, group, instance);
 			log.info("nacos registry, {} {} {}:{} register finished", group, serviceId,
 					instance.getIp(), instance.getPort());
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			log.error("nacos registry, {} register failed...{},", serviceId,
 					registration.toString(), e);
 			// rethrow a RuntimeException if the registration is failed.
@@ -81,13 +83,15 @@ public class NacosServiceRegistry implements ServiceRegistry<Registration> {
 			return;
 		}
 
+		NamingService namingService = namingService();
 		String serviceId = registration.getServiceId();
 		String group = nacosDiscoveryProperties.getGroup();
 
 		try {
-			namingService().deregisterInstance(serviceId, group, registration.getHost(),
+			namingService.deregisterInstance(serviceId, group, registration.getHost(),
 					registration.getPort(), nacosDiscoveryProperties.getClusterName());
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			log.error("ERR_NACOS_DEREGISTER, de-register failed...{},",
 					registration.toString(), e);
 		}
@@ -114,14 +118,16 @@ public class NacosServiceRegistry implements ServiceRegistry<Registration> {
 
 		if (status.equalsIgnoreCase("DOWN")) {
 			instance.setEnabled(false);
-		} else {
+		}
+		else {
 			instance.setEnabled(true);
 		}
 
 		try {
 			nacosDiscoveryProperties.namingMaintainServiceInstance()
 					.updateInstance(serviceId, instance);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			throw new RuntimeException("update nacos instance status fail", e);
 		}
 
@@ -140,7 +146,8 @@ public class NacosServiceRegistry implements ServiceRegistry<Registration> {
 					return instance.isEnabled() ? "UP" : "DOWN";
 				}
 			}
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			log.error("get all instance of {} error,", serviceName, e);
 		}
 		return null;


### PR DESCRIPTION

### Describe what this PR does / why we need it
我们的场景是在多注册中心不重启实例的情况下动态切换注册中心。

### Does this pull request fix one issue?
NONE

### Describe how you did it
实例已经在线的情况下，通过post /actuator/env 或由配置中心更改了${spring.cloud.nacos.discovery.server-addr}配置,NacosDiscoveryProperties Bean重载完static NamingService还是保留旧的注册中心地址。导致无法注册到新的注册中心

### Describe how to verify it
通过post /actuator/env 或由配置中心更改了 查看注册中心实例是否注册

### Special notes for reviews
