### PR TITLE
optimized code,A static field should be directly referred by its class name

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/registry/AbstractSpringCloudRegistry.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/registry/AbstractSpringCloudRegistry.java
@@ -260,7 +260,7 @@ public abstract class AbstractSpringCloudRegistry extends FailbackRegistry {
 				String listenerId = generateId(url);
 				// The metaservice will restart the new listener. It needs to be optimized
 				// to see whether the original listener can be reused.
-				this.registerListeners.remove(listenerId);
+				registerListeners.remove(listenerId);
 			}
 
 			/**


### PR DESCRIPTION
…s name


### Describe what this PR does / why we need it
A static field or method should be directly referred by its class name instead of its corresponding object name.

### Does this pull request fix one issue?
Not

### Describe how you did it
A static field  be directly referred by its class name instead of its corresponding object name.

### Describe how to verify it
Not

### Special notes for reviews
Not