### PR TITLE
Upgrade Sentinel version to 1.7.2

### DIFF
--- a/spring-cloud-alibaba-dependencies/pom.xml
+++ b/spring-cloud-alibaba-dependencies/pom.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <revision>2.2.1.RELEASE</revision>
-        <sentinel.version>1.7.1</sentinel.version>
+        <sentinel.version>1.7.2</sentinel.version>
         <oss.version>3.1.0</oss.version>
         <seata.version>1.1.0</seata.version>
         <nacos.client.version>1.2.1</nacos.client.version>

--- a/spring-cloud-alibaba-examples/sentinel-example/sentinel-core-example/src/main/resources/application.properties
+++ b/spring-cloud-alibaba-examples/sentinel-example/sentinel-core-example/src/main/resources/application.properties
@@ -9,6 +9,7 @@ management.health.diskspace.enabled=false
 
 spring.cloud.sentinel.transport.dashboard=localhost:8080
 spring.cloud.sentinel.eager=true
+spring.cloud.sentinel.web-context-unify=true
 
 #spring.cloud.sentinel.block-page=/errorPage
 #spring.cloud.sentinel.filter.enabled=false

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/SentinelProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/SentinelProperties.java
@@ -102,6 +102,20 @@ public class SentinelProperties {
 	 */
 	private Boolean httpMethodSpecify = false;
 
+	/**
+	 * Specify whether unify web context(i.e. use the default context name), and is true
+	 * by default.
+	 */
+	private Boolean webContextUnify = true;
+
+	public Boolean getWebContextUnify() {
+		return webContextUnify;
+	}
+
+	public void setWebContextUnify(Boolean webContextUnify) {
+		this.webContextUnify = webContextUnify;
+	}
+
 	public boolean isEager() {
 		return eager;
 	}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/SentinelWebAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/SentinelWebAutoConfiguration.java
@@ -96,6 +96,7 @@ public class SentinelWebAutoConfiguration implements WebMvcConfigurer {
 	public SentinelWebMvcConfig sentinelWebMvcConfig() {
 		SentinelWebMvcConfig sentinelWebMvcConfig = new SentinelWebMvcConfig();
 		sentinelWebMvcConfig.setHttpMethodSpecify(properties.getHttpMethodSpecify());
+		sentinelWebMvcConfig.setWebContextUnify(properties.getWebContextUnify());
 
 		if (blockExceptionHandlerOptional.isPresent()) {
 			blockExceptionHandlerOptional

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/endpoint/SentinelEndpoint.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/endpoint/SentinelEndpoint.java
@@ -61,7 +61,7 @@ public class SentinelEndpoint {
 			result.put("metricsFileSize", SentinelConfig.singleMetricFileSize());
 			result.put("metricsFileCharset", SentinelConfig.charset());
 			result.put("totalMetricsFileCount", SentinelConfig.totalMetricFileCount());
-			result.put("consoleServer", TransportConfig.getConsoleServer());
+			result.put("consoleServer", TransportConfig.getConsoleServerList());
 			result.put("clientIp", TransportConfig.getHeartbeatClientIp());
 			result.put("heartbeatIntervalMs", TransportConfig.getHeartbeatIntervalMs());
 			result.put("clientPort", TransportConfig.getPort());

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/endpoint/SentinelHealthIndicator.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/endpoint/SentinelHealthIndicator.java
@@ -17,6 +17,7 @@
 package com.alibaba.cloud.sentinel.endpoint;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import com.alibaba.cloud.sentinel.SentinelProperties;
@@ -24,13 +25,14 @@ import com.alibaba.csp.sentinel.datasource.AbstractDataSource;
 import com.alibaba.csp.sentinel.heartbeat.HeartbeatSenderProvider;
 import com.alibaba.csp.sentinel.transport.HeartbeatSender;
 import com.alibaba.csp.sentinel.transport.config.TransportConfig;
+import com.alibaba.csp.sentinel.util.function.Tuple2;
 
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.boot.actuate.health.AbstractHealthIndicator;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.boot.actuate.health.Status;
-import org.springframework.util.StringUtils;
+import org.springframework.util.CollectionUtils;
 
 /**
  * A {@link HealthIndicator} for Sentinel, which checks the status of Sentinel Dashboard
@@ -82,8 +84,9 @@ public class SentinelHealthIndicator extends AbstractHealthIndicator {
 
 		// Check health of Dashboard
 		boolean dashboardUp = true;
-		String consoleServer = TransportConfig.getConsoleServer();
-		if (StringUtils.isEmpty(consoleServer)) {
+		List<Tuple2<String, Integer>> consoleServerList = TransportConfig
+				.getConsoleServerList();
+		if (CollectionUtils.isEmpty(consoleServerList)) {
 			// If Dashboard isn't configured, it's OK and mark the status of Dashboard
 			// with UNKNOWN.
 			detailMap.put("dashboard",
@@ -101,8 +104,10 @@ public class SentinelHealthIndicator extends AbstractHealthIndicator {
 			else {
 				// If failed to send heartbeat message, means that the Dashboard is DOWN
 				dashboardUp = false;
-				detailMap.put("dashboard", new Status(Status.DOWN.getCode(),
-						consoleServer + " can't be connected"));
+				detailMap.put("dashboard",
+						new Status(Status.DOWN.getCode(), String.format(
+								"the dashboard servers [%s] one of them can't be connected",
+								consoleServerList)));
 			}
 		}
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -19,6 +19,12 @@
       "description": "earlier initialize heart-beat when the spring container starts when the transport dependency is on classpath, the configuration is effective."
     },
     {
+      "name": "spring.cloud.sentinel.web-context-unify",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Specify whether unify web context(i.e. use the default context name), and is true by default."
+    },
+    {
       "name": "spring.cloud.sentinel.transport.port",
       "type": "java.lang.String",
       "defaultValue": "8719",

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/test/java/com/alibaba/cloud/sentinel/SentinelAutoConfigurationTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/test/java/com/alibaba/cloud/sentinel/SentinelAutoConfigurationTests.java
@@ -33,6 +33,7 @@ import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRuleManager;
 import com.alibaba.csp.sentinel.slots.block.flow.FlowRule;
 import com.alibaba.csp.sentinel.slots.block.flow.FlowRuleManager;
 import com.alibaba.csp.sentinel.transport.config.TransportConfig;
+import com.alibaba.csp.sentinel.util.function.Tuple2;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -73,7 +74,7 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 				"spring.cloud.sentinel.flow.coldFactor=3",
 				"spring.cloud.sentinel.eager=true",
 				"spring.cloud.sentinel.log.switchPid=true",
-				"spring.cloud.sentinel.transport.dashboard=http://localhost:8080",
+				"spring.cloud.sentinel.transport.dashboard=http://localhost:8080,http://localhost:8081",
 				"spring.cloud.sentinel.transport.port=9999",
 				"spring.cloud.sentinel.transport.clientIp=1.1.1.1",
 				"spring.cloud.sentinel.transport.heartbeatIntervalMs=20000" },
@@ -142,7 +143,9 @@ public class SentinelAutoConfigurationTests {
 		Map<String, Object> map = sentinelEndpoint.invoke();
 
 		assertThat(map.get("logUsePid")).isEqualTo(Boolean.TRUE);
-		assertThat(map.get("consoleServer")).isEqualTo("http://localhost:8080");
+		assertThat(map.get("consoleServer").toString()).isEqualTo(
+				Arrays.asList(Tuple2.of("localhost", 8080), Tuple2.of("localhost", 8081))
+						.toString());
 		assertThat(map.get("clientPort")).isEqualTo("9999");
 		assertThat(map.get("heartbeatIntervalMs")).isEqualTo(20000L);
 		assertThat(map.get("clientIp")).isEqualTo("1.1.1.1");
@@ -174,7 +177,7 @@ public class SentinelAutoConfigurationTests {
 	private void checkSentinelTransport() {
 		assertThat(sentinelProperties.getTransport().getPort()).isEqualTo("9999");
 		assertThat(sentinelProperties.getTransport().getDashboard())
-				.isEqualTo("http://localhost:8080");
+				.isEqualTo("http://localhost:8080,http://localhost:8081");
 		assertThat(sentinelProperties.getTransport().getClientIp()).isEqualTo("1.1.1.1");
 		assertThat(sentinelProperties.getTransport().getHeartbeatIntervalMs())
 				.isEqualTo("20000");
@@ -191,7 +194,9 @@ public class SentinelAutoConfigurationTests {
 	@Test
 	public void testSentinelSystemProperties() {
 		assertThat(LogBase.isLogNameUsePid()).isEqualTo(true);
-		assertThat(TransportConfig.getConsoleServer()).isEqualTo("http://localhost:8080");
+		assertThat(TransportConfig.getConsoleServerList().toString()).isEqualTo(
+				Arrays.asList(Tuple2.of("localhost", 8080), Tuple2.of("localhost", 8081))
+						.toString());
 		assertThat(TransportConfig.getPort()).isEqualTo("9999");
 		assertThat(TransportConfig.getHeartbeatIntervalMs().longValue())
 				.isEqualTo(20000L);


### PR DESCRIPTION
### Describe what this PR does / why we need it
- upgrade Sentinel version to 1.7.2
- add a new configuration item `spring.cloud.sentinel.web-context-unify` to specify whether unify web context(i.e. use the default context name), and is `true` by default.
### Does this pull request fix one issue?
Fixes #1431 

