### PR TITLE
SORRY,提交方式有问题，麻烦管理员关闭这个PR

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/metadata/DubboProtocolConfigSupplier.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/metadata/DubboProtocolConfigSupplier.java
@@ -65,7 +65,6 @@ public class DubboProtocolConfigSupplier implements Supplier<ProtocolConfig> {
 		if (protocolConfig == null) {
 			protocolConfig = new ProtocolConfig();
 			protocolConfig.setName(DEFAULT_PROTOCOL);
-			protocolConfig.setPort(-1);
 		}
 
 		return protocolConfig;


### PR DESCRIPTION
### Describe what this PR does / why we need it
spring-cloud-alibaba版本 2.2.1.RELEASE，修改是基于master分支
**1. 在服务提供方如果未配置 dubbo.protocol.port ，在服务暴露时，其会选择对应协议的默认端口暴露**
```
org.apache.dubbo.config.ServiceConfig#findConfigedPorts
ExtensionLoader.getExtensionLoader(Protocol.class).getExtension(name).getDefaultPort();
if (portToBind == null || portToBind == 0) {
       portToBind = defaultPort;
}
```
**2. 而DubboMetadataService服务暴露时，其构建的ServiceConfig对应的Protocol对应的端口是-1，导致在服务暴露时，暴露的端口会从默认端口开始获取可用端口，而由于20880此时已经被占用，所以获取到的是20881，同时注册到注册中心的metadata中的端口也是20881**
```
com.alibaba.cloud.dubbo.metadata.DubboProtocolConfigSupplier#get
if (protocolConfig == null) {
	protocolConfig = new ProtocolConfig();
	protocolConfig.setName(DEFAULT_PROTOCOL);
	protocolConfig.setPort(-1);
}
```
```
// 注册中心的实例metadata
dubbo.metadata-service.urls=[ "dubbo://192.168.43.254:20881/com.alibaba.cloud.dubbo.service.DubboMetadataService?anyhost=true&application=loksail-user&bind.ip=192.168.43.254&bind.port=20881&deprecated=false&dubbo=2.0.2&dynamic=true&generic=false&group=loksail-user&interface=com.alibaba.cloud.dubbo.service.DubboMetadataService&methods=getAllServiceKeys,getServiceRestMetadata,getExportedURLs,getAllExportedURLs&pid=21448&qos.enable=false&release=2.7.6&revision=2.2.1.RELEASE&side=provider&timestamp=1589102832376&version=1.0.0" ]
```
**3. 服务消费方在启动构建对应dubbo服务的消费者URL时，是取注册中心中DubboMetadataService的URL的端口作为构建订阅Dubbo服务URL的端口，在调用时就会报错**
```
com.alibaba.cloud.dubbo.registry.AbstractSpringCloudRegistry#subscribeDubboServiceURL
// port  这里是20881
Integer port = repository.getDubboProtocolPort(serviceInstance, protocol);
String host = serviceInstance.getHost();
if (port == null) {
	if (logger.isWarnEnabled()) {
		logger.warn(
				"The protocol[{}] port of Dubbo  service instance[host : {}] "
					+ "can't be resolved",
	}
}else {
	URL subscribedURL = new URL(protocol, host, port,
			exportedURL.getParameters());
			subscribedURLs.add(subscribedURL);
}
```
**4. 报错信息**
```
Not found exported service: com.loksail.user.biz.rpc.UserRpc:1.0.0:20881 in [com.loksail.user.biz.rpc.UserRpc:1.0.0:20880, loksail-user/com.alibaba.cloud.dubbo.service.DubboMetadataService:1.0.0:20881]
```

### Does this pull request fix one issue?
#1442

### Describe how you did it
DubboMetadataService服务暴露时不需用指定-1，如果没有指定dubbo.protocol.port，那么默认都是20880,

### Describe how to verify it
测试可以把dubbo.protocol.port去掉

### Special notes for reviews
