### PR TITLE
Fix dubbo service call error when dubbo.protocol.port is not specified

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/metadata/DubboProtocolConfigSupplier.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/metadata/DubboProtocolConfigSupplier.java
@@ -65,7 +65,6 @@ public class DubboProtocolConfigSupplier implements Supplier<ProtocolConfig> {
 		if (protocolConfig == null) {
 			protocolConfig = new ProtocolConfig();
 			protocolConfig.setName(DEFAULT_PROTOCOL);
-			protocolConfig.setPort(-1);
 		}
 
 		return protocolConfig;


### PR DESCRIPTION
### Describe what this PR does / why we need it
**1. If the service provider does not configure dubbo.protocol.port, when the service is exposed, it will select the default port exposure of the corresponding protocol**
```
org.apache.dubbo.config.ServiceConfig#findConfigedPorts
ExtensionLoader.getExtensionLoader(Protocol.class).getExtension(name).getDefaultPort();
if (portToBind == null || portToBind == 0) {
       portToBind = defaultPort;
}
```
**2. When the DubbMetadataService is exposed, the port of protocol corresponding to ServiceConfig is - 1. As a result, when the service is exposed, the exposed port will start to obtain the available port from the default port. Because the 20880 has been occupied at this time, the obtained port will be 20881. At the same time, the port registered in the metadata of the registry is 20881**
```
com.alibaba.cloud.dubbo.metadata.DubboProtocolConfigSupplier#get
if (protocolConfig == null) {
	protocolConfig = new ProtocolConfig();
	protocolConfig.setName(DEFAULT_PROTOCOL);
	protocolConfig.setPort(-1);
}
```
```
// registry instance metadata
dubbo.metadata-service.urls=[ "dubbo://192.168.43.254:20881/com.alibaba.cloud.dubbo.service.DubboMetadataService?anyhost=true&application=loksail-user&bind.ip=192.168.43.254&bind.port=20881&deprecated=false&dubbo=2.0.2&dynamic=true&generic=false&group=loksail-user&interface=com.alibaba.cloud.dubbo.service.DubboMetadataService&methods=getAllServiceKeys,getServiceRestMetadata,getExportedURLs,getAllExportedURLs&pid=21448&qos.enable=false&release=2.7.6&revision=2.2.1.RELEASE&side=provider&timestamp=1589102832376&version=1.0.0" ]
```
**3. When the service consumer starts to build the consumer URL of the corresponding dubbo service, it takes the port of the DubbMetadataService URL in the registry as the port to build the subscription Dubbo service URL, and an error will be reported when calling**
```
com.alibaba.cloud.dubbo.registry.AbstractSpringCloudRegistry#subscribeDubboServiceURL
// port  20881
Integer port = repository.getDubboProtocolPort(serviceInstance, protocol);
String host = serviceInstance.getHost();
if (port == null) {
	if (logger.isWarnEnabled()) {
		logger.warn(
				"The protocol[{}] port of Dubbo  service instance[host : {}] "
					+ "can't be resolved",
	}
}else {
	URL subscribedURL = new URL(protocol, host, port,
			exportedURL.getParameters());
			subscribedURLs.add(subscribedURL);
}
```
4. Error message
```
Not found exported service: com.loksail.user.biz.rpc.UserRpc:1.0.0:20881 in [com.loksail.user.biz.rpc.UserRpc:1.0.0:20880, loksail-user/com.alibaba.cloud.dubbo.service.DubboMetadataService:1.0.0:20881]
```

### Does this pull request fix one issue?
Fix Issues #1442

### Describe how you did it
When exposing DubboMetadataService, you do not need to specify - 1. If you do not specify dubbo.protocol.port, the default port will be the default port of the corresponding protocol, and port inconsistency will not occur

### Describe how to verify it
Do not specify dubbo.protocol.port

### Special notes for reviews
