### PR TITLE
多注册中心动态切换serverAddr配置还是保留旧注册中心地址

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
@@ -64,8 +64,8 @@ import static com.alibaba.nacos.api.PropertyKeyConst.USERNAME;
  * @author xiaojing
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
  * @author <a href="mailto:lyuzb@lyuzb.com">lyuzb</a>
+ * @author <a href="mailto:78552423@qq.com">eshun</a>
  */
-
 @ConfigurationProperties("spring.cloud.nacos.discovery")
 public class NacosDiscoveryProperties {
 
@@ -211,6 +211,7 @@ public class NacosDiscoveryProperties {
 
 	@PostConstruct
 	public void init() throws SocketException {
+		namingService = null;
 
 		metadata.put(PreservedMetadataKeys.REGISTER_SOURCE, "SPRING_CLOUD");
 		if (secure) {

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosServiceRegistry.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosServiceRegistry.java
@@ -33,6 +33,7 @@ import static org.springframework.util.ReflectionUtils.rethrowRuntimeException;
 /**
  * @author xiaojing
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @author <a href="mailto:78552423@qq.com">eshun</a>
  */
 public class NacosServiceRegistry implements ServiceRegistry<Registration> {
 
@@ -40,11 +41,8 @@ public class NacosServiceRegistry implements ServiceRegistry<Registration> {
 
 	private final NacosDiscoveryProperties nacosDiscoveryProperties;
 
-	private final NamingService namingService;
-
 	public NacosServiceRegistry(NacosDiscoveryProperties nacosDiscoveryProperties) {
 		this.nacosDiscoveryProperties = nacosDiscoveryProperties;
-		this.namingService = nacosDiscoveryProperties.namingServiceInstance();
 	}
 
 	@Override
@@ -55,6 +53,7 @@ public class NacosServiceRegistry implements ServiceRegistry<Registration> {
 			return;
 		}
 
+		NamingService namingService = namingService();
 		String serviceId = registration.getServiceId();
 		String group = nacosDiscoveryProperties.getGroup();
 
@@ -84,7 +83,7 @@ public class NacosServiceRegistry implements ServiceRegistry<Registration> {
 			return;
 		}
 
-		NamingService namingService = nacosDiscoveryProperties.namingServiceInstance();
+		NamingService namingService = namingService();
 		String serviceId = registration.getServiceId();
 		String group = nacosDiscoveryProperties.getGroup();
 
@@ -163,6 +162,10 @@ public class NacosServiceRegistry implements ServiceRegistry<Registration> {
 		instance.setMetadata(registration.getMetadata());
 
 		return instance;
+	}
+
+	private NamingService namingService() {
+		return nacosDiscoveryProperties.namingServiceInstance();
 	}
 
 }


### PR DESCRIPTION
### Describe what this PR does / why we need it
我们的场景是在多注册中心不重启实例的情况下动态切换注册中心。

### Does this pull request fix one issue?
NONE

### Describe how you did it
实例已经在线的情况下，通过post /actuator/env 或由配置中心更改了${spring.cloud.nacos.discovery.server-addr}配置,NacosDiscoveryProperties Bean重载完static NamingService还是保留旧的注册中心地址。导致无法注册到新的注册中心

### Describe how to verify it
通过post /actuator/env 或由配置中心更改了 查看注册中心实例是否注册

### Special notes for reviews
