### PR TITLE
Update RocketMQMessageChannelBinder.java

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/RocketMQMessageChannelBinder.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/RocketMQMessageChannelBinder.java
@@ -169,7 +169,7 @@ public class RocketMQMessageChannelBinder extends
 					rocketMQTemplate, destination.getName(), producerGroup,
 					producerProperties.getExtension().getTransactional(),
 					instrumentationManager, producerProperties,
-					((AbstractMessageChannel) channel).getChannelInterceptors().stream()
+					((AbstractMessageChannel) channel).getInterceptors().stream()
 							.filter(channelInterceptor -> channelInterceptor instanceof MessageConverterConfigurer.PartitioningInterceptor)
 							.map(channelInterceptor -> ((MessageConverterConfigurer.PartitioningInterceptor) channelInterceptor))
 							.findFirst().orElse(null));


### PR DESCRIPTION
 use   AbstractMessageChannel.getInterceptors() to replace  ChannelInterceptorAware.getChannelInterceptors()


### Describe what this PR does / why we need it
interface ChannelInterceptorAware  will be removed in the next 5.3 version.  (spring-Integration-5.3)

### Does this pull request fix one issue?


### Describe how you did it


### Describe how to verify it
when i use com.alibaba.cloud:spring-cloud-starter-stream-rocketmq RELEASE version, the following exception is thrown:
The following method did not exist:
    'java.util.List org.springframework.integration.channel.AbstractMessageChannel.getChannelInterceptors()'

### Special notes for reviews
