### PR TITLE
remove ConditionalOnEnabledEndpoint replace with ConditionalOnEnabledEndpoint

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-datasource/src/main/java/com/alibaba/cloud/sentinel/datasource/config/ConsulDataSourceProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-datasource/src/main/java/com/alibaba/cloud/sentinel/datasource/config/ConsulDataSourceProperties.java
@@ -28,71 +28,71 @@ import org.springframework.util.StringUtils;
  */
 public class ConsulDataSourceProperties extends AbstractDataSourceProperties {
 
-    public ConsulDataSourceProperties(){
-        super(ConsulDataSourceFactoryBean.class.getName());
-    }
+	public ConsulDataSourceProperties() {
+		super(ConsulDataSourceFactoryBean.class.getName());
+	}
 
-    /**
-     * consul server host.
-     */
-    private String host;
+	/**
+	 * consul server host.
+	 */
+	private String host;
 
-    /**
-     * consul server port.
-     */
-    private int port=8500;
+	/**
+	 * consul server port.
+	 */
+	private int port = 8500;
 
-    /**
-     * data key in Redis.
-     */
-    private String ruleKey;
+	/**
+	 * data key in Redis.
+	 */
+	private String ruleKey;
 
-    /**
-     * Request of query will hang until timeout (in second) or get updated value.
-     */
-    private int waitTimeoutInSecond = 1;
+	/**
+	 * Request of query will hang until timeout (in second) or get updated value.
+	 */
+	private int waitTimeoutInSecond = 1;
 
-    @Override
-    public void preCheck(String dataSourceName) {
-        if(StringUtils.isEmpty(host)){
-            throw new IllegalArgumentException(
-                    "ConsulDataSource server-host is empty");
-        }
-        if(StringUtils.isEmpty(ruleKey)){
-            throw new IllegalArgumentException(
-                    "ConsulDataSource ruleKey can not be empty");
-        }
-    }
+	@Override
+	public void preCheck(String dataSourceName) {
+		if (StringUtils.isEmpty(host)) {
+			throw new IllegalArgumentException("ConsulDataSource server-host is empty");
+		}
+		if (StringUtils.isEmpty(ruleKey)) {
+			throw new IllegalArgumentException(
+					"ConsulDataSource ruleKey can not be empty");
+		}
+	}
 
-    public String getHost() {
-        return host;
-    }
+	public String getHost() {
+		return host;
+	}
 
-    public void setHost(String host) {
-        this.host = host;
-    }
+	public void setHost(String host) {
+		this.host = host;
+	}
 
-    public int getPort() {
-        return port;
-    }
+	public int getPort() {
+		return port;
+	}
 
-    public void setPort(int port) {
-        this.port = port;
-    }
+	public void setPort(int port) {
+		this.port = port;
+	}
 
-    public String getRuleKey() {
-        return ruleKey;
-    }
+	public String getRuleKey() {
+		return ruleKey;
+	}
 
-    public void setRuleKey(String ruleKey) {
-        this.ruleKey = ruleKey;
-    }
+	public void setRuleKey(String ruleKey) {
+		this.ruleKey = ruleKey;
+	}
 
-    public int getWaitTimeoutInSecond() {
-        return waitTimeoutInSecond;
-    }
+	public int getWaitTimeoutInSecond() {
+		return waitTimeoutInSecond;
+	}
 
-    public void setWaitTimeoutInSecond(int waitTimeoutInSecond) {
-        this.waitTimeoutInSecond = waitTimeoutInSecond;
-    }
+	public void setWaitTimeoutInSecond(int waitTimeoutInSecond) {
+		this.waitTimeoutInSecond = waitTimeoutInSecond;
+	}
+
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-datasource/src/main/java/com/alibaba/cloud/sentinel/datasource/factorybean/ConsulDataSourceFactoryBean.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-datasource/src/main/java/com/alibaba/cloud/sentinel/datasource/factorybean/ConsulDataSourceFactoryBean.java
@@ -29,68 +29,64 @@ import org.springframework.beans.factory.FactoryBean;
  */
 public class ConsulDataSourceFactoryBean implements FactoryBean<ConsulDataSource> {
 
-    private String    host;
+	private String host;
 
-    private int       port;
+	private int port;
 
-    private String    ruleKey;
+	private String ruleKey;
 
-    private int       waitTimeoutInSecond;
+	private int waitTimeoutInSecond;
 
-    private Converter converter;
+	private Converter converter;
 
-    @Override
-    public ConsulDataSource getObject() throws Exception {
-        return new ConsulDataSource(
-                host,
-                port,
-                ruleKey,
-                waitTimeoutInSecond,
-                converter);
-    }
+	@Override
+	public ConsulDataSource getObject() throws Exception {
+		return new ConsulDataSource(host, port, ruleKey, waitTimeoutInSecond, converter);
+	}
 
-    @Override
-    public Class<?> getObjectType() {
-        return ConsulDataSource.class;
-    }
+	@Override
+	public Class<?> getObjectType() {
+		return ConsulDataSource.class;
+	}
 
-    public String getHost() {
-        return host;
-    }
+	public String getHost() {
+		return host;
+	}
 
-    public void setHost(String host) {
-        this.host = host;
-    }
+	public void setHost(String host) {
+		this.host = host;
+	}
 
-    public int getPort() {
-        return port;
-    }
+	public int getPort() {
+		return port;
+	}
 
-    public void setPort(int port) {
-        this.port = port;
-    }
+	public void setPort(int port) {
+		this.port = port;
+	}
 
-    public String getRuleKey() {
-        return ruleKey;
-    }
+	public String getRuleKey() {
+		return ruleKey;
+	}
 
-    public void setRuleKey(String ruleKey) {
-        this.ruleKey = ruleKey;
-    }
+	public void setRuleKey(String ruleKey) {
+		this.ruleKey = ruleKey;
+	}
 
-    public int getWaitTimeoutInSecond() {
-        return waitTimeoutInSecond;
-    }
+	public int getWaitTimeoutInSecond() {
+		return waitTimeoutInSecond;
+	}
 
-    public void setWaitTimeoutInSecond(int waitTimeoutInSecond) {
-        this.waitTimeoutInSecond = waitTimeoutInSecond;
-    }
+	public void setWaitTimeoutInSecond(int waitTimeoutInSecond) {
+		this.waitTimeoutInSecond = waitTimeoutInSecond;
+	}
 
-    public Converter getConverter() {
-        return converter;
-    }
+	public Converter getConverter() {
+		return converter;
+	}
 
-    public void setConverter(Converter converter) {
-        this.converter = converter;
-    }
+	public void setConverter(Converter converter) {
+		this.converter = converter;
+	}
+
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/endpoint/NacosConfigEndpointAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/endpoint/NacosConfigEndpointAutoConfiguration.java
@@ -20,7 +20,7 @@ import com.alibaba.cloud.nacos.NacosConfigManager;
 import com.alibaba.cloud.nacos.refresh.NacosRefreshHistory;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnEnabledEndpoint;
+import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -43,9 +43,9 @@ public class NacosConfigEndpointAutoConfiguration {
 	@Autowired
 	private NacosRefreshHistory nacosRefreshHistory;
 
-	@ConditionalOnMissingBean
-	@ConditionalOnEnabledEndpoint
 	@Bean
+	@ConditionalOnMissingBean
+	@ConditionalOnAvailableEndpoint
 	public NacosConfigEndpoint nacosConfigEndpoint() {
 		return new NacosConfigEndpoint(nacosConfigManager.getNacosConfigProperties(),
 				nacosRefreshHistory);

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/endpoint/NacosDiscoveryEndpointAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/endpoint/NacosDiscoveryEndpointAutoConfiguration.java
@@ -20,7 +20,7 @@ import com.alibaba.cloud.nacos.ConditionalOnNacosDiscoveryEnabled;
 import com.alibaba.cloud.nacos.NacosDiscoveryProperties;
 import com.alibaba.cloud.nacos.discovery.actuate.health.NacosDiscoveryHealthIndicator;
 
-import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnEnabledEndpoint;
+import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.health.HealthIndicator;
@@ -42,7 +42,7 @@ public class NacosDiscoveryEndpointAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	@ConditionalOnEnabledEndpoint
+	@ConditionalOnAvailableEndpoint
 	public NacosDiscoveryEndpoint nacosDiscoveryEndpoint(
 			NacosDiscoveryProperties nacosDiscoveryProperties) {
 		return new NacosDiscoveryEndpoint(nacosDiscoveryProperties);

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/endpoint/NacosDiscoveryEndpointConditionalOnAvailableEndpointTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/endpoint/NacosDiscoveryEndpointConditionalOnAvailableEndpointTests.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.nacos.endpoint;
+
+import com.alibaba.cloud.nacos.discovery.NacosDiscoveryAutoConfiguration;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cloud.commons.util.UtilAutoConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test cases for {@link NacosDiscoveryEndpointAutoConfiguration}.
+ *
+ * @author lengleng
+ */
+public class NacosDiscoveryEndpointConditionalOnAvailableEndpointTests {
+
+    private ApplicationContextRunner contextRunner;
+
+    @Before
+    public void setUp() {
+        contextRunner = new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(UtilAutoConfiguration.class,
+                        NacosDiscoveryAutoConfiguration.class, NacosDiscoveryEndpointAutoConfiguration.class));
+    }
+
+    @Test
+    public void testNacosDiscoveryEndpointEnabled() {
+        this.contextRunner
+                .withPropertyValues("management.endpoints.web.exposure.include=*",
+                        "management.endpoint.nacos-discovery.enabled=true")
+                .run((context) -> assertThat(context).hasBean("nacosDiscoveryEndpoint"));
+    }
+
+    @Test
+    public void testNacosDiscoveryEndpointNotEnabled() {
+        this.contextRunner
+                .withPropertyValues("management.endpoints.web.exposure.include=*",
+                        "management.endpoint.nacos-discovery.enabled=false")
+                .run((context) -> assertThat(context).doesNotHaveBean("nacosDiscoveryEndpoint"));
+    }
+
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/endpoint/NacosDiscoveryEndpointConditionalOnAvailableEndpointTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/endpoint/NacosDiscoveryEndpointConditionalOnAvailableEndpointTests.java
@@ -32,29 +32,31 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class NacosDiscoveryEndpointConditionalOnAvailableEndpointTests {
 
-    private ApplicationContextRunner contextRunner;
+	private ApplicationContextRunner contextRunner;
 
-    @Before
-    public void setUp() {
-        contextRunner = new ApplicationContextRunner()
-                .withConfiguration(AutoConfigurations.of(UtilAutoConfiguration.class,
-                        NacosDiscoveryAutoConfiguration.class, NacosDiscoveryEndpointAutoConfiguration.class));
-    }
+	@Before
+	public void setUp() {
+		contextRunner = new ApplicationContextRunner()
+				.withConfiguration(AutoConfigurations.of(UtilAutoConfiguration.class,
+						NacosDiscoveryAutoConfiguration.class,
+						NacosDiscoveryEndpointAutoConfiguration.class));
+	}
 
-    @Test
-    public void testNacosDiscoveryEndpointEnabled() {
-        this.contextRunner
-                .withPropertyValues("management.endpoints.web.exposure.include=*",
-                        "management.endpoint.nacos-discovery.enabled=true")
-                .run((context) -> assertThat(context).hasBean("nacosDiscoveryEndpoint"));
-    }
+	@Test
+	public void testNacosDiscoveryEndpointEnabled() {
+		this.contextRunner
+				.withPropertyValues("management.endpoints.web.exposure.include=*",
+						"management.endpoint.nacos-discovery.enabled=true")
+				.run((context) -> assertThat(context).hasBean("nacosDiscoveryEndpoint"));
+	}
 
-    @Test
-    public void testNacosDiscoveryEndpointNotEnabled() {
-        this.contextRunner
-                .withPropertyValues("management.endpoints.web.exposure.include=*",
-                        "management.endpoint.nacos-discovery.enabled=false")
-                .run((context) -> assertThat(context).doesNotHaveBean("nacosDiscoveryEndpoint"));
-    }
+	@Test
+	public void testNacosDiscoveryEndpointNotEnabled() {
+		this.contextRunner
+				.withPropertyValues("management.endpoints.web.exposure.include=*",
+						"management.endpoint.nacos-discovery.enabled=false")
+				.run((context) -> assertThat(context)
+						.doesNotHaveBean("nacosDiscoveryEndpoint"));
+	}
 
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/endpoint/NacosDiscoveryEndpointConditionalOnAvailableEndpointTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/endpoint/NacosDiscoveryEndpointConditionalOnAvailableEndpointTests.java
@@ -19,6 +19,7 @@ package com.alibaba.cloud.nacos.endpoint;
 import com.alibaba.cloud.nacos.discovery.NacosDiscoveryAutoConfiguration;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.cloud.commons.util.UtilAutoConfiguration;

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/java/com/alibaba/cloud/seata/feign/hystrix/SeataHystrixConcurrencyStrategy.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/java/com/alibaba/cloud/seata/feign/hystrix/SeataHystrixConcurrencyStrategy.java
@@ -44,7 +44,9 @@ import org.springframework.web.context.request.RequestContextHolder;
  */
 public class SeataHystrixConcurrencyStrategy extends HystrixConcurrencyStrategy {
 
-	private final Logger logger = LoggerFactory.getLogger(SeataHystrixConcurrencyStrategy.class);
+	private final Logger logger = LoggerFactory
+			.getLogger(SeataHystrixConcurrencyStrategy.class);
+
 	private HystrixConcurrencyStrategy delegate;
 
 	public SeataHystrixConcurrencyStrategy() {
@@ -53,45 +55,54 @@ public class SeataHystrixConcurrencyStrategy extends HystrixConcurrencyStrategy 
 			if (this.delegate instanceof SeataHystrixConcurrencyStrategy) {
 				return;
 			}
-			HystrixCommandExecutionHook commandExecutionHook = HystrixPlugins.getInstance().getCommandExecutionHook();
-			HystrixEventNotifier eventNotifier = HystrixPlugins.getInstance().getEventNotifier();
-			HystrixMetricsPublisher metricsPublisher = HystrixPlugins.getInstance().getMetricsPublisher();
-			HystrixPropertiesStrategy propertiesStrategy = HystrixPlugins.getInstance().getPropertiesStrategy();
-			logCurrentStateOfHystrixPlugins(eventNotifier, metricsPublisher, propertiesStrategy);
+			HystrixCommandExecutionHook commandExecutionHook = HystrixPlugins
+					.getInstance().getCommandExecutionHook();
+			HystrixEventNotifier eventNotifier = HystrixPlugins.getInstance()
+					.getEventNotifier();
+			HystrixMetricsPublisher metricsPublisher = HystrixPlugins.getInstance()
+					.getMetricsPublisher();
+			HystrixPropertiesStrategy propertiesStrategy = HystrixPlugins.getInstance()
+					.getPropertiesStrategy();
+			logCurrentStateOfHystrixPlugins(eventNotifier, metricsPublisher,
+					propertiesStrategy);
 			HystrixPlugins.reset();
 			HystrixPlugins.getInstance().registerConcurrencyStrategy(this);
-			HystrixPlugins.getInstance().registerCommandExecutionHook(commandExecutionHook);
+			HystrixPlugins.getInstance()
+					.registerCommandExecutionHook(commandExecutionHook);
 			HystrixPlugins.getInstance().registerEventNotifier(eventNotifier);
 			HystrixPlugins.getInstance().registerMetricsPublisher(metricsPublisher);
 			HystrixPlugins.getInstance().registerPropertiesStrategy(propertiesStrategy);
-		} catch (Exception ex) {
+		}
+		catch (Exception ex) {
 			logger.error("Failed to register Seata Hystrix Concurrency Strategy", ex);
 		}
 	}
 
 	private void logCurrentStateOfHystrixPlugins(HystrixEventNotifier eventNotifier,
-												 HystrixMetricsPublisher metricsPublisher,
-												 HystrixPropertiesStrategy propertiesStrategy) {
+			HystrixMetricsPublisher metricsPublisher,
+			HystrixPropertiesStrategy propertiesStrategy) {
 		if (logger.isDebugEnabled()) {
-			logger.debug("Current Hystrix plugins configuration is [" + "concurrencyStrategy [" + this.delegate + "],"
-				+ "eventNotifier [" + eventNotifier + "]," + "metricPublisher [" + metricsPublisher + "],"
-				+ "propertiesStrategy [" + propertiesStrategy + "]," + "]");
+			logger.debug("Current Hystrix plugins configuration is ["
+					+ "concurrencyStrategy [" + this.delegate + "]," + "eventNotifier ["
+					+ eventNotifier + "]," + "metricPublisher [" + metricsPublisher + "],"
+					+ "propertiesStrategy [" + propertiesStrategy + "]," + "]");
 			logger.debug("Registering Seata Hystrix Concurrency Strategy.");
 		}
 	}
 
 	@Override
-	public ThreadPoolExecutor getThreadPool(HystrixThreadPoolKey threadPoolKey, HystrixProperty<Integer> corePoolSize,
-											HystrixProperty<Integer> maximumPoolSize,
-											HystrixProperty<Integer> keepAliveTime, TimeUnit unit,
-											BlockingQueue<Runnable> workQueue) {
-		return this.delegate.getThreadPool(threadPoolKey, corePoolSize, maximumPoolSize, keepAliveTime, unit,
-			workQueue);
+	public ThreadPoolExecutor getThreadPool(HystrixThreadPoolKey threadPoolKey,
+			HystrixProperty<Integer> corePoolSize,
+			HystrixProperty<Integer> maximumPoolSize,
+			HystrixProperty<Integer> keepAliveTime, TimeUnit unit,
+			BlockingQueue<Runnable> workQueue) {
+		return this.delegate.getThreadPool(threadPoolKey, corePoolSize, maximumPoolSize,
+				keepAliveTime, unit, workQueue);
 	}
 
 	@Override
 	public ThreadPoolExecutor getThreadPool(HystrixThreadPoolKey threadPoolKey,
-											HystrixThreadPoolProperties threadPoolProperties) {
+			HystrixThreadPoolProperties threadPoolProperties) {
 		return this.delegate.getThreadPool(threadPoolKey, threadPoolProperties);
 	}
 
@@ -101,7 +112,8 @@ public class SeataHystrixConcurrencyStrategy extends HystrixConcurrencyStrategy 
 	}
 
 	@Override
-	public <T> HystrixRequestVariable<T> getRequestVariable(HystrixRequestVariableLifecycle<T> rv) {
+	public <T> HystrixRequestVariable<T> getRequestVariable(
+			HystrixRequestVariableLifecycle<T> rv) {
 		return this.delegate.getRequestVariable(rv);
 	}
 
@@ -114,14 +126,16 @@ public class SeataHystrixConcurrencyStrategy extends HystrixConcurrencyStrategy 
 		Callable<K> wrappedCallable;
 		if (this.delegate != null) {
 			wrappedCallable = this.delegate.wrapCallable(c);
-		} else {
+		}
+		else {
 			wrappedCallable = c;
 		}
 		if (wrappedCallable instanceof SeataContextCallable) {
 			return wrappedCallable;
 		}
 
-		return new SeataContextCallable<>(wrappedCallable, RequestContextHolder.getRequestAttributes());
+		return new SeataContextCallable<>(wrappedCallable,
+				RequestContextHolder.getRequestAttributes());
 	}
 
 	private static class SeataContextCallable<K> implements Callable<K> {
@@ -144,7 +158,8 @@ public class SeataHystrixConcurrencyStrategy extends HystrixConcurrencyStrategy 
 				RequestContextHolder.setRequestAttributes(requestAttributes);
 				RootContext.bind(xid);
 				return actual.call();
-			} finally {
+			}
+			finally {
 				RootContext.unbind();
 				RequestContextHolder.resetRequestAttributes();
 			}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/endpoint/SentinelEndpointAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/endpoint/SentinelEndpointAutoConfiguration.java
@@ -19,7 +19,7 @@ package com.alibaba.cloud.sentinel.endpoint;
 import com.alibaba.cloud.sentinel.SentinelProperties;
 
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
-import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnEnabledEndpoint;
+import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -36,7 +36,7 @@ public class SentinelEndpointAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	@ConditionalOnEnabledEndpoint
+	@ConditionalOnAvailableEndpoint
 	public SentinelEndpoint sentinelEndPoint(SentinelProperties sentinelProperties) {
 		return new SentinelEndpoint(sentinelProperties);
 	}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/test/java/com/alibaba/cloud/sentinel/endpoint/SentinelEndpointConditionalOnAvailableEndpointTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/test/java/com/alibaba/cloud/sentinel/endpoint/SentinelEndpointConditionalOnAvailableEndpointTests.java
@@ -29,10 +29,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class SentinelEndpointConditionalOnAvailableEndpointTests {
 
-	private  ApplicationContextRunner contextRunner;
+	private ApplicationContextRunner contextRunner;
 
 	@Before
-	public void setUp(){
+	public void setUp() {
 		contextRunner = new ApplicationContextRunner()
 				.withUserConfiguration(SentinelEndpointAutoConfiguration.class);
 	}
@@ -50,7 +50,8 @@ public class SentinelEndpointConditionalOnAvailableEndpointTests {
 		this.contextRunner
 				.withPropertyValues("management.endpoints.web.exposure.include=*",
 						"management.endpoint.sentinel.enabled=false")
-				.run((context) -> assertThat(context).doesNotHaveBean("sentinelEndPoint"));
+				.run((context) -> assertThat(context)
+						.doesNotHaveBean("sentinelEndPoint"));
 	}
 
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/test/java/com/alibaba/cloud/sentinel/endpoint/SentinelEndpointConditionalOnAvailableEndpointTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/test/java/com/alibaba/cloud/sentinel/endpoint/SentinelEndpointConditionalOnAvailableEndpointTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.sentinel.endpoint;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test cases for {@link SentinelEndpointAutoConfiguration}.
+ *
+ * @author lengleng
+ */
+public class SentinelEndpointConditionalOnAvailableEndpointTests {
+
+	private  ApplicationContextRunner contextRunner;
+
+	@Before
+	public void setUp(){
+		contextRunner = new ApplicationContextRunner()
+				.withUserConfiguration(SentinelEndpointAutoConfiguration.class);
+	}
+
+	@Test
+	public void testSentinelEndpointEnabled() {
+		this.contextRunner
+				.withPropertyValues("management.endpoints.web.exposure.include=*",
+						"management.endpoint.sentinel.enabled=true")
+				.run((context) -> assertThat(context).hasBean("sentinelEndPoint"));
+	}
+
+	@Test
+	public void testSentinelEndpointNotEnabled() {
+		this.contextRunner
+				.withPropertyValues("management.endpoints.web.exposure.include=*",
+						"management.endpoint.sentinel.enabled=false")
+				.run((context) -> assertThat(context).doesNotHaveBean("sentinelEndPoint"));
+	}
+
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/test/java/com/alibaba/cloud/sentinel/endpoint/SentinelEndpointConditionalOnAvailableEndpointTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/test/java/com/alibaba/cloud/sentinel/endpoint/SentinelEndpointConditionalOnAvailableEndpointTests.java
@@ -18,6 +18,7 @@ package com.alibaba.cloud.sentinel.endpoint;
 
 import org.junit.Before;
 import org.junit.Test;
+
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/actuate/DubboMetadataEndpointAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/actuate/DubboMetadataEndpointAutoConfiguration.java
@@ -18,7 +18,7 @@ package com.alibaba.cloud.dubbo.actuate;
 
 import com.alibaba.cloud.dubbo.actuate.endpoint.DubboRestMetadataEndpoint;
 
-import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnEnabledEndpoint;
+import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -39,7 +39,7 @@ public class DubboMetadataEndpointAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	@ConditionalOnEnabledEndpoint
+	@ConditionalOnAvailableEndpoint
 	public DubboRestMetadataEndpoint dubboRestMetadataEndpoint() {
 		return new DubboRestMetadataEndpoint();
 	}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/RocketMQMessageChannelBinder.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/RocketMQMessageChannelBinder.java
@@ -169,8 +169,8 @@ public class RocketMQMessageChannelBinder extends
 					rocketMQTemplate, destination.getName(), producerGroup,
 					producerProperties.getExtension().getTransactional(),
 					instrumentationManager, producerProperties,
-					((AbstractMessageChannel) channel).getInterceptors().stream()
-							.filter(channelInterceptor -> channelInterceptor instanceof MessageConverterConfigurer.PartitioningInterceptor)
+					((AbstractMessageChannel) channel).getInterceptors().stream().filter(
+							channelInterceptor -> channelInterceptor instanceof MessageConverterConfigurer.PartitioningInterceptor)
 							.map(channelInterceptor -> ((MessageConverterConfigurer.PartitioningInterceptor) channelInterceptor))
 							.findFirst().orElse(null));
 			messageHandler.setBeanFactory(this.getApplicationContext().getBeanFactory());


### PR DESCRIPTION
### Describe what this PR does / why we need it

Our team upgraded to spring boot 2.3.1.There is no compatibility problem in the current test spring cloud alibaba 2.2.1.

Detailed about endpoint ，In spring 2.2.X `@ConditionalOnAvailableEndpoint` 

```
 * @author Stephane Nicoll
 * @since 2.0.0
 * @see Endpoint
 * @deprecated as of 2.2.0 in favor of
 * {@link ConditionalOnAvailableEndpoint @ConditionalOnAvailableEndpoint}
 */
@Retention(RetentionPolicy.RUNTIME)
@Target({ ElementType.METHOD, ElementType.TYPE })
@Documented
@Conditional(OnEnabledEndpointCondition.class)
@Deprecated
public @interface ConditionalOnEnabledEndpoint {}
```
spring boot 2.3.X removed  this annotation  ，replace with `@ConditionalOnEnabledEndpoint`

### Does this pull request fix one issue?
no
### Describe how you did it

replace with `@ConditionalOnEnabledEndpoint`

### Describe how to verify it

run NacosDiscoveryEndpointConditionalOnAvailableEndpointTests
SentinelEndpointConditionalOnAvailableEndpointTests


