### PR TITLE
to avoid k8s readinessProbe remove the pod

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/endpoint/SentinelHealthIndicator.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/endpoint/SentinelHealthIndicator.java
@@ -105,7 +105,7 @@ public class SentinelHealthIndicator extends AbstractHealthIndicator {
 				// If failed to send heartbeat message, means that the Dashboard is DOWN
 				dashboardUp = false;
 				detailMap.put("dashboard",
-						new Status(Status.DOWN.getCode(), String.format(
+						new Status(Status.UNKNOWN.getCode(), String.format(
 								"the dashboard servers [%s] one of them can't be connected",
 								consoleServerList)));
 			}
@@ -138,7 +138,7 @@ public class SentinelHealthIndicator extends AbstractHealthIndicator {
 				// DOWN
 				dataSourceUp = false;
 				dataSourceDetailMap.put(dataSourceBeanName,
-						new Status(Status.DOWN.getCode(), e.getMessage()));
+						new Status(Status.UNKNOWN.getCode(), e.getMessage()));
 			}
 		}
 
@@ -147,7 +147,7 @@ public class SentinelHealthIndicator extends AbstractHealthIndicator {
 			builder.up().withDetails(detailMap);
 		}
 		else {
-			builder.down().withDetails(detailMap);
+			builder.unknown().withDetails(detailMap);
 		}
 	}
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/test/java/com/alibaba/cloud/sentinel/endpoint/SentinelHealthIndicatorTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/test/java/com/alibaba/cloud/sentinel/endpoint/SentinelHealthIndicatorTests.java
@@ -109,9 +109,9 @@ public class SentinelHealthIndicatorTests {
 
 		Health health = sentinelHealthIndicator.health();
 
-		assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+		assertThat(health.getStatus()).isEqualTo(Status.UNKNOWN);
 		assertThat(health.getDetails().get("dashboard")).isEqualTo(
-				new Status(Status.DOWN.getCode(), "localhost:8080 can't be connected"));
+				new Status(Status.UNKNOWN.getCode(), "localhost:8080 can't be connected"));
 	}
 
 	@Test
@@ -169,7 +169,7 @@ public class SentinelHealthIndicatorTests {
 		assertThat(dataSourceDetailMap.get("ds1-sentinel-file-datasource"))
 				.isEqualTo(Status.UP);
 		assertThat(dataSourceDetailMap.get("ds2-sentinel-file-datasource"))
-				.isEqualTo(new Status(Status.DOWN.getCode(), "fileDataSource2 error"));
+				.isEqualTo(new Status(Status.UNKNOWN.getCode(), "fileDataSource2 error"));
 	}
 
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/test/java/com/alibaba/cloud/sentinel/endpoint/SentinelHealthIndicatorTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/test/java/com/alibaba/cloud/sentinel/endpoint/SentinelHealthIndicatorTests.java
@@ -163,7 +163,7 @@ public class SentinelHealthIndicatorTests {
 
 		Health health = sentinelHealthIndicator.health();
 
-		assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+		assertThat(health.getStatus()).isEqualTo(Status.UNKNOWN);
 		Map<String, Status> dataSourceDetailMap = (Map<String, Status>) health
 				.getDetails().get("dataSource");
 		assertThat(dataSourceDetailMap.get("ds1-sentinel-file-datasource"))


### PR DESCRIPTION

### Describe what this PR does / why we need it
For sentinel , we just no need remove the pod just because of the dashboard unreachable.
If sentinel dashboard crash , we will remove the pod just because indicator mark down. 
It's bad to do like this. 

### Does this pull request fix one issue?

https://github.com/alibaba/spring-cloud-alibaba/issues/842 

### Describe how you did it
We mark just UNKNOWN so the healthIndicator will return https status 200.

### Describe how to verify it
Killing dashboard , then will return 200 other then 503

### Special notes for reviews
