### PR TITLE
Add one missing configuration item

### DIFF
--- a/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/readme.md
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/readme.md
@@ -207,6 +207,7 @@ Metadata|spring.cloud.nacos.discovery.metadata||Extended data, Configure using M
 log name|spring.cloud.nacos.discovery.log-name||
 endpoint|spring.cloud.nacos.discovery.endpoint||The domain name of a service, through which the server address can be dynamically obtained.
 Integration Ribbon|ribbon.nacos.enabled|true|
+enabled|spring.cloud.nacos.discovery.enabled|true|The switch to enable or disable nacos service discovery
 
 
 


### PR DESCRIPTION
### Describe what this PR does / why we need it
There is an important, yet missing option spring.cloud.nacos.discovery.enabled.

### Does this pull request fix one issue?
No
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
I added this option's description by following  the "More configuration items" format.

### Describe how to verify it
Ran the nacos example code.

### Special notes for reviews
None