### PR TITLE
maven project name change

### DIFF
--- a/spring-cloud-alibaba-examples/seata-example/order-service/pom.xml
+++ b/spring-cloud-alibaba-examples/seata-example/order-service/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>order-service</artifactId>
-    <name>Spring Cloud Starter Alibaba Seata Example - Business Service</name>
+    <name>Spring Cloud Starter Alibaba Seata Example - Order Service</name>
     <packaging>jar</packaging>
 
     <dependencies>


### PR DESCRIPTION
示例项目中的 spring-cloud-alibaba-examples=>seata-example=>order-service=>pom.xml中的maven name写错了，写成了
Spring Cloud Starter Alibaba Seata Example - Business Service
猜测应该是复制的时候没有改正，已改为
Spring Cloud Starter Alibaba Seata Example - Order Service