### PR TITLE
Add grpc-adapter to spring-cloud-alibaba-dependencies

### DIFF
--- a/spring-cloud-alibaba-dependencies/pom.xml
+++ b/spring-cloud-alibaba-dependencies/pom.xml
@@ -178,6 +178,12 @@
                 <version>${sentinel.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>com.alibaba.csp</groupId>
+                <artifactId>sentinel-logging-slf4j</artifactId>
+                <version>${sentinel.version}</version>
+            </dependency>
+
             <!--Alibaba Seata-->
             <dependency>
                 <groupId>io.seata</groupId>

--- a/spring-cloud-alibaba-dependencies/pom.xml
+++ b/spring-cloud-alibaba-dependencies/pom.xml
@@ -172,6 +172,12 @@
                 <version>${sentinel.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>com.alibaba.csp</groupId>
+                <artifactId>sentinel-grpc-adapter</artifactId>
+                <version>${sentinel.version}</version>
+            </dependency>
+
             <!--Alibaba Seata-->
             <dependency>
                 <groupId>io.seata</groupId>


### PR DESCRIPTION
### Describe what this PR does / why we need it

`grpc-adapter` is missing from the platform dependencies. If you use `spring-cloud-alibaba-dependencies` and need the `grpc-adapter` then you need to add the appropriate dependency version manually.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

NONE

### Describe how you did it

Just added the missing dep

### Describe how to verify it

Add grpc-adapter as dependency with the platform, the version for it should be resolved automatically.

### Special notes for reviews
