### PR TITLE
feat: sentinel dashboard support set context-path

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/SentinelProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/SentinelProperties.java
@@ -304,6 +304,12 @@ public class SentinelProperties {
 		private String dashboard = "";
 
 		/**
+		 * Sentinel dashboard heartbeat api path, default value is '/registry/machine'.
+		 * {@link TransportConfig#HEARTBEAT_API_PATH}.
+		 */
+		private String apiPath;
+
+		/**
 		 * Send heartbeat interval millisecond
 		 * {@link TransportConfig#HEARTBEAT_INTERVAL_MS}.
 		 */
@@ -337,6 +343,14 @@ public class SentinelProperties {
 
 		public void setDashboard(String dashboard) {
 			this.dashboard = dashboard;
+		}
+
+		public String getApiPath() {
+			return apiPath;
+		}
+
+		public void setApiPath(String apiPath) {
+			this.apiPath = apiPath;
 		}
 
 		public String getClientIp() {

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/custom/SentinelAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/custom/SentinelAutoConfiguration.java
@@ -92,6 +92,11 @@ public class SentinelAutoConfiguration {
 			System.setProperty(TransportConfig.CONSOLE_SERVER,
 					properties.getTransport().getDashboard());
 		}
+		if (StringUtils.isEmpty(System.getProperty(TransportConfig.HEARTBEAT_API_PATH))
+				&& StringUtils.hasText(properties.getTransport().getApiPath())) {
+			System.setProperty(TransportConfig.HEARTBEAT_API_PATH,
+					properties.getTransport().getApiPath());
+		}
 		if (StringUtils.isEmpty(System.getProperty(TransportConfig.HEARTBEAT_INTERVAL_MS))
 				&& StringUtils
 						.hasText(properties.getTransport().getHeartbeatIntervalMs())) {

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/test/java/com/alibaba/cloud/sentinel/SentinelAutoConfigurationTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/test/java/com/alibaba/cloud/sentinel/SentinelAutoConfigurationTests.java
@@ -73,6 +73,7 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 				"spring.cloud.sentinel.eager=true",
 				"spring.cloud.sentinel.log.switchPid=true",
 				"spring.cloud.sentinel.transport.dashboard=http://localhost:8080,http://localhost:8081",
+				"spring.cloud.sentinel.transport.apiPath=/sentinel/registry/machine",
 				"spring.cloud.sentinel.transport.port=9999",
 				"spring.cloud.sentinel.transport.clientIp=1.1.1.1",
 				"spring.cloud.sentinel.transport.heartbeatIntervalMs=20000" },
@@ -169,6 +170,8 @@ public class SentinelAutoConfigurationTests {
 		assertThat(sentinelProperties.getTransport().getPort()).isEqualTo("9999");
 		assertThat(sentinelProperties.getTransport().getDashboard())
 				.isEqualTo("http://localhost:8080,http://localhost:8081");
+		assertThat(sentinelProperties.getTransport().getApiPath())
+				.isEqualTo("/sentinel/registry/machine");
 		assertThat(sentinelProperties.getTransport().getClientIp()).isEqualTo("1.1.1.1");
 		assertThat(sentinelProperties.getTransport().getHeartbeatIntervalMs())
 				.isEqualTo("20000");
@@ -192,6 +195,8 @@ public class SentinelAutoConfigurationTests {
 		assertThat(TransportConfig.getHeartbeatIntervalMs().longValue())
 				.isEqualTo(20000L);
 		assertThat(TransportConfig.getHeartbeatClientIp()).isEqualTo("1.1.1.1");
+		assertThat(TransportConfig.getHeartbeatApiPath())
+				.isEqualTo("/sentinel/registry/machine");
 		assertThat(SentinelConfig.singleMetricFileSize()).isEqualTo(9999);
 		assertThat(SentinelConfig.totalMetricFileCount()).isEqualTo(100);
 		assertThat(SentinelConfig.charset()).isEqualTo("UTF-8");


### PR DESCRIPTION
### Describe what this PR does / why we need it
[#1818](https://github.com/alibaba/spring-cloud-alibaba/issues/1818)
[Sentinel dashboard feat #1851](https://github.com/alibaba/Sentinel/pull/1851)

### Does this pull request fix one issue?
NONE
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
Add heartbeat api path configuration

### Describe how to verify it
Sentinel dashboard set context-path
```
java -jar sentinel-dashboard-1.8.1-SNAPSHOT.jar --server.port=8080 --server.servlet.context-path=/sentinel
```
Test application add `spring.cloud.sentinel.transport.apiPath`, eg:
```
spring:
  cloud:
    sentinel:
      transport:
        dashboard: localhost:8080
        api-path: /sentinel/registry/machine
```

### Special notes for reviews
Use Sentinel Dashboard, last version 1.8.1-SNAPSHOT