### PR TITLE
Solve the problem that NacosDiscoveryClientConfigServiceBootstrapConfiguration loading cannot find NacosServiceManager

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/resources/META-INF/spring.factories
@@ -8,4 +8,5 @@ org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
   com.alibaba.cloud.nacos.discovery.configclient.NacosConfigServerAutoConfiguration,\
   com.alibaba.cloud.nacos.NacosServiceAutoConfiguration
 org.springframework.cloud.bootstrap.BootstrapConfiguration=\
+  com.alibaba.cloud.nacos.NacosServiceAutoConfiguration,\
   com.alibaba.cloud.nacos.discovery.configclient.NacosDiscoveryClientConfigServiceBootstrapConfiguration


### PR DESCRIPTION
Solve the problem that NacosDiscoveryClientConfigServiceBootstrapConfiguration loading cannot find NacosServiceManager