### PR TITLE
BugFix: remote yaml config in nacos config center cannot be parsed correctly

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/parser/NacosDataYamlParser.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/parser/NacosDataYamlParser.java
@@ -19,7 +19,7 @@ package com.alibaba.cloud.nacos.parser;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.springframework.beans.factory.config.YamlMapFactoryBean;
+import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
 import org.springframework.core.io.ByteArrayResource;
 
 /**
@@ -33,11 +33,11 @@ public class NacosDataYamlParser extends AbstractNacosDataParser {
 
 	@Override
 	protected Map<String, Object> doParse(String data) {
-		YamlMapFactoryBean yamlFactory = new YamlMapFactoryBean();
+		YamlPropertiesFactoryBean yamlFactory = new YamlPropertiesFactoryBean();
 		yamlFactory.setResources(new ByteArrayResource(data.getBytes()));
 
-		Map<String, Object> result = new LinkedHashMap<>();
-		flattenedMap(result, yamlFactory.getObject(), EMPTY_STRING);
+		Map properties = yamlFactory.getObject();
+		Map<String, Object> result = new LinkedHashMap<>(properties);
 		return result;
 	}
 


### PR DESCRIPTION
### Describe what this PR does / why we need it
Fixing the bug that some yaml configurations which work in local application.yml don't work in nacos config center.
For instance,
zuul:
——sensitive-headers:
——user:
———path:/user/**
———serviceId:user-center
In local application.yml,the config will be parsed into 'zuul.sensitive-headers:""',

but nacos client will parse the same config from nacos center into 'zuul.sensitive-headers:null'.

As we know, zuul will delete "cookie","set-cookie","Authentication" headers by default.
If we need to pass these headers to downstream services,we need to declare relevant config a 'default' explicitly to cover the default config,
such as 'zuul.sensitive-headers=' in '.properties' file or
zuul:
 ——sensitive-headers:
in '.yml' file.
The nacos properties parser can correctly pase 'zuul.sensitive-headers=' into 'zuul.sensitive-headers:""',while the yaml parser cannot.
So I reconstruct the yaml parser with same parser which springboot use to parse 'application.yml'.
In this case,the same yaml configurations will lead to the same result whether they're stored in local application.yml or in nacos config center.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
NONE
### Describe how you did it
Rewriting NacosDataYamlParser with the yamlFactoryBean used by springboot.

### Describe how to verify it
1.Build a zuul gateway springboot project.
2.Enable nacos config center
3.Create nacos config with the content below
zuul:
     sensitive-headers:
4.Create break point at the last line in PropertySourceBootstrapConfiguration.initialize()
5.Debug the zuul gateway
6.Watching applicationContext.environment and you will discover the 'zuul:/r/n	sensitive-headers:' was parsed into key-value 'zuul.sensitive-headers:null'
7.And my PR will make sure 'zuul:/r/n	sensitive-headers:' will be parsed into 'zuul.sensitive-headers:""'.
### Special notes for reviews
Fixing the bug that some yaml configurations which work in local application.yml don't work in nacos config center.
修正部分nacos yaml格式远程配置无法正确生效的问题。