### PR TITLE
不应该使用类实例访问静态成员\不应该直接使用不确定的值调用equals容易空指针\final static应该使用大写命名并且使用下划线

### DIFF
--- a/spring-cloud-alibaba-examples/rocketmq-example/rocketmq-produce-example/src/main/java/com/alibaba/cloud/examples/RocketMQProduceApplication.java
+++ b/spring-cloud-alibaba-examples/rocketmq-example/rocketmq-produce-example/src/main/java/com/alibaba/cloud/examples/RocketMQProduceApplication.java
@@ -83,7 +83,7 @@ public class RocketMQProduceApplication {
 
 		@Override
 		public void run(String... args) throws Exception {
-			if (this.bindingName.equals("output1")) {
+			if ("output1".equals(this.bindingName)) {
 				int count = 5;
 				for (int index = 1; index <= count; index++) {
 					String msgContent = "msg-" + index;
@@ -98,7 +98,7 @@ public class RocketMQProduceApplication {
 					}
 				}
 			}
-			else if (this.bindingName.equals("output3")) {
+			else if ("output3".equals(this.bindingName)) {
 				int count = 20;
 				for (int index = 1; index <= count; index++) {
 					String msgContent = "pullMsg-" + index;

--- a/spring-cloud-alibaba-examples/sentinel-example/sentinel-zuul-example/src/main/java/com/alibaba/cloud/examples/ZuulConfiguration.java
+++ b/spring-cloud-alibaba-examples/sentinel-example/sentinel-zuul-example/src/main/java/com/alibaba/cloud/examples/ZuulConfiguration.java
@@ -41,10 +41,10 @@ public class ZuulConfiguration {
 
 			@Override
 			public BlockResponse fallbackResponse(String route, Throwable cause) {
-				if (route.equals("my-service3")) {
+				if ("my-service3".equals(route)) {
 					return new BlockResponse(433, "Sentinel Block3", route);
 				}
-				else if (route.equals("my-service4")) {
+				else if ("my-service4".equals(route)) {
 					return new BlockResponse(444, "my-service4", route);
 				}
 				else {

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-gateway/src/main/java/com/alibaba/cloud/sentinel/gateway/ConfigConstants.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-gateway/src/main/java/com/alibaba/cloud/sentinel/gateway/ConfigConstants.java
@@ -37,7 +37,7 @@ public final class ConfigConstants {
 	/**
 	 * ConfigurationProperties for {@link SentinelZuulProperties}.
 	 */
-	public static final String ZUUl_PREFIX = "spring.cloud.sentinel.zuul";
+	public static final String ZUUL_PREFIX = "spring.cloud.sentinel.zuul";
 
 	/**
 	 * ConfigurationProperties for {@link SentinelGatewayProperties}.

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-gateway/src/main/java/com/alibaba/cloud/sentinel/gateway/zuul/SentinelZuulAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-gateway/src/main/java/com/alibaba/cloud/sentinel/gateway/zuul/SentinelZuulAutoConfiguration.java
@@ -47,7 +47,7 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(ZuulServlet.class)
-@ConditionalOnProperty(prefix = ConfigConstants.ZUUl_PREFIX, name = "enabled",
+@ConditionalOnProperty(prefix = ConfigConstants.ZUUL_PREFIX, name = "enabled",
 		havingValue = "true", matchIfMissing = true)
 @EnableConfigurationProperties(SentinelZuulProperties.class)
 public class SentinelZuulAutoConfiguration {

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-gateway/src/main/java/com/alibaba/cloud/sentinel/gateway/zuul/SentinelZuulProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-gateway/src/main/java/com/alibaba/cloud/sentinel/gateway/zuul/SentinelZuulProperties.java
@@ -28,7 +28,7 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
 /**
  * @author <a href="mailto:fangjian0423@gmail.com">Jim</a>
  */
-@ConfigurationProperties(prefix = ConfigConstants.ZUUl_PREFIX)
+@ConfigurationProperties(prefix = ConfigConstants.ZUUL_PREFIX)
 public class SentinelZuulProperties {
 
 	@NestedConfigurationProperty

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosServiceRegistry.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosServiceRegistry.java
@@ -119,7 +119,7 @@ public class NacosServiceRegistry implements ServiceRegistry<Registration> {
 	@Override
 	public void setStatus(Registration registration, String status) {
 
-		if (!status.equalsIgnoreCase("UP") && !status.equalsIgnoreCase("DOWN")) {
+		if (!"UP".equalsIgnoreCase(status) && !"DOWN".equalsIgnoreCase(status)) {
 			log.warn("can't support status {},please choose UP or DOWN", status);
 			return;
 		}
@@ -128,7 +128,7 @@ public class NacosServiceRegistry implements ServiceRegistry<Registration> {
 
 		Instance instance = getNacosInstanceFromRegistration(registration);
 
-		if (status.equalsIgnoreCase("DOWN")) {
+		if ("DOWN".equalsIgnoreCase(status)) {
 			instance.setEnabled(false);
 		}
 		else {

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/registry/AbstractSpringCloudRegistry.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/registry/AbstractSpringCloudRegistry.java
@@ -77,7 +77,7 @@ public abstract class AbstractSpringCloudRegistry extends FailbackRegistry {
 	/**
 	 * Caches the IDs of {@link ApplicationListener}.
 	 */
-	private static final Set<String> registerListeners = new HashSet<>();
+	private static final Set<String> REGISTER_LISTENERS = new HashSet<>();
 
 	protected final Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -193,7 +193,7 @@ public abstract class AbstractSpringCloudRegistry extends FailbackRegistry {
 	private void registerServiceInstancesChangedEventListener(URL url,
 			NotifyListener listener) {
 		String listenerId = generateId(url);
-		if (registerListeners.add(listenerId)) {
+		if (REGISTER_LISTENERS.add(listenerId)) {
 			applicationContext.addApplicationListener(
 					new ApplicationListener<ServiceInstancesChangedEvent>() {
 						@Override
@@ -261,7 +261,7 @@ public abstract class AbstractSpringCloudRegistry extends FailbackRegistry {
 				String listenerId = generateId(url);
 				// The metaservice will restart the new listener. It needs to be optimized
 				// to see whether the original listener can be reused.
-				this.registerListeners.remove(listenerId);
+				REGISTER_LISTENERS.remove(listenerId);
 			}
 
 			/**

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/registry/DubboCloudRegistry.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/registry/DubboCloudRegistry.java
@@ -83,7 +83,7 @@ public class DubboCloudRegistry extends FailbackRegistry {
 	/**
 	 * Caches the IDs of {@link ApplicationListener}.
 	 */
-	private static final Set<String> registerListeners = new HashSet<>();
+	private static final Set<String> REGISTER_LISTENERS = new HashSet<>();
 
 	protected final Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -215,7 +215,7 @@ public class DubboCloudRegistry extends FailbackRegistry {
 	private void registerServiceInstancesChangedListener(URL url,
 			ApplicationListener<ServiceInstancesChangedEvent> listener) {
 		String listenerId = generateId(url);
-		if (registerListeners.add(listenerId)) {
+		if (REGISTER_LISTENERS.add(listenerId)) {
 			applicationContext.addApplicationListener(listener);
 		}
 	}


### PR DESCRIPTION
不应该使用类实例访问静态成员\不应该直接使用不确定的值调用equals容易空指针\final static应该使用大写命名并且使用下划线