### PR TITLE
Map/Set的key为自定义对象时，必须重写hashcode和equals方法

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/http/matcher/ConsumeMediaTypeExpression.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/http/matcher/ConsumeMediaTypeExpression.java
@@ -42,4 +42,13 @@ class ConsumeMediaTypeExpression extends AbstractMediaTypeExpression {
 		return (!isNegated() ? match : !match);
 	}
 
+	@Override
+	public boolean equals(Object other) {
+		return super.equals(other);
+	}
+
+	@Override
+	public int hashCode() {
+		return super.hashCode();
+	}
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/http/matcher/HeaderExpression.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/http/matcher/HeaderExpression.java
@@ -59,4 +59,13 @@ class HeaderExpression extends AbstractNameValueExpression<String> {
 		return ObjectUtils.nullSafeEquals(this.value, headerValue);
 	}
 
+	@Override
+	public boolean equals(Object other) {
+		return super.equals(other);
+	}
+
+	@Override
+	public int hashCode() {
+		return super.hashCode();
+	}
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/http/matcher/ParamExpression.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/http/matcher/ParamExpression.java
@@ -61,4 +61,13 @@ class ParamExpression extends AbstractNameValueExpression<String> {
 		return ObjectUtils.nullSafeEquals(this.value, parameterValue);
 	}
 
+	@Override
+	public boolean equals(Object other) {
+		return super.equals(other);
+	}
+
+	@Override
+	public int hashCode() {
+		return super.hashCode();
+	}
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/http/matcher/ProduceMediaTypeExpression.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/http/matcher/ProduceMediaTypeExpression.java
@@ -53,4 +53,13 @@ class ProduceMediaTypeExpression extends AbstractMediaTypeExpression {
 		return false;
 	}
 
+	@Override
+	public boolean equals(Object other) {
+		return super.equals(other);
+	}
+
+	@Override
+	public int hashCode() {
+		return super.hashCode();
+	}
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/http/matcher/RequestMetadataMatcher.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/http/matcher/RequestMetadataMatcher.java
@@ -45,4 +45,14 @@ public class RequestMetadataMatcher extends CompositeHttpRequestMatcher {
 						metadata.getProduces().toArray(new String[0])));
 	}
 
+
+	@Override
+	public boolean equals(Object other) {
+		return super.equals(other);
+	}
+
+	@Override
+	public int hashCode() {
+		return super.hashCode();
+	}
 }


### PR DESCRIPTION
按照规范 ： Map/Set的key为自定义对象时，必须重写hashcode和equals方法