### PR TITLE
修复引入sleuth和seata时，出现TracingFeignClient和LazyTracingFeignClient无限相互调用导致栈溢出的bug

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/java/com/alibaba/cloud/seata/feign/SeataFeignBlockingLoadBalancerClient.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/java/com/alibaba/cloud/seata/feign/SeataFeignBlockingLoadBalancerClient.java
@@ -28,7 +28,7 @@ import org.springframework.cloud.openfeign.loadbalancer.FeignBlockingLoadBalance
 /**
  * @author yuhuangbin
  */
-public class SeataFeignBlockingLoadBalancerClient
+public final class SeataFeignBlockingLoadBalancerClient
 		extends FeignBlockingLoadBalancerClient {
 
 	public SeataFeignBlockingLoadBalancerClient(Client delegate,

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/java/com/alibaba/cloud/seata/feign/SeataLoadBalancerFeignClient.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/java/com/alibaba/cloud/seata/feign/SeataLoadBalancerFeignClient.java
@@ -30,7 +30,7 @@ import org.springframework.cloud.openfeign.ribbon.LoadBalancerFeignClient;
  * @author xiaojing
  * @author yuhuangbin
  */
-public class SeataLoadBalancerFeignClient extends LoadBalancerFeignClient {
+public final class SeataLoadBalancerFeignClient extends LoadBalancerFeignClient {
 
 	SeataLoadBalancerFeignClient(Client delegate,
 			CachingSpringLoadBalancerFactory lbClientFactory,


### PR DESCRIPTION
### 背景

当同时引入sleuth和seata时，出现TracingFeignClient和LazyTracingFeignClient无限相互调用最终导致栈溢出，如下图所示：

```
	at org.springframework.cloud.sleuth.instrument.web.client.feign.TracingFeignClient.execute(TracingFeignClient.java:81)
	at org.springframework.cloud.sleuth.instrument.web.client.feign.LazyTracingFeignClient.execute(LazyTracingFeignClient.java:60)
	at org.springframework.cloud.sleuth.instrument.web.client.feign.TracingFeignClient.execute(TracingFeignClient.java:81)
	at org.springframework.cloud.sleuth.instrument.web.client.feign.LazyTracingFeignClient.execute(LazyTracingFeignClient.java:60)
	at org.springframework.cloud.sleuth.instrument.web.client.feign.TracingFeignClient.execute(TracingFeignClient.java:81)
	at org.springframework.cloud.sleuth.instrument.web.client.feign.LazyTracingFeignClient.execute(LazyTracingFeignClient.java:60)
	at org.springframework.cloud.sleuth.instrument.web.client.feign.TracingFeignClient.execute(TracingFeignClient.java:81)
...
...
```

可以参考issue: https://github.com/alibaba/spring-cloud-alibaba/issues/1909

下载里面提供的工程，本地使用postman压测，大概调用1000多次的时候就会出现栈溢出，你可以设置postman压力测试调用10000次。

### 原因

通过跟踪源码，发现每次调用到`SeataLoadBalancerFeignClient.execute()`的时候都会进入`TraceFeignAspect`切面，这个切面的代码如下：

![image](https://user-images.githubusercontent.com/42676983/104609793-60a2f780-56be-11eb-9c95-5451d1381735.png)

在这里会对`SeataLoadBalancerFeignClient`进行增强，`wrap()`方法如下所示：

![image](https://user-images.githubusercontent.com/42676983/104610138-bd061700-56be-11eb-802f-d490187fb9af.png)

此时，会进入第一个条件分支，里面的代码如下：

![image](https://user-images.githubusercontent.com/42676983/104610268-e0c95d00-56be-11eb-8d53-cc5d8e8f0afb.png)

然后，这里会发现，把`SeataLoadBalancerFeignClient`的`delegate`属性重新包装并赋值了，而这个包装的方法依然是上面的方法，只是会走到最后一个分支，也就是创建`LazyTracingFeignClient`对象并赋值给`SeataLoadBalancerFeignClient`的`delegate`的属性，为了方便我把图重新截一下：

![image](https://user-images.githubusercontent.com/42676983/104610623-40276d00-56bf-11eb-9871-556b93d1131a.png)

此时，新创建的`LazyTracingFeignClient`对象是没有`tracingFeignClient`属性的。

下面，我们再看看`LazyTracingFeignClient`的`execute()`方法：

![image](https://user-images.githubusercontent.com/42676983/104610813-651be000-56bf-11eb-94c1-b448695cd916.png)

可以看到，当调用`LazyTracingFeignClient`的`execute()`方法时，判断`tracingFeignClient`为空就重新创建一个。

这就出现了一个神奇的现象，每次调用都会进入`TraceFeignAspect`切面，在这个切面里面每次都会重新创建新的`LazyTracingFeignClient`对象重新赋值给`SeataLoadBalancerFeignClient`的`delegate`属性，同时，把其旧的`delegate`属性作为新的`LazyTracingFeignClient`对象的`delegate`（此时已经形成delegate死链），而每次调用到`LazyTracingFeignClient`的`execute()`方法，又都会创建新的`TracingFeignClient`对象作为`LazyTracingFeignClient`的`tracingFeignClient`属性，这样，就形成了一个链条，而且，这个链条是每调用一次就增加一环，最终，当这个链条足够长时，就导致了栈溢出（StackOverFlow）。

所以，要想解决这个问题，从源头上，只要不让`SeataLoadBalancerFeignClient`进入切面即可，观察这个切面，我们发现不是final类才会进来，所以，只要把`SeataLoadBalancerFeignClient`类改成final类型即可，同理，`SeataFeignBlockingLoadBalancerClient`亦如此。

![image](https://user-images.githubusercontent.com/42676983/104611821-803b1f80-56c0-11eb-90e8-af71d63a1fdd.png)

修改之后，通过postman压测10000个请求没有再出现栈溢出的问题。

### 调试方法

 - 在`org.springframework.cloud.sleuth.instrument.web.client.feign.TraceFeignObjectWrapper#wrap`里面打个断点，跟踪每次增强的过程
 - 在`org.springframework.cloud.sleuth.instrument.web.client.feign.LazyTracingFeignClient#execute`里面打个断点，跟踪每次循环调用的过程