### PR TITLE
修复dubbo使用服务分组和分组聚合获取不到url

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/metadata/repository/DubboServiceMetadataRepository.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/metadata/repository/DubboServiceMetadataRepository.java
@@ -19,6 +19,7 @@ package com.alibaba.cloud.dubbo.metadata.repository;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -41,6 +42,7 @@ import com.alibaba.cloud.dubbo.util.JSONUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.constants.CommonConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -407,8 +409,34 @@ public class DubboServiceMetadataRepository
 
 	public List<URL> getExportedURLs(String serviceInterface, String group,
 			String version) {
-		String serviceKey = URL.buildKey(serviceInterface, group, version);
-		return allExportedURLs.getOrDefault(serviceKey, Collections.emptyList());
+		if (group != null) {
+			List<URL> urls = new LinkedList<>();
+			if (CommonConstants.ANY_VALUE.equals(group)) {
+				String serviceKey = URL.buildKey(serviceInterface, group, version);
+				String expectKey = serviceKey.substring(2);
+				for (String key : allExportedURLs.keySet()) {
+					if (key.endsWith(expectKey)) {
+						urls.addAll(allExportedURLs.get(key));
+					}
+				}
+			}
+			else {
+				String[] groups = group.split(CommonConstants.COMMA_SEPARATOR);
+				for (String expectKey : groups) {
+					String serviceKey = URL.buildKey(serviceInterface, expectKey,
+							version);
+					List<URL> urlList = allExportedURLs.get(serviceKey);
+					if (urlList != null) {
+						urls.addAll(urlList);
+					}
+				}
+			}
+			return urls;
+		}
+		else {
+			String serviceKey = URL.buildKey(serviceInterface, null, version);
+			return allExportedURLs.getOrDefault(serviceKey, Collections.emptyList());
+		}
 	}
 
 	/**


### PR DESCRIPTION
修复问题：

1. 使用服务分组，当`group`是多个的情况下（例如`group="provider1,provider2"`），获取不到服务提供者
2. 使用分组聚合，当`group`是多个的时候下（`group="provider1,provider2"`）或者为`*`（`group="*"`）的情况下，获取不到服务提供者

修改`com.alibaba.cloud.dubbo.metadata.repository.DubboServiceMetadataRepository#getExportedURLs`判断group为多个或者*的情况

```java
	public List<URL> getExportedURLs(String serviceInterface, String group,
			String version) {
		if (group != null) {
			List<URL> urls = new LinkedList<>();
			if (CommonConstants.ANY_VALUE.equals(group)) {
				String serviceKey = URL.buildKey(serviceInterface, group, version);
				String expectKey = serviceKey.substring(2);
				for (String key : allExportedURLs.keySet()) {
					if (key.endsWith(expectKey)) {
						urls.addAll(allExportedURLs.get(key));
					}
				}
			}
			else {
				String[] groups = group.split(CommonConstants.COMMA_SEPARATOR);
				for (String expectKey : groups) {
					String serviceKey = URL.buildKey(serviceInterface, expectKey,
							version);
					List<URL> urlList = allExportedURLs.get(serviceKey);
					if (urlList != null) {
						urls.addAll(urlList);
					}
				}
			}
			return urls;
		}
		else {
			String serviceKey = URL.buildKey(serviceInterface, null, version);
			return allExportedURLs.getOrDefault(serviceKey, Collections.emptyList());
		}
	}
```