### PR TITLE
bugfix invokers metadata tag error

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/registry/DubboCloudRegistry.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/registry/DubboCloudRegistry.java
@@ -308,6 +308,16 @@ public class DubboCloudRegistry extends FailbackRegistry {
 						String protocol = templateURL.getProtocol();
 						Integer port = repository.getDubboProtocolPort(serviceInstance,
 								protocol);
+
+						// reserve tag
+						String tag = null;
+						List<URL> urls = jsonUtils.toURLs(serviceInstance.getMetadata()
+								.get("dubbo.metadata-service.urls"));
+						if (urls != null && urls.size() > 0) {
+							Map<String, String> parameters = urls.get(0).getParameters();
+							tag = parameters.get("dubbo.tag");
+						}
+
 						if (Objects.equals(templateURL.getHost(), host)
 								&& Objects.equals(templateURL.getPort(), port)) { // use
 							// templateURL
@@ -331,7 +341,8 @@ public class DubboCloudRegistry extends FailbackRegistry {
 									// the template
 									// URL
 									.setHost(host) // reset the host
-									.setPort(port); // reset the port
+									.setPort(port) // reset the port
+									.addParameter("dubbo.tag", tag); // reset the tag
 
 							return clonedURLBuilder.build();
 						}


### PR DESCRIPTION
### Describe what this PR does / why we need it

### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #2031

### Describe how you did it
Receive each service instance tag and replace `dubbo.tag` parameter when clone exported url,
thus consumer can select the same tag invoker and complete the remote invocation correctly!

### Describe how to verify it
consumer invoke with set tag_key`RpcContext.getContext().setAttachment(CommonConstants.TAG_KEY, "tag1");`

### Special notes for reviews
consumer can not invoke provider services with tag when not set tag  key `RpcContext.getContext().setAttachment(CommonConstants.TAG_KEY, "tag1");`,
but can invoke provider services with tag! I think that's dubbo framework bug if [dubbo documentation](https://dubbo.apache.org/zh/docs/v2.7/user/examples/routing-rule/) is correct!
