### PR TITLE
fix issus#2040

### DIFF
--- a/spring-cloud-alibaba-examples/rocketmq-example/rocketmq-produce-example/src/main/resources/application.properties
+++ b/spring-cloud-alibaba-examples/rocketmq-example/rocketmq-produce-example/src/main/resources/application.properties
@@ -9,7 +9,7 @@ spring.cloud.stream.rocketmq.bindings.output1.producer.sync=true
 
 spring.cloud.stream.bindings.output2.destination=TransactionTopic
 spring.cloud.stream.bindings.output2.content-type=application/json
-spring.cloud.stream.rocketmq.bindings.output2.producer.transactional=true
+spring.cloud.stream.rocketmq.bindings.output2.producer.producerType=Trans
 spring.cloud.stream.rocketmq.bindings.output2.producer.group=myTxProducerGroup
 spring.cloud.stream.rocketmq.bindings.output2.producer.transactionListener=myTransactionListener
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/autoconfigurate/ExtendedBindingHandlerMappingsProviderConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/autoconfigurate/ExtendedBindingHandlerMappingsProviderConfiguration.java
@@ -19,10 +19,14 @@ package com.alibaba.cloud.stream.binder.rocketmq.autoconfigurate;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.alibaba.cloud.stream.binder.rocketmq.convert.RocketMQMessageConverter;
+import com.alibaba.cloud.stream.binder.rocketmq.custom.RocketMQConfigBeanPostProcessor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
 import org.springframework.cloud.stream.config.BindingHandlerAdvise.MappingsProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.converter.CompositeMessageConverter;
 
 @Configuration
 public class ExtendedBindingHandlerMappingsProviderConfiguration {
@@ -40,6 +44,18 @@ public class ExtendedBindingHandlerMappingsProviderConfiguration {
 							.of("spring.cloud.stream.rocketmq.streams.default"));
 			return mappings;
 		};
+	}
+
+	@Bean
+	public RocketMQConfigBeanPostProcessor rocketMQConfigBeanPostProcessor() {
+		return new RocketMQConfigBeanPostProcessor();
+	}
+
+
+	@Bean(RocketMQMessageConverter.DEFAULT_NAME)
+	@ConditionalOnMissingBean(name = { RocketMQMessageConverter.DEFAULT_NAME })
+	public CompositeMessageConverter rocketMQMessageConverter() {
+		return new RocketMQMessageConverter().getMessageConverter();
 	}
 
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/autoconfigurate/ExtendedBindingHandlerMappingsProviderConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/autoconfigurate/ExtendedBindingHandlerMappingsProviderConfiguration.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import com.alibaba.cloud.stream.binder.rocketmq.convert.RocketMQMessageConverter;
 import com.alibaba.cloud.stream.binder.rocketmq.custom.RocketMQConfigBeanPostProcessor;
+
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
 import org.springframework.cloud.stream.config.BindingHandlerAdvise.MappingsProvider;

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/autoconfigurate/RocketMQBinderAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/autoconfigurate/RocketMQBinderAutoConfiguration.java
@@ -50,11 +50,6 @@ public class RocketMQBinderAutoConfiguration {
 	@Autowired
 	private RocketMQBinderConfigurationProperties rocketBinderConfigurationProperties;
 
-	@Bean
-	public RocketMQConfigBeanPostProcessor rocketMQConfigBeanPostProcessor() {
-		return new RocketMQConfigBeanPostProcessor();
-	}
-
 	@Bean(RocketMQMessageConverter.DEFAULT_NAME)
 	@ConditionalOnMissingBean(name = { RocketMQMessageConverter.DEFAULT_NAME })
 	public CompositeMessageConverter rocketMQMessageConverter() {

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/autoconfigurate/RocketMQBinderAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/autoconfigurate/RocketMQBinderAutoConfiguration.java
@@ -19,7 +19,6 @@ package com.alibaba.cloud.stream.binder.rocketmq.autoconfigurate;
 import com.alibaba.cloud.stream.binder.rocketmq.RocketMQMessageChannelBinder;
 import com.alibaba.cloud.stream.binder.rocketmq.actuator.RocketMQBinderHealthIndicator;
 import com.alibaba.cloud.stream.binder.rocketmq.convert.RocketMQMessageConverter;
-import com.alibaba.cloud.stream.binder.rocketmq.custom.RocketMQConfigBeanPostProcessor;
 import com.alibaba.cloud.stream.binder.rocketmq.properties.RocketMQBinderConfigurationProperties;
 import com.alibaba.cloud.stream.binder.rocketmq.properties.RocketMQExtendedBindingProperties;
 import com.alibaba.cloud.stream.binder.rocketmq.provisioning.RocketMQTopicProvisioner;

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/autoconfigurate/RocketMQBinderAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/autoconfigurate/RocketMQBinderAutoConfiguration.java
@@ -18,7 +18,6 @@ package com.alibaba.cloud.stream.binder.rocketmq.autoconfigurate;
 
 import com.alibaba.cloud.stream.binder.rocketmq.RocketMQMessageChannelBinder;
 import com.alibaba.cloud.stream.binder.rocketmq.actuator.RocketMQBinderHealthIndicator;
-import com.alibaba.cloud.stream.binder.rocketmq.convert.RocketMQMessageConverter;
 import com.alibaba.cloud.stream.binder.rocketmq.properties.RocketMQBinderConfigurationProperties;
 import com.alibaba.cloud.stream.binder.rocketmq.properties.RocketMQExtendedBindingProperties;
 import com.alibaba.cloud.stream.binder.rocketmq.provisioning.RocketMQTopicProvisioner;
@@ -26,11 +25,9 @@ import com.alibaba.cloud.stream.binder.rocketmq.provisioning.RocketMQTopicProvis
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.messaging.converter.CompositeMessageConverter;
 
 /**
  * issue:https://github.com/alibaba/spring-cloud-alibaba/issues/1681 .
@@ -48,12 +45,6 @@ public class RocketMQBinderAutoConfiguration {
 
 	@Autowired
 	private RocketMQBinderConfigurationProperties rocketBinderConfigurationProperties;
-
-	@Bean(RocketMQMessageConverter.DEFAULT_NAME)
-	@ConditionalOnMissingBean(name = { RocketMQMessageConverter.DEFAULT_NAME })
-	public CompositeMessageConverter rocketMQMessageConverter() {
-		return new RocketMQMessageConverter().getMessageConverter();
-	}
 
 	@Bean
 	@ConditionalOnEnabledHealthIndicator("rocketmq")

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.alibaba.cloud.stream.binder.rocketmq.autoconfigurate.ExtendedBindingHandlerMappingsProviderConfiguration
+com.alibaba.cloud.stream.binder.rocketmq.autoconfigurate.ExtendedBindingHandlerMappingsProviderConfiguration,\
+com.alibaba.cloud.stream.binder.rocketmq.custom.RocketMQConfigBeanPostProcessor

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,2 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.alibaba.cloud.stream.binder.rocketmq.autoconfigurate.ExtendedBindingHandlerMappingsProviderConfiguration,\
-com.alibaba.cloud.stream.binder.rocketmq.custom.RocketMQConfigBeanPostProcessor
+com.alibaba.cloud.stream.binder.rocketmq.autoconfigurate.ExtendedBindingHandlerMappingsProviderConfiguration


### PR DESCRIPTION
### Describe what this PR does / why we need it
修复自定义bean无法被rockmq启用的bug

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #2040

### Describe how you did it
把RocketMQConfigBeanPostProcessor的注入方式从spring.binders移动到spring.factories中，
前者经过spring-cloud-stream代理会出现一个新的child context 导致自定义常用bean无法经过RocketMQConfigBeanPostProcessor处理


### Describe how to verify it
启动RocketMQProduceApplication事务消息通过TransactionListenerImpl且无错误

### Special notes for reviews
