### PR TITLE
update dubbo to 2.7.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <spring.cloud.version>Hoxton.SR9</spring.cloud.version>
 
         <!-- Apache Dubbo -->
-        <dubbo.version>2.7.8</dubbo.version>
+        <dubbo.version>2.7.10</dubbo.version>
         <curator.version>4.0.1</curator.version>
 
         <!-- Apache RocketMQ -->

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/servicediscovery/SpringCloudServiceDiscovery.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/servicediscovery/SpringCloudServiceDiscovery.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.dubbo.servicediscovery;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.registry.client.AbstractServiceDiscovery;
+import org.apache.dubbo.registry.client.ServiceInstance;
+import org.apache.dubbo.registry.client.event.listener.ServiceInstancesChangedListener;
+
+/**
+ * Spring Cloud Service Discvoery has no function at all.
+ *
+ * @author <a href="ppzzyy11:q15138956968@gmail.com">ppzzyy11</a>
+ */
+public class SpringCloudServiceDiscovery extends AbstractServiceDiscovery {
+
+	public SpringCloudServiceDiscovery() {
+	}
+
+	@Override
+	public void doRegister(ServiceInstance serviceInstance) {
+	}
+
+	@Override
+	public void doUpdate(ServiceInstance serviceInstance) {
+	}
+
+	@Override
+	public void initialize(URL registryURL) throws Exception {
+	}
+
+	@Override
+	public void destroy() throws Exception {
+	}
+
+	@Override
+	public void unregister(ServiceInstance serviceInstance) throws RuntimeException {
+	}
+
+	@Override
+	public Set<String> getServices() {
+		return Collections.emptySet();
+
+	}
+
+	@Override
+	public URL getUrl() {
+		return new URL("", "", 0);
+	}
+
+	@Override
+	public void addServiceInstancesChangedListener(
+			ServiceInstancesChangedListener listener)
+			throws NullPointerException, IllegalArgumentException {
+	}
+
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/util/DubboCloudConstants.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/util/DubboCloudConstants.java
@@ -44,6 +44,11 @@ public final class DubboCloudConstants {
 	 */
 	public static final String DUBBO_CLOUD_REGISTRY_PROPERTY_VALUE = "dubbo-cloud";
 
+	/**
+	 * The class appears from dubbo 2.7.9.
+	 */
+	public static final String DUBBO_BOOTSTRAP_STATED_EVENT_CLASS_NAME = "org.apache.dubbo.config.spring.context.event.DubboBootstrapStatedEvent";
+
 	private DubboCloudConstants() {
 		throw new AssertionError("Must not instantiate constant utility class");
 	}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/resources/META-INF/dubbo/org.apache.dubbo.registry.client.ServiceDiscovery
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/resources/META-INF/dubbo/org.apache.dubbo.registry.client.ServiceDiscovery
@@ -1,0 +1,1 @@
+spring-cloud=com.alibaba.cloud.dubbo.servicediscovery.SpringCloudServiceDiscovery


### PR DESCRIPTION
## Describe what this PR does / why we need it
I upgrade the Dubbo version from 2.7.8 to 2.7.10 and list the previous mock DubboBootstrapStartedEvent with DubboBootstrap's DubboBootstrapStatedEvent side by side.
To be compatible with Dubbo 2.7.10 new feature called Immigration Invoker, I implemented a SpringCloudDiscovery actually doing nothing.

## Does this pull request fix one issue?
#1947

## Describe how you did it
I upgrade the versions, then I reserve the mock DubboBootstarpStartedEvent on DubboBootstrapStartCommandLineRunner.java to be compatible with the old versions.
I created new listeners to receive DubboBootstrapStartedEvent published by DubboBootstrap in Dubbo 2.7.10.
I assemble listener bean by "ConditionOnClass" and "ConditionalOnMissingClass".

## Describe how to verify it
All samples ran smoothly on my laptop both using the Zookeeper or Nacos registry.

## Special notes for reviews
NONE