### PR TITLE
feat: 配置添加unitName，支持同一应用连接多集群

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/RocketMQMessageChannelBinder.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/RocketMQMessageChannelBinder.java
@@ -158,6 +158,7 @@ public class RocketMQMessageChannelBinder extends
 						producerProperties.getExtension().isRetryNextServer());
 				producer.setMaxMessageSize(
 						producerProperties.getExtension().getMaxMessageSize());
+				producer.setUnitName(rocketBinderConfigurationProperties.getUnitName());
 				rocketMQTemplate.setProducer(producer);
 				if (producerProperties.isPartitioned()) {
 					rocketMQTemplate

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/consuming/RocketMQListenerBindingContainer.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/consuming/RocketMQListenerBindingContainer.java
@@ -237,6 +237,7 @@ public class RocketMQListenerBindingContainer
 		consumer.setNamesrvAddr(RocketMQBinderUtils.getNameServerStr(nameServer));
 		consumer.setConsumeThreadMax(rocketMQConsumerProperties.getConcurrency());
 		consumer.setConsumeThreadMin(rocketMQConsumerProperties.getConcurrency());
+		consumer.setUnitName(rocketBinderConfigurationProperties.getUnitName());
 
 		switch (messageModel) {
 		case BROADCASTING:

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/properties/RocketMQBinderConfigurationProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/properties/RocketMQBinderConfigurationProperties.java
@@ -58,6 +58,11 @@ public class RocketMQBinderConfigurationProperties {
 	 */
 	private String customizedTraceTopic = MixAll.RMQ_SYS_TRACE_TOPIC;
 
+	/**
+	 * The property of "unitName".
+	 */
+	private String unitName;
+
 	public List<String> getNameServer() {
 		return nameServer;
 	}
@@ -98,4 +103,11 @@ public class RocketMQBinderConfigurationProperties {
 		this.customizedTraceTopic = customizedTraceTopic;
 	}
 
+	public String getUnitName() {
+		return unitName;
+	}
+
+	public void setUnitName(String unitName) {
+		this.unitName = unitName;
+	}
 }


### PR DESCRIPTION
### Describe what this PR does / why we need it

同一应用连接多个集群时，因无法设置unitName导致MQClientInstance只有一个生效

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

配置添加unitName，创建producer和consumer时进行设置

### Describe how to verify it


### Special notes for reviews
