### PR TITLE
[Feature] support for registration of quick failed configuration items

### DIFF
--- a/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/nacos-discovery-consumer-example/src/main/resources/application.properties
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/nacos-discovery-consumer-example/src/main/resources/application.properties
@@ -2,6 +2,7 @@ spring.application.name=service-consumer
 server.port=18083
 management.endpoints.web.exposure.include=*
 spring.cloud.nacos.discovery.server-addr=127.0.0.1:8848
+spring.cloud.nacos.discovery.fail-fast=true
 
 spring.cloud.nacos.username=nacos
 spring.cloud.nacos.password=nacos

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
@@ -207,6 +207,12 @@ public class NacosDiscoveryProperties {
 	 */
 	private boolean ephemeral = true;
 
+	/**
+	 * Throw exceptions during service registration if true, otherwise, log error
+	 * (defaults to true).
+	 */
+	private boolean failFast = true;
+
 	@Autowired
 	private InetUtils inetUtils;
 
@@ -486,6 +492,14 @@ public class NacosDiscoveryProperties {
 		this.ephemeral = ephemeral;
 	}
 
+	public boolean isFailFast() {
+		return failFast;
+	}
+
+	public void setFailFast(boolean failFast) {
+		this.failFast = failFast;
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) {
@@ -510,6 +524,7 @@ public class NacosDiscoveryProperties {
 				&& Objects.equals(secretKey, that.secretKey)
 				&& Objects.equals(heartBeatInterval, that.heartBeatInterval)
 				&& Objects.equals(heartBeatTimeout, that.heartBeatTimeout)
+				&& Objects.equals(failFast, that.failFast)
 				&& Objects.equals(ipDeleteTimeout, that.ipDeleteTimeout);
 	}
 
@@ -519,7 +534,7 @@ public class NacosDiscoveryProperties {
 				watchDelay, logName, service, weight, clusterName, group,
 				namingLoadCacheAtStart, registerEnabled, ip, networkInterface, port,
 				secure, accessKey, secretKey, heartBeatInterval, heartBeatTimeout,
-				ipDeleteTimeout, instanceEnabled, ephemeral);
+				ipDeleteTimeout, instanceEnabled, ephemeral, failFast);
 	}
 
 	@Override
@@ -535,7 +550,7 @@ public class NacosDiscoveryProperties {
 				+ ", port=" + port + ", secure=" + secure + ", accessKey='" + accessKey
 				+ '\'' + ", secretKey='" + secretKey + '\'' + ", heartBeatInterval="
 				+ heartBeatInterval + ", heartBeatTimeout=" + heartBeatTimeout
-				+ ", ipDeleteTimeout=" + ipDeleteTimeout + '}';
+				+ ", ipDeleteTimeout=" + ipDeleteTimeout + ", failFast=" + failFast + '}';
 	}
 
 	public void overrideFromEnv(Environment env) {

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosServiceRegistry.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosServiceRegistry.java
@@ -76,11 +76,15 @@ public class NacosServiceRegistry implements ServiceRegistry<Registration> {
 					instance.getIp(), instance.getPort());
 		}
 		catch (Exception e) {
-			log.error("nacos registry, {} register failed...{},", serviceId,
-					registration.toString(), e);
-			// rethrow a RuntimeException if the registration is failed.
-			// issue : https://github.com/alibaba/spring-cloud-alibaba/issues/1132
-			rethrowRuntimeException(e);
+			if (nacosDiscoveryProperties.isFailFast()) {
+				log.error("nacos registry, {} register failed...{},", serviceId,
+						registration.toString(), e);
+				rethrowRuntimeException(e);
+			}
+			else {
+				log.warn("Failfast is false. {} register failed...{},", serviceId,
+						registration.toString(), e);
+			}
 		}
 	}
 


### PR DESCRIPTION
Support for registration of quick failed configuration items `spring.cloud.nacos.discovery.fail-fast`

When the Service register failed
- If `true`, The application start will fail. ( default is `true`)
- If `false`, The application start will success.  When Nacos Server is ready, the service instance is automatically registered.

Fixed #2099 
Fixed #1604 