### PR TITLE
feat: sentinel对feign的资源粒度的支持。

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/feign/SentinelInvocationHandler.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/feign/SentinelInvocationHandler.java
@@ -23,6 +23,9 @@ import java.lang.reflect.Proxy;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import com.alibaba.cloud.sentinel.feign.handler.FeignResourceHandler;
+import com.alibaba.cloud.sentinel.feign.handler.FeignResourceHandlerFactory;
+import com.alibaba.cloud.sentinel.feign.handler.ResourceHandler;
 import com.alibaba.csp.sentinel.Entry;
 import com.alibaba.csp.sentinel.EntryType;
 import com.alibaba.csp.sentinel.SphU;
@@ -52,15 +55,16 @@ public class SentinelInvocationHandler implements InvocationHandler {
 
 	private Map<Method, Method> fallbackMethodMap;
 
-	SentinelInvocationHandler(Target<?> target, Map<Method, MethodHandler> dispatch,
-			FallbackFactory fallbackFactory) {
+	public SentinelInvocationHandler(Target<?> target,
+			Map<Method, MethodHandler> dispatch, FallbackFactory fallbackFactory) {
 		this.target = checkNotNull(target, "target");
 		this.dispatch = checkNotNull(dispatch, "dispatch");
 		this.fallbackFactory = fallbackFactory;
 		this.fallbackMethodMap = toFallbackMethod(dispatch);
 	}
 
-	SentinelInvocationHandler(Target<?> target, Map<Method, MethodHandler> dispatch) {
+	public SentinelInvocationHandler(Target<?> target,
+			Map<Method, MethodHandler> dispatch) {
 		this.target = checkNotNull(target, "target");
 		this.dispatch = checkNotNull(dispatch, "dispatch");
 	}
@@ -68,38 +72,46 @@ public class SentinelInvocationHandler implements InvocationHandler {
 	@Override
 	public Object invoke(final Object proxy, final Method method, final Object[] args)
 			throws Throwable {
-		if ("equals".equals(method.getName())) {
-			try {
-				Object otherHandler = args.length > 0 && args[0] != null
-						? Proxy.getInvocationHandler(args[0]) : null;
-				return equals(otherHandler);
-			}
-			catch (IllegalArgumentException e) {
-				return false;
-			}
+		// invoke object methods
+		if (Object.class.equals(method.getDeclaringClass())) {
+			return invokeObjectMethod(proxy, method, args);
 		}
-		else if ("hashCode".equals(method.getName())) {
-			return hashCode();
-		}
-		else if ("toString".equals(method.getName())) {
-			return toString();
-		}
+		// invoke proxy method
+		return invokeProxyMethod(proxy, method, args);
+	}
 
+	protected MethodMetadata parseMethodMetadata(
+			Target.HardCodedTarget<?> hardCodedTarget, Method method) {
+		return SentinelContractHolder.METADATA_MAP.get(hardCodedTarget.type().getName()
+				+ Feign.configKey(hardCodedTarget.type(), method));
+	}
+
+	private FeignResourceHandler parseResourceHandler(Method method) {
+		ResourceHandler resourceHandler = method.getAnnotation(ResourceHandler.class);
+		if (resourceHandler == null) {
+			resourceHandler = target.type().getAnnotation(ResourceHandler.class);
+		}
+		if (resourceHandler == null) {
+			return FeignResourceHandlerFactory.getDefaultHandler();
+		}
+		return FeignResourceHandlerFactory.getHandler(resourceHandler.value());
+	}
+
+	protected Object invokeProxyMethod(final Object proxy, final Method method,
+			final Object[] args) throws Throwable {
 		Object result;
 		MethodHandler methodHandler = this.dispatch.get(method);
 		// only handle by HardCodedTarget
 		if (target instanceof Target.HardCodedTarget) {
-			Target.HardCodedTarget hardCodedTarget = (Target.HardCodedTarget) target;
-			MethodMetadata methodMetadata = SentinelContractHolder.METADATA_MAP
-					.get(hardCodedTarget.type().getName()
-							+ Feign.configKey(hardCodedTarget.type(), method));
-			// resource default is HttpMethod:protocol://url
+			Target.HardCodedTarget<?> hardCodedTarget = (Target.HardCodedTarget<?>) target;
+			MethodMetadata methodMetadata = parseMethodMetadata(hardCodedTarget, method);
+
 			if (methodMetadata == null) {
 				result = methodHandler.invoke(args);
 			}
 			else {
-				String resourceName = methodMetadata.template().method().toUpperCase()
-						+ ":" + hardCodedTarget.url() + methodMetadata.template().path();
+				String resourceName = parseResourceHandler(method)
+						.makeResourceName(this.target, methodMetadata);
 				Entry entry = null;
 				try {
 					ContextUtil.enter(resourceName);
@@ -145,6 +157,21 @@ public class SentinelInvocationHandler implements InvocationHandler {
 		}
 
 		return result;
+	}
+
+	private Object invokeObjectMethod(final Object proxy, final Method method,
+			final Object[] args) throws Throwable {
+		if ("equals".equals(method.getName())) {
+			try {
+				Object otherHandler = args.length > 0 && args[0] != null
+						? Proxy.getInvocationHandler(args[0]) : null;
+				return equals(otherHandler);
+			}
+			catch (IllegalArgumentException e) {
+				return false;
+			}
+		}
+		return method.invoke(this, args);
 	}
 
 	@Override

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/feign/SentinelInvocationHandlerFactory.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/feign/SentinelInvocationHandlerFactory.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.sentinel.feign;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import feign.InvocationHandlerFactory;
+import feign.Target;
+import feign.hystrix.FallbackFactory;
+
+import org.springframework.cloud.openfeign.FeignContext;
+import org.springframework.context.ApplicationContext;
+import org.springframework.util.ReflectionUtils;
+import org.springframework.util.StringUtils;
+
+/**
+ * @author <a href="a11en.huang@foxmail.com">Allen Huang</a>
+ */
+public class SentinelInvocationHandlerFactory implements InvocationHandlerFactory {
+
+	protected final ApplicationContext applicationContext;
+
+	protected final FeignContext feignContext;
+
+	public SentinelInvocationHandlerFactory(ApplicationContext applicationContext) {
+		this(applicationContext, applicationContext.getBean(FeignContext.class));
+	}
+
+	public SentinelInvocationHandlerFactory(ApplicationContext applicationContext,
+			FeignContext feignContext) {
+		this.applicationContext = applicationContext;
+		this.feignContext = feignContext;
+	}
+
+	@Override
+	public InvocationHandler create(Target target, Map<Method, MethodHandler> dispatch) {
+		// using reflect get fallback and fallbackFactory properties from
+		// FeignClientFactoryBean because FeignClientFactoryBean is a package
+		// level class, we can not use it in our package
+		Object feignClientFactoryBean = applicationContext
+				.getBean("&" + target.type().getName());
+
+		Class<?> fallback = (Class<?>) getFieldValue(feignClientFactoryBean, "fallback");
+		Class<?> fallbackFactory = (Class<?>) getFieldValue(feignClientFactoryBean,
+				"fallbackFactory");
+		String beanName = (String) getFieldValue(feignClientFactoryBean, "contextId");
+		if (!StringUtils.hasText(beanName)) {
+			beanName = (String) getFieldValue(feignClientFactoryBean, "name");
+		}
+
+		Object fallbackInstance;
+		FallbackFactory<?> fallbackFactoryInstance = null;
+		// check fallback and fallbackFactory properties
+		if (void.class != fallback) {
+			fallbackInstance = getFromContext(beanName, "fallback", fallback,
+					target.type());
+			fallbackFactoryInstance = new FallbackFactory.Default(fallbackInstance);
+		}
+		else if (void.class != fallbackFactory) {
+			fallbackFactoryInstance = (FallbackFactory) getFromContext(beanName,
+					"fallbackFactory", fallbackFactory, FallbackFactory.class);
+		}
+		return buildInvocationHandler(target, dispatch, fallbackFactoryInstance);
+	}
+
+	protected InvocationHandler buildInvocationHandler(Target<?> target,
+			Map<Method, MethodHandler> dispatch, FallbackFactory fallbackFactory) {
+		return fallbackFactory == null ? new SentinelInvocationHandler(target, dispatch)
+				: new SentinelInvocationHandler(target, dispatch, fallbackFactory);
+	}
+
+	private Object getFromContext(String name, String type, Class<?> fallbackType,
+			Class<?> targetType) {
+		Object fallbackInstance = feignContext.getInstance(name, fallbackType);
+		if (fallbackInstance == null) {
+			throw new IllegalStateException(
+					String.format("No %s instance of type %s found for feign client %s",
+							type, fallbackType, name));
+		}
+
+		if (!targetType.isAssignableFrom(fallbackType)) {
+			throw new IllegalStateException(String.format(
+					"Incompatible %s instance. Fallback/fallbackFactory of type %s is not assignable to %s for feign client %s",
+					type, fallbackType, targetType, name));
+		}
+		return fallbackInstance;
+	}
+
+	private Object getFieldValue(Object instance, String fieldName) {
+		Field field = ReflectionUtils.findField(instance.getClass(), fieldName);
+		if (field != null) {
+			boolean accessible = field.isAccessible();
+			try {
+				field.setAccessible(true);
+				return field.get(instance);
+			}
+			catch (IllegalAccessException e) {
+				// ignore
+			}
+			finally {
+				field.setAccessible(accessible);
+			}
+		}
+		return null;
+	}
+
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/feign/handler/FeignResourceHandler.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/feign/handler/FeignResourceHandler.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.sentinel.feign.handler;
+
+import feign.MethodMetadata;
+import feign.Target;
+
+/**
+ * @author <a href="a11en.huang@foxmail.com">Allen Huang</a>
+ */
+public interface FeignResourceHandler {
+
+	/**
+	 * create resource name by this strategy.
+	 * @param target feign proxy target
+	 * @param methodMetadata method metadata
+	 * @return resource name
+	 */
+	String makeResourceName(Target<?> target, MethodMetadata methodMetadata);
+
+	/**
+	 * 此策略方法的类型。类型不能重复.
+	 * @return 返回类型值
+	 */
+	String handlerType();
+
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/feign/handler/FeignResourceHandlerFactory.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/feign/handler/FeignResourceHandlerFactory.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.sentinel.feign.handler;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.lang.NonNull;
+
+/**
+ * @author <a href="a11en.huang@foxmail.com">Allen Huang</a>
+ */
+public class FeignResourceHandlerFactory implements BeanPostProcessor {
+
+	private static final Map<String, FeignResourceHandler> HANDLER_MAP = new HashMap<>();
+
+	private static FeignResourceHandler DEFAULT_HANDLER = new RestFeignResourceHandler();
+
+	public static FeignResourceHandler getHandler(String strategy) {
+		return Optional.ofNullable(HANDLER_MAP.get(strategy)).orElse(DEFAULT_HANDLER);
+	}
+
+	public static FeignResourceHandler getDefaultHandler() {
+		return DEFAULT_HANDLER;
+	}
+
+	public void setDefaultStrategy(FeignResourceHandler defaultHandler) {
+		if (defaultHandler != null) {
+			DEFAULT_HANDLER = defaultHandler;
+		}
+	}
+
+	@Override
+	public Object postProcessAfterInitialization(@NonNull Object bean,
+			@NonNull String beanName) throws BeansException {
+		if (bean instanceof FeignResourceHandler) {
+			FeignResourceHandler handler = (FeignResourceHandler) bean;
+			String type = handler.handlerType();
+			synchronized (HANDLER_MAP) {
+				FeignResourceHandler initBean = HANDLER_MAP.get(type);
+				if (initBean != null && handler != initBean) {
+					throw new BeanCreationException("Repeated strategy. type: " + type,
+							"," + initBean.getClass().getName() + " <-->"
+									+ beanClass(bean));
+				}
+				HANDLER_MAP.put(type, handler);
+			}
+		}
+		return bean;
+	}
+
+	private Class<?> beanClass(Object bean) {
+		return AopUtils.isAopProxy(bean) ? AopUtils.getTargetClass(bean)
+				: bean.getClass();
+	}
+
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/feign/handler/ResourceHandler.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/feign/handler/ResourceHandler.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.sentinel.feign.handler;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author <a href="a11en.huang@foxmail.com">Allen Huang</a>
+ */
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ResourceHandler {
+
+	String value() default ResourceHandlerHolder.REST_API;
+
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/feign/handler/ResourceHandlerHolder.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/feign/handler/ResourceHandlerHolder.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.sentinel.feign.handler;
+
+/**
+ * @author <a href="a11en.huang@foxmail.com">Allen Huang</a>
+ */
+public final class ResourceHandlerHolder {
+
+	/**
+	 * 基于rest api的策略类型.每一个url都会被当作一个资源.
+	 */
+	public static final String REST_API = "rest-api";
+
+	/**
+	 * 基于服务的策略类型.一个服务只有一个资源.
+	 */
+	public static final String SERVICE_INSTANCE = "service-instance";
+
+	private ResourceHandlerHolder() {
+
+	}
+
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/feign/handler/RestFeignResourceHandler.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/feign/handler/RestFeignResourceHandler.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.sentinel.feign.handler;
+
+import feign.MethodMetadata;
+import feign.Target;
+
+/**
+ * 基于rest url的限制策略.
+ *
+ * @author <a href="a11en.huang@foxmail.com">Allen Huang</a>
+ */
+public class RestFeignResourceHandler implements FeignResourceHandler {
+
+	@Override
+	public String makeResourceName(Target<?> target, MethodMetadata methodMetadata) {
+		if (target instanceof Target.HardCodedTarget) {
+			Target.HardCodedTarget<?> hardCodedTarget = (Target.HardCodedTarget<?>) target;
+			return methodMetadata.template().method().toUpperCase() + ":"
+					+ hardCodedTarget.url() + methodMetadata.template().path();
+		}
+		return null;
+	}
+
+	@Override
+	public String handlerType() {
+		return ResourceHandlerHolder.REST_API;
+	}
+
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/feign/handler/SentinelResourceHandlerAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/feign/handler/SentinelResourceHandlerAutoConfiguration.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.sentinel.feign.handler;
+
+import com.alibaba.csp.sentinel.SphU;
+import feign.Feign;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * ResourceName handler config.
+ *
+ * @author Allen Huang
+ */
+@RefreshScope
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass({ SphU.class, Feign.class })
+@ConfigurationProperties("spring.cloud.sentinel.feign.resource-handler")
+public class SentinelResourceHandlerAutoConfiguration {
+
+	/**
+	 * Global default resource strategy.
+	 */
+	private Class<? extends FeignResourceHandler> defaultHandler = RestFeignResourceHandler.class;
+
+	@Bean
+	public FeignResourceHandlerFactory feignResourceStrategyFactory()
+			throws InstantiationException, IllegalAccessException {
+		FeignResourceHandlerFactory resourceHandlerFactory = new FeignResourceHandlerFactory();
+		resourceHandlerFactory.setDefaultStrategy(defaultHandler.newInstance());
+		return resourceHandlerFactory;
+	}
+
+	@Bean
+	public RestFeignResourceHandler restFeignResourceHandler() {
+		return new RestFeignResourceHandler();
+	}
+
+	@Bean
+	public ServiceFeignResourceHandler serviceFeignResourceHandler() {
+		return new ServiceFeignResourceHandler();
+	}
+
+	public Class<? extends FeignResourceHandler> getDefaultHandler() {
+		return defaultHandler;
+	}
+
+	public void setDefaultHandler(Class<? extends FeignResourceHandler> defaultHandler) {
+		if (defaultHandler != null) {
+			this.defaultHandler = defaultHandler;
+		}
+	}
+
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/feign/handler/ServiceFeignResourceHandler.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/feign/handler/ServiceFeignResourceHandler.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.sentinel.feign.handler;
+
+import feign.MethodMetadata;
+import feign.Target;
+
+/**
+ * 基于服务的限制策略.
+ *
+ * @author <a href="a11en.huang@foxmail.com">Allen Huang</a>
+ */
+public class ServiceFeignResourceHandler implements FeignResourceHandler {
+
+	@Override
+	public String makeResourceName(Target<?> target, MethodMetadata methodMetadata) {
+		if (target instanceof Target.HardCodedTarget) {
+			Target.HardCodedTarget<?> hardCodedTarget = (Target.HardCodedTarget<?>) target;
+			String serviceName = hardCodedTarget.name();
+			// default resource name is HTTP#serviceName
+			return String.join("#", "HTTP", serviceName);
+		}
+		return null;
+	}
+
+	@Override
+	public String handlerType() {
+		return ResourceHandlerHolder.SERVICE_INSTANCE;
+	}
+
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/resources/META-INF/spring.factories
@@ -3,7 +3,8 @@ com.alibaba.cloud.sentinel.SentinelWebAutoConfiguration,\
 com.alibaba.cloud.sentinel.SentinelWebFluxAutoConfiguration,\
 com.alibaba.cloud.sentinel.endpoint.SentinelEndpointAutoConfiguration,\
 com.alibaba.cloud.sentinel.custom.SentinelAutoConfiguration,\
-com.alibaba.cloud.sentinel.feign.SentinelFeignAutoConfiguration
+com.alibaba.cloud.sentinel.feign.SentinelFeignAutoConfiguration,\
+com.alibaba.cloud.sentinel.feign.handler.SentinelResourceHandlerAutoConfiguration
 
 org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker=\
 com.alibaba.cloud.sentinel.custom.SentinelCircuitBreakerConfiguration

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/test/java/com/alibaba/cloud/sentinel/SentinelFeignTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/test/java/com/alibaba/cloud/sentinel/SentinelFeignTests.java
@@ -125,9 +125,7 @@ public class SentinelFeignTests {
 
 	@Test
 	public void testFeignServiceInstanceResourceHandler() {
-		assertThatThrownBy(() -> {
-			echoService.echo("test");
-		}).isInstanceOf(Exception.class);
+		assertThat(echoService.echo("test")).isEqualTo("echo fallback");
 	}
 
 	@Configuration

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/test/java/com/alibaba/cloud/sentinel/SentinelFeignTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/test/java/com/alibaba/cloud/sentinel/SentinelFeignTests.java
@@ -19,6 +19,9 @@ package com.alibaba.cloud.sentinel;
 import java.util.Arrays;
 
 import com.alibaba.cloud.sentinel.feign.SentinelFeignAutoConfiguration;
+import com.alibaba.cloud.sentinel.feign.handler.ResourceHandler;
+import com.alibaba.cloud.sentinel.feign.handler.ResourceHandlerHolder;
+import com.alibaba.cloud.sentinel.feign.handler.SentinelResourceHandlerAutoConfiguration;
 import com.alibaba.csp.sentinel.slots.block.RuleConstant;
 import com.alibaba.csp.sentinel.slots.block.flow.FlowRule;
 import com.alibaba.csp.sentinel.slots.block.flow.FlowRuleManager;
@@ -45,7 +48,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * @author <a href="mailto:fangjian0423@gmail.com">Jim</a>
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = { SentinelFeignTests.TestConfig.class },
+@SpringBootTest(
+		classes = { SentinelFeignTests.TestConfig.class,
+				SentinelResourceHandlerAutoConfiguration.class },
 		properties = { "feign.sentinel.enabled=true" })
 public class SentinelFeignTests {
 
@@ -118,6 +123,13 @@ public class SentinelFeignTests {
 		assertThat(echoService.equals(fooService)).isEqualTo(Boolean.FALSE);
 	}
 
+	@Test
+	public void testFeignServiceInstanceResourceHandler() {
+		assertThatThrownBy(() -> {
+			echoService.echo("test");
+		}).isInstanceOf(Exception.class);
+	}
+
 	@Configuration
 	@EnableAutoConfiguration
 	@ImportAutoConfiguration({ SentinelFeignAutoConfiguration.class })
@@ -136,6 +148,7 @@ public class SentinelFeignTests {
 
 	}
 
+	@ResourceHandler(ResourceHandlerHolder.SERVICE_INSTANCE)
 	@FeignClient(value = "test-service", fallback = EchoServiceFallback.class)
 	public interface EchoService {
 


### PR DESCRIPTION
feat: sentinel对feign的资源粒度的支持


### Describe what this PR does / why we need it
当前的sentinel处理feign时，无法控制资源的粒度。每一个rest api都当作一个粒度。这并不合理。当一个服务出现问题时，该服务的其他接口也很有可能也无法访问，所以按照服务为粒度进行资源限制是一个合理的需求。并且当前版本的sentinel最多只能对2000个资源进行限制，如果每一个rest api都当作一个资源来限制的话，有可能造成部分资源无法被sentinel处理的问题。

When the current sentinel processes feign, it cannot control the granularity of resources. Each rest api is treated as a granularity. This is not reasonable. When a service has a problem, other interfaces of the service may also be inaccessible, so it is a reasonable requirement to restrict resources according to the granularity of the service. And the current version of sentinel can only limit up to 2000 resources. If each rest api is treated as a resource to limit, it may cause the problem that some resources cannot be processed by sentinel.

### Does this pull request fix one issue?
Feature #2094

### Describe how you did it
在SentinelInvocationHandler生成resourceName时，将会查找生成策略，根据不同的生成策略来进行不同的处理。全局默认的生成策略为rest api.可以在配置文件中(spring.cloud.sentinel.feign.resource-handler.default-handler)配置默认的生成策略。
当然，为了让粒度控制变得更加灵活，我也自定义了一个注解: @ResourceHandler 他可以作用在类上，也可以作用在方法上，该注解能够指定要使用的策略。其中粒度设置优先级的关系是 方法 > 类 > 全局配置。用户也可以根据自己的实际情况，定义自己的粒度策略。

When the SentinelInvocationHandler generates the resourceName, it will look up the generation strategy and perform different processing according to different generation strategies. The global default generation strategy is rest api. The default generation strategy can be configured in the configuration file (spring.cloud.sentinel.feign.resource-handler.default-handler).
Of course, in order to make the granular control more flexible, I also customized an annotation: @ResourceHandler can act on the class or on the method. The annotation can specify the strategy to be used. The relationship of granularity setting priority is Method> Class> Global Configuration. Users can also define their own granularity strategy according to their actual situation.

### Describe how to verify it
com.alibaba.cloud.sentinel.SentinelFeignTests#testFeignServiceInstanceResourceHandler()
可以在接口中添加注解，调整resource策略。

com.alibaba.cloud.sentinel.feign.SentinelInvocationHandler第115行，断点可以看到生成的resourceName。

### Special notes for reviews
