### PR TITLE
init DubboCloudRegistry when subscribe or unsubscribe

### DIFF
--- a/spring-cloud-alibaba-examples/spring-cloud-alibaba-dubbo-examples/spring-cloud-dubbo-client-sample/pom.xml
+++ b/spring-cloud-alibaba-examples/spring-cloud-alibaba-dubbo-examples/spring-cloud-dubbo-client-sample/pom.xml
@@ -10,7 +10,6 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.alibaba.cloud</groupId>
     <artifactId>spring-cloud-dubbo-client-sample</artifactId>
     <name>Spring Cloud Dubbo Client Sample</name>
 

--- a/spring-cloud-alibaba-examples/spring-cloud-alibaba-dubbo-examples/spring-cloud-dubbo-client-sample/src/main/resources/bootstrap.yaml
+++ b/spring-cloud-alibaba-examples/spring-cloud-alibaba-dubbo-examples/spring-cloud-dubbo-client-sample/src/main/resources/bootstrap.yaml
@@ -12,7 +12,11 @@ spring:
     allow-bean-definition-overriding: true
   cloud:
     nacos:
-      username: nacos
-      password: nacos
       discovery:
+        username: nacos
+        password: nacos
         server-addr: 127.0.0.1:8848
+        namespace: public
+
+server:
+  port: 8080

--- a/spring-cloud-alibaba-examples/spring-cloud-alibaba-dubbo-examples/spring-cloud-dubbo-server-sample/src/main/resources/bootstrap.yaml
+++ b/spring-cloud-alibaba-examples/spring-cloud-alibaba-dubbo-examples/spring-cloud-dubbo-server-sample/src/main/resources/bootstrap.yaml
@@ -1,4 +1,6 @@
 dubbo:
+  cloud:
+    subscribed-services: ${spring.application.name}
   scan:
     base-packages: com.alibaba.cloud.dubbo.bootstrap
   protocol:


### PR DESCRIPTION
as https://github.com/alibaba/spring-cloud-alibaba/issues/2007

DubboCloudRegistry should be init earlier. 

---
original DubboCloudRegistry listenerning ContextRefreshedEvent, so only if all spring environment prepared then the DubboCloudRegistry can be init.
but, when creating dubbo service reference, ReferenceConfig need DubboCloudRegistry init finish. 

so. it will lead to the provider not exist exception.

---
在原先的实现中，DubboCloudRegistry 通过监听 ContextRefreshedEvent 事件来实现初始化。所以只有完整的spring环境全部准备弯沉过以后，才会触发 DubboCloudRegistry 的初始化逻辑。
但是由于在创建 dubbo 的 Reference 过程中，需要 DubboCloudRegistry 初始化完成。

这就导致了只要开启了 dubbo 的 consumer.check 就会触发 noprovider 的异常。
