### PR TITLE
add 基于spring cloud loadbalancer实现nacos权重路由

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ target
 
 # Maven ignore
 .flattened-pom.xml
+
+# AsciiDoc ignore
+spring-cloud-alibaba-docs/**/*.html

--- a/spring-cloud-alibaba-docs/src/main/asciidoc-zh/nacos-discovery.adoc
+++ b/spring-cloud-alibaba-docs/src/main/asciidoc-zh/nacos-discovery.adoc
@@ -291,6 +291,47 @@ Endpoint 暴露的 json 中包含了两种属性:
 }
 ----
 
+=== 如何开启权重路由
+
+开启方式有2种，分别基于Ribbon和Spring Cloud Loadbalancer
+
+==== Ribbon
+
+.application.properties
+[source,properties]
+----
+[service_name].ribbon.NFLoadBalancerRuleClassName=com.alibaba.cloud.nacos.ribbon.NacosRule
+----
+
+==== Spring Cloud Loadbalancer
+.pom.xml
+[source,xml]
+----
+<dependency>
+    <groupId>org.springframework.cloud</groupId>
+    <artifactId>spring-cloud-loadbalancer</artifactId>
+</dependency>
+----
+
+.application.properties
+[source,properties]
+----
+spring.cloud.loadbalancer.ribbon.enabled=false
+----
+.Application.java
+[source,java]
+----
+@LoadBalancerClients(defaultConfiguration = NacosLoadBalancerClientConfiguration.class)
+@SpringBootApplication
+public class Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Gateway.class, args);
+    }
+}
+----
+
+
 === 关于 Nacos Discovery Starter 更多的配置项信息
 
 更多关于 Nacos Discovery Starter 的配置项如下所示:

--- a/spring-cloud-alibaba-docs/src/main/asciidoc-zh/nacos-discovery.adoc
+++ b/spring-cloud-alibaba-docs/src/main/asciidoc-zh/nacos-discovery.adoc
@@ -366,6 +366,7 @@ public class Application {
 |集群|`spring.cloud.nacos.discovery.cluster-name`|`DEFAULT`|Nacos集群名称
 |接入点|`spring.cloud.nacos.discovery.endpoint`||地域的某个服务的入口域名，通过此域名可以动态地拿到服务端地址
 |是否集成Ribbon|`ribbon.nacos.enabled`|`true`|一般都设置成true即可
+|是否集成LoadBalancer|`loadbalancer.nacos.enabled`|`false`|为true则开启NacosLoadBalancer
 |是否开启Nacos Watch|`spring.cloud.nacos.discovery.watch.enabled`|`true`|可以设置成false来关闭 watch
 |===
 

--- a/spring-cloud-alibaba-docs/src/main/asciidoc-zh/nacos-discovery.adoc
+++ b/spring-cloud-alibaba-docs/src/main/asciidoc-zh/nacos-discovery.adoc
@@ -307,11 +307,25 @@ Endpoint 暴露的 json 中包含了两种属性:
 .pom.xml
 [source,xml]
 ----
-<dependency>
-    <groupId>org.springframework.cloud</groupId>
-    <artifactId>spring-cloud-loadbalancer</artifactId>
-</dependency>
+<dependencies>
+    <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-loadbalancer</artifactId>
+    </dependency>
+
+    <dependency>
+        <groupId>com.alibaba.cloud</groupId>
+        <artifactId>spring-cloud-starter-alibaba-nacos-discovery</artifactId>
+        <exclusions>
+            <exclusion>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-starter-netflix-ribbon</artifactId>
+            </exclusion>
+        </exclusions>
+    </dependency>
+</dependencies>
 ----
+你也可以不在 pom.xml 中排除spring-cloud-starter-netflix-ribbon，而在配置文件中关闭Ribbon
 
 .application.properties
 [source,properties]

--- a/spring-cloud-alibaba-docs/src/main/asciidoc/nacos-discovery.adoc
+++ b/spring-cloud-alibaba-docs/src/main/asciidoc/nacos-discovery.adoc
@@ -368,6 +368,7 @@ The following shows the other configurations of the starter of Nacos Discovery:
 |Cluster Name|`spring.cloud.nacos.discovery.cluster-name`|`DEFAULT`|Cluster name of Nacos
 |Endpoint|`spring.cloud.nacos.discovery.endpoint`||The domain name of a certain service in a specific region. You can retrieve the server address dynamically with this domain name
 |Integrate Ribbon or not|`ribbon.nacos.enabled`|`true`|Set to true in most cases
+|Integrate LoadBalancer or not|`loadbalancer.nacos.enabled`|`false`|True turns on NacoLoadBalancer
 |Enable Nacos Watch|`spring.cloud.nacos.discovery.watch.enabled`|`true`|set to false to close watch
 |===
 

--- a/spring-cloud-alibaba-docs/src/main/asciidoc/nacos-discovery.adoc
+++ b/spring-cloud-alibaba-docs/src/main/asciidoc/nacos-discovery.adoc
@@ -294,6 +294,46 @@ The followings shows how a service instance accesses the Endpoint:
 }
 ----
 
+=== Weight Route
+
+There are 2 ways to open it, respectively based on the Ribbon and Spring Cloud Loadbalancer
+
+==== Ribbon
+
+.application.properties
+[source,properties]
+----
+[service_name].ribbon.NFLoadBalancerRuleClassName=com.alibaba.cloud.nacos.ribbon.NacosRule
+----
+
+==== Spring Cloud Loadbalancer
+.pom.xml
+[source,xml]
+----
+<dependency>
+    <groupId>org.springframework.cloud</groupId>
+    <artifactId>spring-cloud-loadbalancer</artifactId>
+</dependency>
+----
+
+.application.properties
+[source,properties]
+----
+spring.cloud.loadbalancer.ribbon.enabled=false
+----
+.Application.java
+[source,java]
+----
+@LoadBalancerClients(defaultConfiguration = NacosLoadBalancerClientConfiguration.class)
+@SpringBootApplication
+public class Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Gateway.class, args);
+    }
+}
+----
+
 === More Information about Nacos Discovery Starter Configurations
 
 The following shows the other configurations of the starter of Nacos Discovery:

--- a/spring-cloud-alibaba-docs/src/main/asciidoc/nacos-discovery.adoc
+++ b/spring-cloud-alibaba-docs/src/main/asciidoc/nacos-discovery.adoc
@@ -310,11 +310,25 @@ There are 2 ways to open it, respectively based on the Ribbon and Spring Cloud L
 .pom.xml
 [source,xml]
 ----
-<dependency>
-    <groupId>org.springframework.cloud</groupId>
-    <artifactId>spring-cloud-loadbalancer</artifactId>
-</dependency>
+<dependencies>
+    <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-loadbalancer</artifactId>
+    </dependency>
+
+    <dependency>
+        <groupId>com.alibaba.cloud</groupId>
+        <artifactId>spring-cloud-starter-alibaba-nacos-discovery</artifactId>
+        <exclusions>
+            <exclusion>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-starter-netflix-ribbon</artifactId>
+            </exclusion>
+        </exclusions>
+    </dependency>
+</dependencies>
 ----
+You can also not exclude spring-cloud-starter-netflix-ribbon in pom.xml, and turn off Ribbon in the configuration file
 
 .application.properties
 [source,properties]

--- a/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/nacos-discovery-consumer-sclb-example/src/main/java/com/alibaba/cloud/examples/ConsumerSCLBApplication.java
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/nacos-discovery-consumer-sclb-example/src/main/java/com/alibaba/cloud/examples/ConsumerSCLBApplication.java
@@ -27,6 +27,7 @@ import reactor.core.publisher.Mono;
 
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.ServiceInstance;
@@ -157,10 +158,19 @@ public class ConsumerSCLBApplication {
 		@Autowired
 		private DiscoveryClient discoveryClient;
 
+		@Value("${spring.cloud.loadbalancer.zone:null}")
+		private String zone;
+
 		@GetMapping("/echo-rest/{str}")
 		public String rest(@PathVariable String str) {
 			return restTemplate.getForObject("http://service-provider/echo/" + str,
 					String.class);
+		}
+
+		@GetMapping("/zone")
+		public String zone() {
+			return "consumer zone " + zone + "\n" + restTemplate
+					.getForObject("http://service-provider/zone", String.class);
 		}
 
 		@GetMapping("/echo-feign/{str}")

--- a/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/nacos-discovery-consumer-sclb-example/src/main/resources/application.properties
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/nacos-discovery-consumer-sclb-example/src/main/resources/application.properties
@@ -7,6 +7,8 @@ spring.cloud.nacos.username=nacos
 spring.cloud.nacos.password=nacos
 
 spring.cloud.loadbalancer.ribbon.enabled=false
+spring.cloud.loadbalancer.configurations=zone-preference
+spring.cloud.loadbalancer.zone=hangzhou
 
 feign.sentinel.enabled=true
 

--- a/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/nacos-discovery-provider-example/src/main/java/com/alibaba/cloud/examples/ProviderApplication.java
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/nacos-discovery-provider-example/src/main/java/com/alibaba/cloud/examples/ProviderApplication.java
@@ -16,6 +16,12 @@
 
 package com.alibaba.cloud.examples;
 
+import java.util.Map;
+
+import javax.annotation.Resource;
+
+import com.alibaba.cloud.nacos.NacosDiscoveryProperties;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
@@ -39,6 +45,9 @@ public class ProviderApplication {
 
 	@RestController
 	class EchoController {
+
+		@Resource
+		private NacosDiscoveryProperties nacosDiscoveryProperties;
 
 		@GetMapping("/")
 		public ResponseEntity index() {
@@ -69,6 +78,12 @@ public class ProviderApplication {
 		@GetMapping("/divide")
 		public String divide(@RequestParam Integer a, @RequestParam Integer b) {
 			return String.valueOf(a / b);
+		}
+
+		@GetMapping("/zone")
+		public String zone() {
+			Map<String, String> metadata = nacosDiscoveryProperties.getMetadata();
+			return "provider zone " + metadata.get("zone");
 		}
 
 	}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/pom.xml
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/pom.xml
@@ -99,6 +99,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-loadbalancer</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
             <scope>test</scope>

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/balancer/NacosBalancer.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/balancer/NacosBalancer.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.nacos.balancer;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.alibaba.nacos.api.naming.pojo.Instance;
+import com.alibaba.nacos.client.naming.core.Balancer;
+
+import org.springframework.cloud.client.ServiceInstance;
+
+/**
+ * @author itmuch.com XuDaojie
+ * @since 2.2.6
+ */
+public class NacosBalancer extends Balancer {
+
+	/**
+	 * Choose instance by weight.
+	 * @param instances Instance List
+	 * @return the chosen instance
+	 */
+	public static Instance getHostByRandomWeight2(List<Instance> instances) {
+		return getHostByRandomWeight(instances);
+	}
+
+	/**
+	 * Spring Cloud LoadBalancer Choose instance by weight.
+	 * @param serviceInstances Instance List
+	 * @return the chosen instance
+	 */
+	public static ServiceInstance getHostByRandomWeight3(
+			List<ServiceInstance> serviceInstances) {
+		Map<Instance, ServiceInstance> instanceMap = new HashMap<>();
+		List<Instance> nacosInstance = serviceInstances.stream().map(serviceInstance -> {
+			Map<String, String> metadata = serviceInstance.getMetadata();
+
+			// see
+			// com.alibaba.cloud.nacos.discovery.NacosServiceDiscovery.hostToServiceInstance()
+			Instance instance = new Instance();
+			instance.setIp(serviceInstance.getHost());
+			instance.setPort(serviceInstance.getPort());
+			instance.setWeight(Double.parseDouble(metadata.get("nacos.weight")));
+			instance.setHealthy(Boolean.parseBoolean(metadata.get("nacos.healthy")));
+			instanceMap.put(instance, serviceInstance);
+			return instance;
+		}).collect(Collectors.toList());
+
+		Instance instance = getHostByRandomWeight2(nacosInstance);
+		return instanceMap.get(instance);
+	}
+
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/ConditionalOnLoadBalancerNacos.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/ConditionalOnLoadBalancerNacos.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.nacos.loadbalancer;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@ConditionalOnProperty(value = "loadbalancer.nacos.enabled", matchIfMissing = false)
+public @interface ConditionalOnLoadBalancerNacos {
+
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/LoadBalancerNacosAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/LoadBalancerNacosAutoConfiguration.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.nacos.loadbalancer;
+
+import com.alibaba.cloud.nacos.ConditionalOnNacosDiscoveryEnabled;
+
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.loadbalancer.annotation.LoadBalancerClients;
+import org.springframework.cloud.loadbalancer.config.LoadBalancerAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * {@link org.springframework.boot.autoconfigure.EnableAutoConfiguration
+ * Auto-configuration} that sets up LoadBalancer for Nacos.
+ */
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties
+@ConditionalOnLoadBalancerNacos
+@ConditionalOnNacosDiscoveryEnabled
+@AutoConfigureBefore(LoadBalancerAutoConfiguration.class)
+@LoadBalancerClients(defaultConfiguration = NacosLoadBalancerClientConfiguration.class)
+public class LoadBalancerNacosAutoConfiguration {
+
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/NacosLoadBalancer.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/NacosLoadBalancer.java
@@ -27,10 +27,8 @@ import com.alibaba.cloud.nacos.ribbon.ExtendBalancer;
 import com.alibaba.nacos.api.naming.NamingService;
 import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.client.naming.utils.CollectionUtils;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import reactor.core.publisher.Mono;
 
 import org.springframework.beans.factory.ObjectProvider;

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/NacosLoadBalancer.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/NacosLoadBalancer.java
@@ -16,6 +16,10 @@
 
 package com.alibaba.cloud.nacos.loadbalancer;
 
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
 import com.alibaba.cloud.commons.lang.StringUtils;
 import com.alibaba.cloud.nacos.NacosDiscoveryProperties;
 import com.alibaba.cloud.nacos.NacosServiceManager;
@@ -26,6 +30,9 @@ import com.alibaba.nacos.client.naming.utils.CollectionUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import reactor.core.publisher.Mono;
+
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.loadbalancer.reactive.DefaultResponse;
@@ -38,14 +45,7 @@ import org.springframework.cloud.loadbalancer.core.ReactorServiceInstanceLoadBal
 import org.springframework.cloud.loadbalancer.core.ServiceInstanceListSupplier;
 import org.springframework.cloud.loadbalancer.core.ServiceInstanceSupplier;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
-
-import reactor.core.publisher.Mono;
-
 /**
- *
  * @author XuDaojie
  * @since 2.2.6
  */
@@ -57,9 +57,11 @@ public class NacosLoadBalancer implements ReactorServiceInstanceLoadBalancer {
 
 	@Deprecated
 	private ObjectProvider<ServiceInstanceSupplier> serviceInstanceSupplier;
+
 	private ObjectProvider<ServiceInstanceListSupplier> serviceInstanceListSupplierProvider;
 
 	private final NacosDiscoveryProperties nacosDiscoveryProperties;
+
 	private final NacosServiceManager nacosServiceManager;
 
 	public NacosLoadBalancer(
@@ -125,7 +127,8 @@ public class NacosLoadBalancer implements ReactorServiceInstanceLoadBalancer {
 			Instance instance = ExtendBalancer.getHostByRandomWeight2(instancesToChoose);
 
 			return new DefaultResponse(serviceInstances.stream()
-					.filter(serviceInstance1 -> StringUtils.equals(instance.getIp(), serviceInstance1.getHost())
+					.filter(serviceInstance1 -> StringUtils.equals(instance.getIp(),
+							serviceInstance1.getHost())
 							&& instance.getPort() == serviceInstance1.getPort())
 					.findFirst().get());
 		}
@@ -135,4 +138,5 @@ public class NacosLoadBalancer implements ReactorServiceInstanceLoadBalancer {
 		}
 
 	}
+
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/NacosLoadBalancer.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/NacosLoadBalancer.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.nacos.loadbalancer;
+
+import com.alibaba.cloud.commons.lang.StringUtils;
+import com.alibaba.cloud.nacos.NacosDiscoveryProperties;
+import com.alibaba.cloud.nacos.NacosServiceManager;
+import com.alibaba.cloud.nacos.ribbon.ExtendBalancer;
+import com.alibaba.nacos.api.naming.NamingService;
+import com.alibaba.nacos.api.naming.pojo.Instance;
+import com.alibaba.nacos.client.naming.utils.CollectionUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.loadbalancer.reactive.DefaultResponse;
+import org.springframework.cloud.client.loadbalancer.reactive.EmptyResponse;
+import org.springframework.cloud.client.loadbalancer.reactive.Request;
+import org.springframework.cloud.client.loadbalancer.reactive.Response;
+import org.springframework.cloud.loadbalancer.core.NoopServiceInstanceListSupplier;
+import org.springframework.cloud.loadbalancer.core.NoopServiceInstanceSupplier;
+import org.springframework.cloud.loadbalancer.core.ReactorServiceInstanceLoadBalancer;
+import org.springframework.cloud.loadbalancer.core.ServiceInstanceListSupplier;
+import org.springframework.cloud.loadbalancer.core.ServiceInstanceSupplier;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import reactor.core.publisher.Mono;
+
+/**
+ *
+ * @author XuDaojie
+ * @since 2.2.6
+ */
+public class NacosLoadBalancer implements ReactorServiceInstanceLoadBalancer {
+
+	private static final Logger log = LoggerFactory.getLogger(NacosLoadBalancer.class);
+
+	private final String serviceId;
+
+	@Deprecated
+	private ObjectProvider<ServiceInstanceSupplier> serviceInstanceSupplier;
+	private ObjectProvider<ServiceInstanceListSupplier> serviceInstanceListSupplierProvider;
+
+	private final NacosDiscoveryProperties nacosDiscoveryProperties;
+	private final NacosServiceManager nacosServiceManager;
+
+	public NacosLoadBalancer(
+			ObjectProvider<ServiceInstanceListSupplier> serviceInstanceListSupplierProvider,
+			String serviceId, NacosDiscoveryProperties nacosDiscoveryProperties,
+			NacosServiceManager nacosServiceManager) {
+		this.serviceId = serviceId;
+		this.serviceInstanceListSupplierProvider = serviceInstanceListSupplierProvider;
+		this.nacosDiscoveryProperties = nacosDiscoveryProperties;
+		this.nacosServiceManager = nacosServiceManager;
+	}
+
+	@Override
+	public Mono<Response<ServiceInstance>> choose(Request request) {
+		// Temporary conditional logic till deprecated members are removed.
+		if (serviceInstanceListSupplierProvider != null) {
+			ServiceInstanceListSupplier supplier = serviceInstanceListSupplierProvider
+					.getIfAvailable(NoopServiceInstanceListSupplier::new);
+			return supplier.get().next().map(this::getInstanceResponse);
+		}
+		ServiceInstanceSupplier supplier = this.serviceInstanceSupplier
+				.getIfAvailable(NoopServiceInstanceSupplier::new);
+		return supplier.get().collectList().map(this::getInstanceResponse);
+	}
+
+	private Response<ServiceInstance> getInstanceResponse(
+			List<ServiceInstance> serviceInstances) {
+		if (serviceInstances.isEmpty()) {
+			log.warn("No servers available for service: " + this.serviceId);
+			return new EmptyResponse();
+		}
+
+		try {
+			String clusterName = this.nacosDiscoveryProperties.getClusterName();
+			String group = this.nacosDiscoveryProperties.getGroup();
+			String serviceName = serviceId;
+
+			NamingService namingService = nacosServiceManager
+					.getNamingService(nacosDiscoveryProperties.getNacosProperties());
+			List<Instance> instances = namingService.selectInstances(serviceName, group,
+					true);
+			if (CollectionUtils.isEmpty(instances)) {
+				log.warn("no instance in service {}", serviceName);
+				return null;
+			}
+
+			List<Instance> instancesToChoose = instances;
+			if (StringUtils.isNotBlank(clusterName)) {
+				List<Instance> sameClusterInstances = instances.stream()
+						.filter(instance -> Objects.equals(clusterName,
+								instance.getClusterName()))
+						.collect(Collectors.toList());
+				if (!CollectionUtils.isEmpty(sameClusterInstances)) {
+					instancesToChoose = sameClusterInstances;
+				}
+				else {
+					log.warn(
+							"A cross-cluster call occurs，name = {}, clusterName = {}, instance = {}",
+							serviceName, clusterName, instances);
+				}
+			}
+
+			Instance instance = ExtendBalancer.getHostByRandomWeight2(instancesToChoose);
+
+			return new DefaultResponse(serviceInstances.stream()
+					.filter(serviceInstance1 -> StringUtils.equals(instance.getIp(), serviceInstance1.getHost())
+							&& instance.getPort() == serviceInstance1.getPort())
+					.findFirst().get());
+		}
+		catch (Exception e) {
+			log.warn("NacosLoadBalancer error", e);
+			return null;
+		}
+
+	}
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/NacosLoadBalancerClientConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/NacosLoadBalancerClientConfiguration.java
@@ -43,4 +43,5 @@ public class NacosLoadBalancerClientConfiguration {
 						ServiceInstanceListSupplier.class),
 				name, nacosDiscoveryProperties, nacosServiceManager);
 	}
+
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/NacosLoadBalancerClientConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/NacosLoadBalancerClientConfiguration.java
@@ -18,6 +18,7 @@ package com.alibaba.cloud.nacos.loadbalancer;
 
 import com.alibaba.cloud.nacos.NacosDiscoveryProperties;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.loadbalancer.core.ReactorLoadBalancer;
 import org.springframework.cloud.loadbalancer.core.ServiceInstanceListSupplier;
@@ -32,6 +33,7 @@ import org.springframework.core.env.Environment;
 public class NacosLoadBalancerClientConfiguration {
 
 	@Bean
+	@ConditionalOnMissingBean
 	public ReactorLoadBalancer<ServiceInstance> nacosLoadBalancer(Environment environment,
 			LoadBalancerClientFactory loadBalancerClientFactory,
 			NacosDiscoveryProperties nacosDiscoveryProperties) {

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/NacosLoadBalancerClientConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/NacosLoadBalancerClientConfiguration.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.nacos.loadbalancer;
+
+import com.alibaba.cloud.nacos.NacosDiscoveryProperties;
+import com.alibaba.cloud.nacos.NacosServiceManager;
+
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.loadbalancer.core.ReactorLoadBalancer;
+import org.springframework.cloud.loadbalancer.core.ServiceInstanceListSupplier;
+import org.springframework.cloud.loadbalancer.support.LoadBalancerClientFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.env.Environment;
+
+/**
+ * @author XuDaojie
+ * @since 2.2.6
+ */
+public class NacosLoadBalancerClientConfiguration {
+
+	@Bean
+	public ReactorLoadBalancer<ServiceInstance> nacosLoadBalancer(Environment environment,
+			LoadBalancerClientFactory loadBalancerClientFactory,
+			NacosDiscoveryProperties nacosDiscoveryProperties,
+			NacosServiceManager nacosServiceManager) {
+		String name = environment.getProperty(LoadBalancerClientFactory.PROPERTY_NAME);
+		return new NacosLoadBalancer(
+				loadBalancerClientFactory.getLazyProvider(name,
+						ServiceInstanceListSupplier.class),
+				name, nacosDiscoveryProperties, nacosServiceManager);
+	}
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/NacosLoadBalancerClientConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/NacosLoadBalancerClientConfiguration.java
@@ -17,7 +17,6 @@
 package com.alibaba.cloud.nacos.loadbalancer;
 
 import com.alibaba.cloud.nacos.NacosDiscoveryProperties;
-import com.alibaba.cloud.nacos.NacosServiceManager;
 
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.loadbalancer.core.ReactorLoadBalancer;
@@ -35,13 +34,12 @@ public class NacosLoadBalancerClientConfiguration {
 	@Bean
 	public ReactorLoadBalancer<ServiceInstance> nacosLoadBalancer(Environment environment,
 			LoadBalancerClientFactory loadBalancerClientFactory,
-			NacosDiscoveryProperties nacosDiscoveryProperties,
-			NacosServiceManager nacosServiceManager) {
+			NacosDiscoveryProperties nacosDiscoveryProperties) {
 		String name = environment.getProperty(LoadBalancerClientFactory.PROPERTY_NAME);
 		return new NacosLoadBalancer(
 				loadBalancerClientFactory.getLazyProvider(name,
 						ServiceInstanceListSupplier.class),
-				name, nacosDiscoveryProperties, nacosServiceManager);
+				name, nacosDiscoveryProperties);
 	}
 
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/ribbon/ExtendBalancer.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/ribbon/ExtendBalancer.java
@@ -16,23 +16,11 @@
 
 package com.alibaba.cloud.nacos.ribbon;
 
-import java.util.List;
-
-import com.alibaba.nacos.api.naming.pojo.Instance;
-import com.alibaba.nacos.client.naming.core.Balancer;
+import com.alibaba.cloud.nacos.balancer.NacosBalancer;
 
 /**
  * @author itmuch.com
  */
-public class ExtendBalancer extends Balancer {
-
-	/**
-	 * Choose instance by weight.
-	 * @param instances Instance List
-	 * @return the chosen instance
-	 */
-	public static Instance getHostByRandomWeight2(List<Instance> instances) {
-		return getHostByRandomWeight(instances);
-	}
+public class ExtendBalancer extends NacosBalancer {
 
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/resources/META-INF/spring.factories
@@ -1,6 +1,7 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
   com.alibaba.cloud.nacos.discovery.NacosDiscoveryAutoConfiguration,\
   com.alibaba.cloud.nacos.ribbon.RibbonNacosAutoConfiguration,\
+  com.alibaba.cloud.nacos.loadbalancer.LoadBalancerNacosAutoConfiguration,\
   com.alibaba.cloud.nacos.endpoint.NacosDiscoveryEndpointAutoConfiguration,\
   com.alibaba.cloud.nacos.registry.NacosServiceRegistryAutoConfiguration,\
   com.alibaba.cloud.nacos.discovery.NacosDiscoveryClientConfiguration,\


### PR DESCRIPTION
### Describe what this PR does / why we need it
1. 修改nacos-discovery文档
nacos 有权重路由的功能，但在spring cloud alibaba、nacos文档中均未提及如何开启此功能，即使通过搜索引擎，有找到的也基本是要自己实现的，不过看了下源码，实际已经提供了完整的实现，只需添加配置即可。
2. 新增基于Spring Cloud LoadBalancer的Nacos权重路由实现 
未来 spring cloud Netflix 应该会被完全移除，目前似乎只剩下ribbon了
3. 修改.gitignore文件
使用idea插件预览adoc html文件时默认会在文档目录生成html文件，对生成的HTML文件进行忽略

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
None
### Describe how you did it
参考的NacosRule（目前已实现的基于Ribbon的方法）、RoundRobinLoadBalancer(spring cloud loadbalancer 默认的轮询实现)

### Describe how to verify it
在[nacos-discovery.adoc](https://github.com/XuDaojie/spring-cloud-alibaba/commit/6b4a3768c1c8f9cf2cd3733c9f6838b0ce0ff588#diff-e18ce2f78c8db08698412c029125f2e656a99e7aafa7075bdddf4296804ccae7)中添加了使用方法

### Special notes for reviews
