### PR TITLE
use aop to save and get FeignClientFactoryBean

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/feign/SentinelFeign.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/feign/SentinelFeign.java
@@ -80,34 +80,37 @@ public final class SentinelFeign {
 					// using reflect get fallback and fallbackFactory properties from
 					// FeignClientFactoryBean because FeignClientFactoryBean is a package
 					// level class, we can not use it in our package
-					Object feignClientFactoryBean = Builder.this.applicationContext
-							.getBean("&" + target.type().getName());
+					Object feignClientFactoryBean = SentinelTargeterAspect
+							.getFeignClientFactoryBean();
 
-					Class fallback = (Class) getFieldValue(feignClientFactoryBean,
-							"fallback");
-					Class fallbackFactory = (Class) getFieldValue(feignClientFactoryBean,
-							"fallbackFactory");
-					String beanName = (String) getFieldValue(feignClientFactoryBean,
-							"contextId");
-					if (!StringUtils.hasText(beanName)) {
-						beanName = (String) getFieldValue(feignClientFactoryBean, "name");
-					}
+					if (feignClientFactoryBean != null) {
+						Class fallback = (Class) getFieldValue(feignClientFactoryBean,
+								"fallback");
+						Class fallbackFactory = (Class) getFieldValue(
+								feignClientFactoryBean, "fallbackFactory");
+						String beanName = (String) getFieldValue(feignClientFactoryBean,
+								"contextId");
+						if (!StringUtils.hasText(beanName)) {
+							beanName = (String) getFieldValue(feignClientFactoryBean,
+									"name");
+						}
 
-					Object fallbackInstance;
-					FallbackFactory fallbackFactoryInstance;
-					// check fallback and fallbackFactory properties
-					if (void.class != fallback) {
-						fallbackInstance = getFromContext(beanName, "fallback", fallback,
-								target.type());
-						return new SentinelInvocationHandler(target, dispatch,
-								new FallbackFactory.Default(fallbackInstance));
-					}
-					if (void.class != fallbackFactory) {
-						fallbackFactoryInstance = (FallbackFactory) getFromContext(
-								beanName, "fallbackFactory", fallbackFactory,
-								FallbackFactory.class);
-						return new SentinelInvocationHandler(target, dispatch,
-								fallbackFactoryInstance);
+						Object fallbackInstance;
+						FallbackFactory fallbackFactoryInstance;
+						// check fallback and fallbackFactory properties
+						if (void.class != fallback) {
+							fallbackInstance = getFromContext(beanName, "fallback",
+									fallback, target.type());
+							return new SentinelInvocationHandler(target, dispatch,
+									new FallbackFactory.Default(fallbackInstance));
+						}
+						if (void.class != fallbackFactory) {
+							fallbackFactoryInstance = (FallbackFactory) getFromContext(
+									beanName, "fallbackFactory", fallbackFactory,
+									FallbackFactory.class);
+							return new SentinelInvocationHandler(target, dispatch,
+									fallbackFactoryInstance);
+						}
 					}
 					return new SentinelInvocationHandler(target, dispatch);
 				}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/feign/SentinelFeignAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/feign/SentinelFeignAutoConfiguration.java
@@ -41,4 +41,11 @@ public class SentinelFeignAutoConfiguration {
 		return SentinelFeign.builder();
 	}
 
+	@Bean
+	@ConditionalOnProperty(name = "feign.sentinel.enabled")
+	@ConditionalOnClass(name = "org.springframework.cloud.openfeign.Targeter")
+	public SentinelTargeterAspect sentinelTargeterAspect() {
+		return new SentinelTargeterAspect();
+	}
+
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/feign/SentinelTargeterAspect.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/feign/SentinelTargeterAspect.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.sentinel.feign;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+
+/**
+ * Record FeignClientFactoryBean to threadlocal, so that SentinelFeign can get it when
+ * creating SentinelInvocationHandler.
+ *
+ * @see com.alibaba.cloud.sentinel.feign.SentinelFeign.Builder
+ * @author <a href="mailto:chenxilzx1@gmail.com">theonefx</a>
+ */
+@Aspect
+public class SentinelTargeterAspect {
+
+	private static final ThreadLocal<Object> FEIGN_CLIENT_FACTORY_BEAN = new ThreadLocal<>();
+
+	public static Object getFeignClientFactoryBean() {
+		return FEIGN_CLIENT_FACTORY_BEAN.get();
+	}
+
+	@Around("execution(* org.springframework.cloud.openfeign.Targeter.target(..))")
+	public Object process(ProceedingJoinPoint pjp) throws Throwable {
+		Object factory = pjp.getArgs()[0];
+		try {
+			FEIGN_CLIENT_FACTORY_BEAN.set(factory);
+			return pjp.proceed();
+		}
+		finally {
+			FEIGN_CLIENT_FACTORY_BEAN.remove();
+		}
+	}
+
+}


### PR DESCRIPTION
Using AOP to obtain feignClientFactoryBean, in order to create SentinelInvocationHandler can get it.

fix following issue: 
- https://github.com/alibaba/spring-cloud-alibaba/issues/2137
- https://github.com/alibaba/spring-cloud-alibaba/issues/2122
- https://github.com/alibaba/spring-cloud-alibaba/issues/2107