### PR TITLE
throw exception directly when exception is not an BlockException

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/custom/SentinelProtectInterceptor.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/custom/SentinelProtectInterceptor.java
@@ -86,13 +86,23 @@ public class SentinelProtectInterceptor implements ClientHttpRequestInterceptor 
 				Tracer.trace(
 						new IllegalStateException("RestTemplate ErrorHandler has error"));
 			}
+			return response;
 		}
 		catch (Throwable e) {
-			if (!BlockException.isBlockException(e)) {
-				Tracer.trace(e);
+			if (BlockException.isBlockException(e)) {
+				return handleBlockException(request, body, execution, (BlockException) e);
 			}
 			else {
-				return handleBlockException(request, body, execution, (BlockException) e);
+				Tracer.trace(e);
+				if (e instanceof IOException) {
+					throw (IOException) e;
+				}
+				else if (e instanceof RuntimeException) {
+					throw (RuntimeException) e;
+				}
+				else {
+					throw new IOException(e);
+				}
 			}
 		}
 		finally {
@@ -103,7 +113,6 @@ public class SentinelProtectInterceptor implements ClientHttpRequestInterceptor 
 				hostEntry.exit();
 			}
 		}
-		return response;
 	}
 
 	private ClientHttpResponse handleBlockException(HttpRequest request, byte[] body,


### PR DESCRIPTION
Throw exception directly when exception is not an BlockException. 
Because Sentinel can't do anything if the exception is not an BlockException, the exception should be handled upstream.

fix issue :
- Closes #2044
- Closes #1346