### PR TITLE
基于版本号调用的一种方法

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
@@ -213,6 +213,16 @@ public class NacosDiscoveryProperties {
 	 */
 	private boolean failFast = true;
 
+	/**
+	 *The service version number.
+	 */
+	private String serviceVersion;
+
+	/**
+	 * The target service version number.
+	 */
+	private String targetVersion;
+
 	@Autowired
 	private InetUtils inetUtils;
 
@@ -498,6 +508,20 @@ public class NacosDiscoveryProperties {
 
 	public void setFailFast(boolean failFast) {
 		this.failFast = failFast;
+	}
+
+	public void setServiceVersion(String serviceVersion) {
+		// Add the serviceVersion field to the provider service's Metadata
+		Map<String, String> temp = new HashMap<>();
+		temp.put("service-version", serviceVersion);
+		setMetadata(temp);
+	}
+
+	public void setTargetVersion(String targetVersion) {
+		// Add the targetVersion field to the consumer service's Metadata
+		Map<String, String> temp = new HashMap<>();
+		temp.put("target-version", targetVersion);
+		setMetadata(temp);
 	}
 
 	@Override

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/ribbon/NacosVersionRule.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/ribbon/NacosVersionRule.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.nacos.ribbon;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import com.alibaba.cloud.commons.lang.StringUtils;
+import com.alibaba.cloud.nacos.NacosDiscoveryProperties;
+import com.alibaba.cloud.nacos.NacosServiceManager;
+import com.alibaba.nacos.api.naming.NamingService;
+import com.alibaba.nacos.api.naming.pojo.Instance;
+import com.netflix.client.config.IClientConfig;
+import com.netflix.loadbalancer.AbstractLoadBalancerRule;
+import com.netflix.loadbalancer.DynamicServerListLoadBalancer;
+import com.netflix.loadbalancer.Server;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.util.CollectionUtils;
+
+/**
+ * Supports calling the ribbon load balancing rules of the same version instance.<br/><br/>
+ * if not have version, will use {@link NacosRule}<br/><br/>
+ * @author ledyy
+ */
+public class NacosVersionRule extends AbstractLoadBalancerRule {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NacosVersionRule.class);
+
+    @Autowired
+    private NacosDiscoveryProperties nacosDiscoveryProperties;
+
+    @Autowired
+    private NacosServiceManager nacosServiceManager;
+
+    @Override
+    public Server choose(Object key) {
+        try {
+            String clusterName = this.nacosDiscoveryProperties.getClusterName();
+            String group = this.nacosDiscoveryProperties.getGroup();
+            String version = this.nacosDiscoveryProperties.getMetadata().get("target-version");
+            DynamicServerListLoadBalancer loadBalancer = (DynamicServerListLoadBalancer) getLoadBalancer();
+            String name = loadBalancer.getName();
+
+            NamingService namingService = nacosServiceManager
+                    .getNamingService(nacosDiscoveryProperties.getNacosProperties());
+            List<Instance> instances = namingService.selectInstances(name, group, true);
+            if (CollectionUtils.isEmpty(instances)) {
+                LOGGER.warn("no instance in service {}", name);
+                return null;
+            }
+
+            List<Instance> instancesToChoose = instances;
+
+            // if use “version” field
+            if (StringUtils.isNotBlank(version)) {
+                List<Instance> versionMatchInstance = instances.stream()
+                        .filter(instance -> Objects.equals(version,
+                                instance.getMetadata().get("service-version")))
+                        .collect(Collectors.toList());
+                if (!CollectionUtils.isEmpty(versionMatchInstance)) {
+                    instances = versionMatchInstance;
+                }
+                else {
+                    LOGGER.warn(
+                            "No instance with matching version, please check the application.properties：spring.cloud.nacos.discovery.version = {}，instance = {}",
+                            version, instances);
+                    return null;
+                }
+            }
+
+            if (StringUtils.isNotBlank(clusterName)) {
+                List<Instance> sameClusterInstances = instances.stream()
+                        .filter(instance -> Objects.equals(clusterName,
+                                instance.getClusterName()))
+                        .collect(Collectors.toList());
+                if (!CollectionUtils.isEmpty(sameClusterInstances)) {
+                    instancesToChoose = sameClusterInstances;
+                }
+                else {
+                    LOGGER.warn(
+                            "A cross-cluster call occurs，name = {}, clusterName = {}, instance = {}",
+                            name, clusterName, instances);
+                }
+            }
+
+            Instance instance = ExtendBalancer.getHostByRandomWeight2(instancesToChoose);
+
+            return new NacosServer(instance);
+        }
+        catch (Exception e) {
+            LOGGER.warn("NacosRule error", e);
+            return null;
+        }
+    }
+
+    @Override
+    public void initWithNiwsConfig(IClientConfig iClientConfig) {}
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,4 +1,5 @@
-{"properties": [
+{
+  "properties": [
     {
       "name": "spring.cloud.nacos.server-addr",
       "type": "java.lang.String",
@@ -60,6 +61,16 @@
       "description": "nacos discovery service's password to authenticate."
     },
     {
+      "name": "spring.cloud.nacos.discovery.service-version",
+      "type": "java.lang.String",
+      "description": "provider service's version."
+    },
+    {
+      "name": "spring.cloud.nacos.discovery.target-version",
+      "type": "java.lang.String",
+      "description": "consumer target service's version."
+    },
+    {
       "name": "spring.cloud.nacos.username",
       "type": "java.lang.String",
       "description": "nacos userName to authenticate."
@@ -69,4 +80,5 @@
       "type": "java.lang.String",
       "description": "nacos password to authenticate."
     }
-]}
+  ]
+}


### PR DESCRIPTION
# What is the purpose of the change
Add **a new loadbalancing rule**. We can use the "version” to loadbalancing

# Brief changelog
1. Add `class NacosVersionRule extends AbstractLoadBalancerRule {}` to implement version loadbalancing
2. Add two new fields `serviceVersion` and `targetVersion` in `class  NacosDiscoveryProperties`
3. Add two new fields `service-version` and `target-version` which prefix is `spring.cloud.nacos.discovery` in file `additional-spring-configuration-metadata.json`

# Verifying this change
In the development of microservices, I think version numbers are used frequently. But, Nacos does not provide service calls using version numbers. So I used the metadata in Nacos to solve the version calling loadbalancing.

Nacos encapsulates Ribbon and Feign to call services remotely, so we can write a custom remote load balancing call to realize version loadbalancing. The `class NacosVersionRule` imitates `class NacosRule`, and adds version load balancing on 
`class NacosRule` basis

Secondly,  I encapsulate two fields "service-version" and "target-version" to quickly specify the service version and invocation version in `application.properties`

# How to Use
1. in provider application.properties
    ```properties
    ...
    spring.cloud.nacos.discovery.service-version=1.0.0
    ....
    ````
2. in consumer application.properties
    ```properties
    ...
    spring.cloud.nacos.discovery.target-version=1.0.0
    ....
    ```
3. consumer config and controller
    ```java
   @Bean
    public IRule iRule(){
        return new NacosVersionRule();
    }
    ```
    ```java
    @Autowired
    private RestTemplate restTemplate;

    @RequestMapping("/time")
    public Object time(){
        String url = "http://nacos-version-provider/system/time";
        return restTemplate.getForObject(url,Object.class);
    }
    ```



<br/><br/><br/>

# 新增功能：Nacos下基于版本号的负载均衡
新增了一种负载均衡规则：`NacosVersionRule`，我们可以仅在Nacos中使用版本号进行服务的负载均衡调用

# 变更记录
1. 在 spring-cloud-starter-alibaba-nacos-discovery 模块的com.alibaba.cloud.nacos.ribbon 包下新增 class NacosVersionRule
2. 封装了两个字段：service-version、target-version 用来指定服务和调用服务的版本号

# 设计思路
首先，Nacos中有metadata（元数据）这一概念，我们可以在注册服务的时候指定元数据的值。所以，不论是服务的提供者或是服务的消费者，都是可以指定自己的version。对于服务提供者来说，用 service-version指定，消费者用 target-version。

通过阅读NacosRule的源码，发现其负载均衡调用大致思路是：先在 Nacos 服务中找到同一个 clustName（集群），在这个集群中筛选出要调用的服务实例（可能是多个），最后返回具体的一个服务实例进行服务

我便沿用的这个思路，在筛选服务实例的时候多筛选一个条件：服务调用者的metadata的target-version 等于 服务提供者的service-version。最后，筛选的服务实例就都是版本号相等的，此时，随机选择一个服务进行调用即可。、

# 如何使用
1. 在提供者 provider 的 application.properties中加入service-version 服务版本号配置
    ```properties
    ...
    spring.cloud.nacos.discovery.service-version=1.0.0
    ....
    ````
2. 在消费者 consumer 的 application.properties中加入target-version 目标服务版本号配置
    ```properties
    ...
    spring.cloud.nacos.discovery.target-version=1.0.0
    ....
    ```
3. 选择 Ribbo 或 Feign 的负载均衡为 NacosVersionRule，最后去调用controller即可
    ```java
   @Bean
    public IRule iRule(){
        return new NacosVersionRule();
    }
    ```
    ```java
    @Autowired
    private RestTemplate restTemplate;

    @RequestMapping("/time")
    public Object time(){
        String url = "http://nacos-version-provider/system/time";
        return restTemplate.getForObject(url,Object.class);
    }
    ```
