### PR TITLE
Fixes #2253: ThreadPoolTaskScheduler instance in NacosWatch can't be shutdown.

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/NacosWatch.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/NacosWatch.java
@@ -35,6 +35,7 @@ import com.alibaba.nacos.api.naming.pojo.Instance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.cloud.client.discovery.event.HeartbeatEvent;
 import org.springframework.context.ApplicationEventPublisher;
@@ -45,8 +46,9 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 /**
  * @author xiaojing
  * @author yuhuangbin
+ * @author pengfei.lu
  */
-public class NacosWatch implements ApplicationEventPublisherAware, SmartLifecycle {
+public class NacosWatch implements ApplicationEventPublisherAware, SmartLifecycle, DisposableBean {
 
 	private static final Logger log = LoggerFactory.getLogger(NacosWatch.class);
 
@@ -199,4 +201,8 @@ public class NacosWatch implements ApplicationEventPublisherAware, SmartLifecycl
 
 	}
 
+	@Override
+	public void destroy() {
+		this.stop();
+	}
 }


### PR DESCRIPTION
### Describe what this PR does / why we need it

Fixes #2253: ThreadPoolTaskScheduler instance in NacosWatch can't be shutdown, causing JVM process leak.

### Does this pull request fix one issue?

Fixes #2253

### Describe how you did it

Implements `DisposableBean` BeanFactory interface's `destroy` hook method for `NacosWatch` class, calling the existing `stop` method for `org.springframework.context.Lifecycle` interface.

As following code shows:
```java
@Override
public void destroy() {
    this.stop();
}
```

### Describe how to verify it
1. The port 8081 in used in current host.
2. Start a SpringBoot web application integrated with `spring-cloud-starter-alibaba-nacos-discovery` on port 8081 too.
3. A `org.springframework.boot.web.server.PortInUseException: Port 8081 is already in use` exception would be thrown by `org.springframework.boot.web.servlet.context.WebServerStartStopLifecycle#start` method.
4. When BeanFactory starts destroying, the new added `destroy` method can be automatically invoked, and the `ThreadPoolTaskScheduler` instance can be shutdown.
5. The JVM process can be shutdown successfully.

### Special notes for reviews
NONE