### PR TITLE
Nacos failure tolerance

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
@@ -19,7 +19,11 @@ package com.alibaba.cloud.nacos;
 import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
-import java.util.*;
+import java.util.HashMap;
+import java.util.Properties;
+import java.util.Objects;
+import java.util.Enumeration;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -199,7 +203,7 @@ public class NacosDiscoveryProperties {
 	 * Whether to enable nacos failure tolerance. If enabled, nacos will return cached
 	 * values when exceptions occur.
 	 */
-	private boolean failureToleranceEnabled = true;
+	private boolean failureToleranceEnabled;
 
 	@Autowired
 	private InetUtils inetUtils;

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryClient.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryClient.java
@@ -18,10 +18,12 @@ package com.alibaba.cloud.nacos.discovery;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 
@@ -29,6 +31,7 @@ import org.springframework.cloud.client.discovery.DiscoveryClient;
  * @author xiaojing
  * @author renhaojun
  * @author echooymxq
+ * @author freeman
  */
 public class NacosDiscoveryClient implements DiscoveryClient {
 
@@ -40,6 +43,9 @@ public class NacosDiscoveryClient implements DiscoveryClient {
 	public static final String DESCRIPTION = "Spring Cloud Nacos Discovery Client";
 
 	private NacosServiceDiscovery serviceDiscovery;
+
+	@Value("${spring.cloud.nacos.discovery.failure-tolerance-enabled:true}")
+	private boolean failureToleranceEnabled = true;
 
 	public NacosDiscoveryClient(NacosServiceDiscovery nacosServiceDiscovery) {
 		this.serviceDiscovery = nacosServiceDiscovery;
@@ -53,9 +59,15 @@ public class NacosDiscoveryClient implements DiscoveryClient {
 	@Override
 	public List<ServiceInstance> getInstances(String serviceId) {
 		try {
-			return serviceDiscovery.getInstances(serviceId);
+			return Optional.of(serviceDiscovery.getInstances(serviceId)).map(instances -> {
+						ServiceCache.setInstances(serviceId, instances);
+						return instances;
+					}).get();
 		}
 		catch (Exception e) {
+			if (failureToleranceEnabled) {
+				return ServiceCache.getInstances(serviceId);
+			}
 			throw new RuntimeException(
 					"Can not get hosts from nacos server. serviceId: " + serviceId, e);
 		}
@@ -64,11 +76,14 @@ public class NacosDiscoveryClient implements DiscoveryClient {
 	@Override
 	public List<String> getServices() {
 		try {
-			return serviceDiscovery.getServices();
+			return Optional.of(serviceDiscovery.getServices()).map(services -> {
+						ServiceCache.set(services);
+						return services;
+					}).get();
 		}
 		catch (Exception e) {
 			log.error("get service name from nacos server fail,", e);
-			return Collections.emptyList();
+			return failureToleranceEnabled ? ServiceCache.get() : Collections.emptyList();
 		}
 	}
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryClient.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryClient.java
@@ -44,8 +44,8 @@ public class NacosDiscoveryClient implements DiscoveryClient {
 
 	private NacosServiceDiscovery serviceDiscovery;
 
-	@Value("${spring.cloud.nacos.discovery.failure-tolerance-enabled:true}")
-	private boolean failureToleranceEnabled = true;
+	@Value("${spring.cloud.nacos.discovery.failure-tolerance-enabled:false}")
+	private boolean failureToleranceEnabled;
 
 	public NacosDiscoveryClient(NacosServiceDiscovery nacosServiceDiscovery) {
 		this.serviceDiscovery = nacosServiceDiscovery;

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/ServiceCache.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/ServiceCache.java
@@ -1,0 +1,41 @@
+package com.alibaba.cloud.nacos.discovery;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.cloud.client.ServiceInstance;
+
+/**
+ * Service cache.
+ * <p>
+ * Cache serviceIds and corresponding instances in Nacos.
+ *
+ * @author freeman
+ * @since 2022.0
+ */
+public class ServiceCache {
+
+	private static List<String> services = Collections.emptyList();
+
+	private static Map<String, List<ServiceInstance>> instancesMap = new ConcurrentHashMap<>();
+
+	public static void setInstances(String serviceId, List<ServiceInstance> instances) {
+		instancesMap.put(serviceId, Collections.unmodifiableList(instances));
+	}
+
+	public static List<ServiceInstance> getInstances(String serviceId) {
+		return Optional.ofNullable(instancesMap.get(serviceId)).orElse(Collections.emptyList());
+	}
+
+	public static void set(List<String> newServices) {
+		services = Collections.unmodifiableList(newServices);
+	}
+
+	public static List<String> get() {
+		return services;
+	}
+
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/reactive/NacosReactiveDiscoveryClient.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/reactive/NacosReactiveDiscoveryClient.java
@@ -19,10 +19,12 @@ package com.alibaba.cloud.nacos.discovery.reactive;
 import java.util.function.Function;
 
 import com.alibaba.cloud.nacos.discovery.NacosServiceDiscovery;
+import com.alibaba.cloud.nacos.discovery.ServiceCache;
 import com.alibaba.nacos.api.exception.NacosException;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -32,6 +34,7 @@ import org.springframework.cloud.client.discovery.ReactiveDiscoveryClient;
 
 /**
  * @author <a href="mailto:echooy.mxq@gmail.com">echooymxq</a>
+ * @author freeman
  **/
 public class NacosReactiveDiscoveryClient implements ReactiveDiscoveryClient {
 
@@ -39,6 +42,9 @@ public class NacosReactiveDiscoveryClient implements ReactiveDiscoveryClient {
 			.getLogger(NacosReactiveDiscoveryClient.class);
 
 	private NacosServiceDiscovery serviceDiscovery;
+
+	@Value("${spring.cloud.nacos.discovery.failure-tolerance-enabled:true}")
+	private boolean failureToleranceEnabled = true;
 
 	public NacosReactiveDiscoveryClient(NacosServiceDiscovery nacosServiceDiscovery) {
 		this.serviceDiscovery = nacosServiceDiscovery;
@@ -59,11 +65,17 @@ public class NacosReactiveDiscoveryClient implements ReactiveDiscoveryClient {
 	private Function<String, Publisher<ServiceInstance>> loadInstancesFromNacos() {
 		return serviceId -> {
 			try {
-				return Flux.fromIterable(serviceDiscovery.getInstances(serviceId));
+				return Mono.justOrEmpty(serviceDiscovery.getInstances(serviceId))
+						.flatMapMany(instances -> {
+							ServiceCache.setInstances(serviceId, instances);
+							return Flux.fromIterable(instances);
+						});
 			}
 			catch (NacosException e) {
 				log.error("get service instance[{}] from nacos error!", serviceId, e);
-				return Flux.empty();
+				return failureToleranceEnabled
+						? Flux.fromIterable(ServiceCache.getInstances(serviceId))
+						: Flux.empty();
 			}
 		};
 	}
@@ -72,11 +84,17 @@ public class NacosReactiveDiscoveryClient implements ReactiveDiscoveryClient {
 	public Flux<String> getServices() {
 		return Flux.defer(() -> {
 			try {
-				return Flux.fromIterable(serviceDiscovery.getServices());
+				return Mono.justOrEmpty(serviceDiscovery.getServices())
+						.flatMapMany(services -> {
+							ServiceCache.set(services);
+							return Flux.fromIterable(services);
+						});
 			}
 			catch (Exception e) {
 				log.error("get services from nacos server fail,", e);
-				return Flux.empty();
+				return failureToleranceEnabled
+						? Flux.fromIterable(ServiceCache.get())
+						: Flux.empty();
 			}
 		}).subscribeOn(Schedulers.boundedElastic());
 	}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/reactive/NacosReactiveDiscoveryClient.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/reactive/NacosReactiveDiscoveryClient.java
@@ -43,8 +43,8 @@ public class NacosReactiveDiscoveryClient implements ReactiveDiscoveryClient {
 
 	private NacosServiceDiscovery serviceDiscovery;
 
-	@Value("${spring.cloud.nacos.discovery.failure-tolerance-enabled:true}")
-	private boolean failureToleranceEnabled = true;
+	@Value("${spring.cloud.nacos.discovery.failure-tolerance-enabled:false}")
+	private boolean failureToleranceEnabled;
 
 	public NacosReactiveDiscoveryClient(NacosServiceDiscovery nacosServiceDiscovery) {
 		this.serviceDiscovery = nacosServiceDiscovery;

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -74,11 +74,5 @@
       "type": "java.lang.Boolean",
       "defaultValue": false,
       "description": "Integrate LoadBalancer or not."
-    },
-    {
-      "name": "spring.cloud.nacos.discovery.failure-tolerance-enabled",
-      "type": "java.lang.Boolean",
-      "defaultValue": true,
-      "description": "Whether to enable nacos failure tolerance. If enabled, nacos will return cached values when exceptions occur."
     }
 ]}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -74,5 +74,11 @@
       "type": "java.lang.Boolean",
       "defaultValue": false,
       "description": "Integrate LoadBalancer or not."
+    },
+    {
+      "name": "spring.cloud.nacos.discovery.failure-tolerance-enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Whether to enable nacos failure tolerance. If enabled, nacos will return cached values when exceptions occur."
     }
 ]}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/NacosDiscoveryClientTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/NacosDiscoveryClientTests.java
@@ -83,6 +83,7 @@ public class NacosDiscoveryClientTests {
 		ServiceCache.setInstances("a", singletonList(serviceInstance));
 
 		when(serviceDiscovery.getInstances("a")).thenThrow(new NacosException());
+		ReflectionTestUtils.setField(client, "failureToleranceEnabled", true);
 
 		List<ServiceInstance> instances = this.client.getInstances("a");
 
@@ -104,6 +105,7 @@ public class NacosDiscoveryClientTests {
 		ServiceCache.set(Arrays.asList("a", "b"));
 
 		when(serviceDiscovery.getServices()).thenThrow(new NacosException());
+		ReflectionTestUtils.setField(client, "failureToleranceEnabled", true);
 
 		List<String> services = this.client.getServices();
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/discovery/reactive/NacosReactiveDiscoveryClientTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/discovery/reactive/NacosReactiveDiscoveryClientTests.java
@@ -79,6 +79,7 @@ class NacosReactiveDiscoveryClientTests {
 		ServiceCache.setInstances("a", singletonList(serviceInstance));
 
 		when(serviceDiscovery.getInstances("a")).thenThrow(new NacosException());
+		ReflectionTestUtils.setField(client, "failureToleranceEnabled", true);
 
 		Flux<ServiceInstance> instances = this.client.getInstances("a");
 
@@ -103,6 +104,8 @@ class NacosReactiveDiscoveryClientTests {
 		ServiceCache.set(Arrays.asList("a", "b"));
 
 		when(serviceDiscovery.getServices()).thenThrow(new NacosException());
+		ReflectionTestUtils.setField(client, "failureToleranceEnabled", true);
+
 
 		Flux<String> services = this.client.getServices();
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/discovery/reactive/NacosReactiveDiscoveryClientTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/discovery/reactive/NacosReactiveDiscoveryClientTests.java
@@ -19,6 +19,7 @@ package com.alibaba.cloud.nacos.discovery.reactive;
 import java.util.Arrays;
 
 import com.alibaba.cloud.nacos.discovery.NacosServiceDiscovery;
+import com.alibaba.cloud.nacos.discovery.ServiceCache;
 import com.alibaba.nacos.api.exception.NacosException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,12 +30,14 @@ import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
 import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static java.util.Collections.singletonList;
 import static org.mockito.Mockito.when;
 
 /**
  * @author <a href="mailto:echooy.mxq@gmail.com">echooymxq</a>
+ * @author freeman
  **/
 @ExtendWith(MockitoExtension.class)
 class NacosReactiveDiscoveryClientTests {
@@ -69,6 +72,71 @@ class NacosReactiveDiscoveryClientTests {
 
 		StepVerifier.create(services).expectNext("reactive-service1", "reactive-service2")
 				.expectComplete().verify();
+	}
+
+	@Test
+	public void testGetInstancesFailureToleranceEnabled() throws NacosException {
+		ServiceCache.setInstances("a", singletonList(serviceInstance));
+
+		when(serviceDiscovery.getInstances("a")).thenThrow(new NacosException());
+
+		Flux<ServiceInstance> instances = this.client.getInstances("a");
+
+		StepVerifier.create(instances).expectNext(serviceInstance)
+				.expectComplete().verify();
+	}
+
+	@Test
+	public void testGetInstancesFailureToleranceDisabled() throws NacosException {
+		ServiceCache.setInstances("a", singletonList(serviceInstance));
+
+		when(serviceDiscovery.getInstances("a")).thenThrow(new NacosException());
+		ReflectionTestUtils.setField(client, "failureToleranceEnabled", false);
+
+		Flux<ServiceInstance> instances = this.client.getInstances("a");
+
+		StepVerifier.create(instances).expectComplete().verify();
+	}
+
+	@Test
+	public void testFailureToleranceEnabled() throws NacosException {
+		ServiceCache.set(Arrays.asList("a", "b"));
+
+		when(serviceDiscovery.getServices()).thenThrow(new NacosException());
+
+		Flux<String> services = this.client.getServices();
+
+		StepVerifier.create(services).expectNext("a", "b")
+				.expectComplete().verify();
+	}
+
+	@Test
+	public void testFailureToleranceDisabled() throws NacosException {
+		ServiceCache.set(Arrays.asList("a", "b"));
+
+		when(serviceDiscovery.getServices()).thenThrow(new NacosException());
+		ReflectionTestUtils.setField(client, "failureToleranceEnabled", false);
+
+		Flux<String> services = this.client.getServices();
+
+		StepVerifier.create(services).expectComplete().verify();
+	}
+
+	@Test
+	public void testCacheIsOK() throws NacosException, InterruptedException {
+		when(serviceDiscovery.getInstances("a"))
+				.thenReturn(singletonList(serviceInstance));
+		Flux<ServiceInstance> instances = this.client.getInstances("a");
+
+		instances = instances.doOnComplete(() -> {
+			if (!ServiceCache.getInstances("a").equals(singletonList(serviceInstance))) {
+				throw new RuntimeException();
+			}
+		});
+
+		StepVerifier.create(instances)
+						.expectNext(serviceInstance)
+						.expectComplete().verify();
 	}
 
 }


### PR DESCRIPTION
Add Nacos failure tolerance ability, use caching values when the query fails.

添加 nacos 失败容错能力, 在查询失败时使用缓存值

### Does this pull request fix one issue?
Fixed #2343 

###  How to use it
New configuration item
set spring.cloud.nacos.discovery.failure-tolerance-enabled true/false to enable/disable it.