### PR TITLE
fix dubbo ServiceParameterResolver NPE

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/service/parameter/AbstractNamedValueServiceParameterResolver.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/service/parameter/AbstractNamedValueServiceParameterResolver.java
@@ -112,7 +112,7 @@ public abstract class AbstractNamedValueServiceParameterResolver
 			}
 		}
 
-		return index > -1 ? arguments[index] : null;
+		return index != null && index > -1 ? arguments[index] : null;
 	}
 
 	protected Collection<String> getNames(RestMethodMetadata restMethodMetadata,


### PR DESCRIPTION
### Describe what this PR does / why we need it
修复当 clientRestMethodMetadata.getIndexToName() 返回的Map没有数据时导致的空指针异常

fix when clientRestMethodMetadata.getIndexToName()  return empty map , throw NPE

### Does this pull request fix one issue?

none

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
