### PR TITLE
[Feature] Support config preference.

### DIFF
--- a/spring-cloud-alibaba-examples/nacos-example/nacos-config-preference-example/pom.xml
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-config-preference-example/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>com.alibaba.cloud</groupId>
+        <artifactId>spring-cloud-alibaba-examples</artifactId>
+        <version>${revision}</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>nacos-config-preference-example</artifactId>
+    <name>Spring Cloud Starter Alibaba Nacos Config Preference Example</name>
+    <description>Example demonstrating how to use nacos config preference in spring boot</description>
+    <packaging>jar</packaging>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba.cloud</groupId>
+            <artifactId>spring-cloud-starter-alibaba-nacos-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>${maven-deploy-plugin.version}</version>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/spring-cloud-alibaba-examples/nacos-example/nacos-config-preference-example/readme-zh.md
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-config-preference-example/readme-zh.md
@@ -8,15 +8,37 @@
 
 1. 启动一个 Nacos server  
 添加配置 `test.yml`
-
 ```yaml
 configdata:
   user:
     name: freeman
 ```
 
-2. 设置配置偏好 `spring.cloud.nacos.config.preference=remote`
+添加配置 `test2.yml`
+```yaml
+dev:
+  age: 22
+```
 
-3. 访问 `localhost`  
-应该能看到值为 `freeman`，因为优先使用了配置中心配置  
-修改配置为 `spring.cloud.nacos.config.preference=local` 那么值应该为 `aa`
+2. 设置配置偏好
+
+设置默认配置偏好 
+```yaml
+spring:
+  cloud:
+    nacos:
+      config:
+        preference: remote
+```
+
+指定配置（test2.yml）设置配置偏好
+```yaml
+spring:
+  config:
+    import:
+      - optional:nacos:test.yml
+      - optional:nacos:test2.yml?preference=local
+```
+
+3. 验证
+访问 `localhost`，应该能看到值为 `freeman: 20`，因为 `name` 优先使用了配置中心配置，`age` 优先使用本地配置。  

--- a/spring-cloud-alibaba-examples/nacos-example/nacos-config-preference-example/readme-zh.md
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-config-preference-example/readme-zh.md
@@ -1,0 +1,22 @@
+# Nacos Config Preference
+
+## 项目说明
+
+本项目演示如何使用配置偏好配置
+
+## 示例
+
+1. 启动一个 Nacos server  
+添加配置 `test.yml`
+
+```yaml
+configdata:
+  user:
+    name: freeman
+```
+
+2. 设置配置偏好 `spring.cloud.nacos.config.preference=remote`
+
+3. 访问 `localhost`  
+应该能看到值为 `freeman`，因为优先使用了配置中心配置  
+修改配置为 `spring.cloud.nacos.config.preference=local` 那么值应该为 `aa`

--- a/spring-cloud-alibaba-examples/nacos-example/nacos-config-preference-example/readme.md
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-config-preference-example/readme.md
@@ -8,15 +8,37 @@ This project demonstrates how to use config preferences.
 
 1. Start a Nacos server
 add configuration `test.yml`
-
 ```yaml
 configdata:
   user:
     name: freeman
 ```
 
-2. Set config preference `spring.cloud.nacos.config.preference=remote`
+add configuration `test2.yml`
+```yaml
+dev:
+  age: 22
+```
 
-3. access `localhost`  
-You should see a value of `freeman`, because the configuration center configuration is used first.  
-Modify the configuration to `spring.cloud.nacos.config.preference=local` then the value should be `aa`.
+2. Set configuration preference
+
+Set default configuration preference
+```yaml
+spring:
+  cloud:
+    nacos:
+      config:
+        preference: remote
+```
+
+Specify configuration (test 2.yml) to set configuration preference
+```yaml
+spring:
+  config:
+    import:
+      - optional:nacos:test.yml
+      - optional:nacos:test2.yml?preference=local
+```
+
+3. Verify 
+Access `localhost`, you should see the value of `freeman: 20`, because `name` uses the configuration center configuration first, and `age` uses the local configuration first.

--- a/spring-cloud-alibaba-examples/nacos-example/nacos-config-preference-example/readme.md
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-config-preference-example/readme.md
@@ -1,0 +1,22 @@
+# Nacos Config Preference
+
+## Project instruction
+
+This project demonstrates how to use config preferences.
+
+## Example
+
+1. Start a Nacos server
+add configuration `test.yml`
+
+```yaml
+configdata:
+  user:
+    name: freeman
+```
+
+2. Set config preference `spring.cloud.nacos.config.preference=remote`
+
+3. access `localhost`  
+You should see a value of `freeman`, because the configuration center configuration is used first.  
+Modify the configuration to `spring.cloud.nacos.config.preference=local` then the value should be `aa`.

--- a/spring-cloud-alibaba-examples/nacos-example/nacos-config-preference-example/src/main/java/com/alibaba/cloud/configpreference/examples/ConfigPreferenceApplication.java
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-config-preference-example/src/main/java/com/alibaba/cloud/configpreference/examples/ConfigPreferenceApplication.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.configpreference.examples;
+
+import com.alibaba.cloud.configpreference.examples.model.UserProperties;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+/**
+ * @author freeman
+ */
+@SpringBootApplication
+@EnableConfigurationProperties(UserProperties.class)
+public class ConfigPreferenceApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(ConfigPreferenceApplication.class, args);
+	}
+
+}

--- a/spring-cloud-alibaba-examples/nacos-example/nacos-config-preference-example/src/main/java/com/alibaba/cloud/configpreference/examples/controller/UserController.java
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-config-preference-example/src/main/java/com/alibaba/cloud/configpreference/examples/controller/UserController.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.configpreference.examples.controller;
+
+import com.alibaba.cloud.configpreference.examples.model.UserProperties;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ *
+ *
+ * @author freeman
+ */
+@RestController
+public class UserController {
+
+	@Autowired
+	private UserProperties userProperties;
+
+	@GetMapping
+	public String getName() {
+		return userProperties.getName();
+	}
+
+}

--- a/spring-cloud-alibaba-examples/nacos-example/nacos-config-preference-example/src/main/java/com/alibaba/cloud/configpreference/examples/controller/UserController.java
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-config-preference-example/src/main/java/com/alibaba/cloud/configpreference/examples/controller/UserController.java
@@ -19,6 +19,8 @@ package com.alibaba.cloud.configpreference.examples.controller;
 import com.alibaba.cloud.configpreference.examples.model.UserProperties;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -28,14 +30,17 @@ import org.springframework.web.bind.annotation.RestController;
  * @author freeman
  */
 @RestController
+@RefreshScope
 public class UserController {
 
 	@Autowired
 	private UserProperties userProperties;
+	@Value("${dev.age}")
+	private int age;
 
 	@GetMapping
 	public String getName() {
-		return userProperties.getName();
+		return userProperties.getName() + ": " + age;
 	}
 
 }

--- a/spring-cloud-alibaba-examples/nacos-example/nacos-config-preference-example/src/main/java/com/alibaba/cloud/configpreference/examples/model/UserProperties.java
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-config-preference-example/src/main/java/com/alibaba/cloud/configpreference/examples/model/UserProperties.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.configpreference.examples.model;
+
+import java.util.List;
+import java.util.Map;
+
+import lombok.Data;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ *
+ *
+ * @author freeman
+ */
+@Data
+@ConfigurationProperties(prefix = "configdata.user")
+public class UserProperties {
+	private String name;
+	private Integer age;
+	private Map<String, Object> map;
+	private List<User> users;
+
+	@Data
+	public static class User {
+		private String name;
+		private Integer age;
+	}
+
+}

--- a/spring-cloud-alibaba-examples/nacos-example/nacos-config-preference-example/src/main/resources/application-dev.yml
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-config-preference-example/src/main/resources/application-dev.yml
@@ -1,0 +1,3 @@
+configdata:
+  user:
+    name: aa

--- a/spring-cloud-alibaba-examples/nacos-example/nacos-config-preference-example/src/main/resources/application.yml
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-config-preference-example/src/main/resources/application.yml
@@ -1,0 +1,25 @@
+server:
+  port: 80
+spring:
+  application:
+    name: nacos-config-import-example
+  cloud:
+    nacos:
+      config:
+        group: DEFAULT_GROUP
+        server-addr: 127.0.0.1:8848
+        preference: remote
+  config:
+    import:
+      - optional:nacos:test.yml
+  profiles:
+    active: dev
+
+---
+spring:
+  config:
+    activate:
+      on-profile: dev
+configdata:
+  user:
+    name: bb

--- a/spring-cloud-alibaba-examples/nacos-example/nacos-config-preference-example/src/main/resources/application.yml
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-config-preference-example/src/main/resources/application.yml
@@ -18,7 +18,7 @@ spring:
 logging:
   level:
     # print content
-    org.springframework.boot.context.config: debug
+    com.alibaba.cloud.nacos.configdata: debug
 ---
 spring:
   config:

--- a/spring-cloud-alibaba-examples/nacos-example/nacos-config-preference-example/src/main/resources/application.yml
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-config-preference-example/src/main/resources/application.yml
@@ -15,7 +15,10 @@ spring:
       - optional:nacos:test2.yml?preference=local
   profiles:
     active: dev
-
+logging:
+  level:
+    # print content
+    org.springframework.boot.context.config: debug
 ---
 spring:
   config:

--- a/spring-cloud-alibaba-examples/nacos-example/nacos-config-preference-example/src/main/resources/application.yml
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-config-preference-example/src/main/resources/application.yml
@@ -12,6 +12,7 @@ spring:
   config:
     import:
       - optional:nacos:test.yml
+      - optional:nacos:test2.yml?preference=local
   profiles:
     active: dev
 
@@ -23,3 +24,5 @@ spring:
 configdata:
   user:
     name: bb
+dev:
+  age: 20

--- a/spring-cloud-alibaba-examples/pom.xml
+++ b/spring-cloud-alibaba-examples/pom.xml
@@ -26,6 +26,7 @@
         <module>nacos-example/nacos-discovery-example</module>
         <module>nacos-example/nacos-config-example</module>
         <module>nacos-example/nacos-config-2.4.x-example</module>
+        <module>nacos-example/nacos-config-preference-example</module>
         <module>nacos-example/nacos-gateway-example</module>
         <module>seata-example/business-service</module>
         <module>seata-example/order-service</module>

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/configdata/ConfigPreference.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/configdata/ConfigPreference.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.nacos.configdata;
+
+/**
+ * Config preference.
+ * <p>
+ * When configured profile specific configuration, local config will override the remote,
+ * because the local config is <strong>profile specific</strong>, it has higher priority.
+ * <p>
+ * So give remote config a chance to "win", we treat remote config as profile specific, it
+ * should be included after profile specific sibling imports. Finally, it will override
+ * the local profile specific config.
+ *
+ * @author freeman
+ * @since 2021.0.1.1
+ */
+public enum ConfigPreference {
+	/**
+	 * Prefer local configuration.
+	 */
+	LOCAL,
+	/**
+	 * Prefer remote configuration.
+	 */
+	REMOTE
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/configdata/NacosConfigDataLoader.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/configdata/NacosConfigDataLoader.java
@@ -153,6 +153,9 @@ public class NacosConfigDataLoader implements ConfigDataLoader<NacosConfigDataRe
 			log.warn(String.format("[Nacos Config] config[dataId=%s, group=%s] is empty",
 					dataId, group));
 		}
+		log.debug(
+				String.format("[Nacos Config] config[dataId=%s, group=%s] content: \n%s",
+						dataId, group, config));
 	}
 
 	protected <T> T getBean(ConfigDataLoaderContext context, Class<T> type) {

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/configdata/NacosConfigDataLoader.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/configdata/NacosConfigDataLoader.java
@@ -34,6 +34,7 @@ import org.springframework.boot.context.config.ConfigData;
 import org.springframework.boot.context.config.ConfigDataLoader;
 import org.springframework.boot.context.config.ConfigDataLoaderContext;
 import org.springframework.boot.context.config.ConfigDataResourceNotFoundException;
+import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.boot.logging.DeferredLogFactory;
 import org.springframework.core.env.PropertySource;
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/configdata/NacosConfigDataLoader.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/configdata/NacosConfigDataLoader.java
@@ -153,10 +153,6 @@ public class NacosConfigDataLoader implements ConfigDataLoader<NacosConfigDataRe
 			log.warn(String.format("[Nacos Config] config[dataId=%s, group=%s] is empty",
 					dataId, group));
 		}
-		if (log.isDebugEnabled()) {
-			log.debug(String.format("[Nacos Config] Get nacos config[dataId=%s, group=%s], " +
-					"content: %s", dataId, group, config));
-		}
 	}
 
 	protected <T> T getBean(ConfigDataLoaderContext context, Class<T> type) {

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/configdata/NacosConfigDataLocationResolver.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/configdata/NacosConfigDataLocationResolver.java
@@ -67,6 +67,8 @@ public class NacosConfigDataLocationResolver
 
 	private static final String REFRESH_ENABLED = "refreshEnabled";
 
+	private static final String PREFERENCE = "preference";
+
 	public NacosConfigDataLocationResolver(Log log) {
 		this.log = log;
 	}
@@ -166,10 +168,15 @@ public class NacosConfigDataLocationResolver
 				location.isOptional(), profiles, log,
 				new NacosItemConfig().setGroup(groupFor(uri, properties))
 						.setDataId(dataIdFor(uri)).setSuffix(suffixFor(uri, properties))
-						.setRefreshEnabled(refreshEnabledFor(uri, properties)));
+						.setRefreshEnabled(refreshEnabledFor(uri, properties))
+						.setPreference(preferenceFor(uri)));
 		result.add(resource);
 
 		return result;
+	}
+
+	private String preferenceFor(URI uri) {
+		return getQueryMap(uri).get(PREFERENCE);
 	}
 
 	private URI getUri(ConfigDataLocation location, NacosConfigProperties properties) {

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/configdata/NacosConfigDataResource.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/configdata/NacosConfigDataResource.java
@@ -105,16 +105,18 @@ public class NacosConfigDataResource extends ConfigDataResource {
 		private String dataId;
 		private String suffix;
 		private boolean refreshEnabled;
+		private String preference;
 
 		public NacosItemConfig() {
 		}
 
 		public NacosItemConfig(String group, String dataId, String suffix,
-				boolean refreshEnabled) {
+				boolean refreshEnabled, String preference) {
 			this.group = group;
 			this.dataId = dataId;
 			this.suffix = suffix;
 			this.refreshEnabled = refreshEnabled;
+			this.preference = preference;
 		}
 
 		public NacosItemConfig setGroup(String group) {
@@ -137,6 +139,11 @@ public class NacosConfigDataResource extends ConfigDataResource {
 			return this;
 		}
 
+		public NacosItemConfig setPreference(String preference) {
+			this.preference = preference;
+			return this;
+		}
+
 		public String getGroup() {
 			return group;
 		}
@@ -153,6 +160,10 @@ public class NacosConfigDataResource extends ConfigDataResource {
 			return refreshEnabled;
 		}
 
+		public String getPreference() {
+			return preference;
+		}
+
 		@Override
 		public boolean equals(Object o) {
 			if (this == o) {
@@ -165,19 +176,20 @@ public class NacosConfigDataResource extends ConfigDataResource {
 			return refreshEnabled == that.refreshEnabled
 					&& Objects.equals(group, that.group)
 					&& Objects.equals(dataId, that.dataId)
-					&& Objects.equals(suffix, that.suffix);
+					&& Objects.equals(suffix, that.suffix)
+					&& Objects.equals(preference, that.preference);
 		}
 
 		@Override
 		public int hashCode() {
-			return Objects.hash(group, dataId, suffix, refreshEnabled);
+			return Objects.hash(group, dataId, suffix, refreshEnabled, preference);
 		}
 
 		@Override
 		public String toString() {
 			return "NacosItemConfig{" + "group='" + group + '\'' + ", dataId='" + dataId
 					+ '\'' + ", suffix='" + suffix + '\'' + ", refreshEnabled="
-					+ refreshEnabled + '}';
+					+ refreshEnabled + ", preference=" + preference + '}';
 		}
 	}
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/refresh/NacosContextRefresher.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/refresh/NacosContextRefresher.java
@@ -127,6 +127,8 @@ public class NacosContextRefresher
 				});
 		try {
 			configService.addListener(dataKey, groupKey, listener);
+			log.info("[Nacos Config] Listening config: dataId={}, group={}", dataKey,
+					groupKey);
 		}
 		catch (NacosException e) {
 			log.warn(String.format(

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -94,6 +94,12 @@
       "name": "spring.cloud.nacos.password",
       "type": "java.lang.String",
       "description": "nacos password to authenticate."
+    },
+    {
+      "name": "spring.cloud.nacos.config.preference",
+      "type": "com.alibaba.cloud.nacos.configdata.ConfigPreference",
+      "defaultValue": "local",
+      "description": "Config preference."
     }
   ]
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/test/java/com/alibaba/cloud/nacos/configdata/NacosConfigDataMissingEnvironmentPostProcessorTest.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/test/java/com/alibaba/cloud/nacos/configdata/NacosConfigDataMissingEnvironmentPostProcessorTest.java
@@ -17,11 +17,9 @@
 package com.alibaba.cloud.nacos.configdata;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIf;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.mock.env.MockEnvironment;
-import org.springframework.util.ClassUtils;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -32,13 +30,7 @@ import static org.mockito.Mockito.mock;
  * @author Ryan Baxter
  * @author freeman
  */
-@DisabledIf("existBootstrapMarker")
 class NacosConfigDataMissingEnvironmentPostProcessorTest {
-
-	static boolean existBootstrapMarker() {
-		return ClassUtils.isPresent("org.springframework.cloud.bootstrap.marker.Marker",
-				null);
-	}
 
 	@Test
 	void noSpringConfigImport() {

--- a/spring-cloud-alibaba-tests/nacos-tests/nacos-config-test/pom.xml
+++ b/spring-cloud-alibaba-tests/nacos-tests/nacos-config-test/pom.xml
@@ -22,6 +22,10 @@
             <artifactId>spring-cloud-starter-alibaba-nacos-config</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>


### PR DESCRIPTION
### Does this pull request fix one issue?
Fixed #2455 
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### How to use it
set `spring.cloud.nacos.config.preference` to `remote`, remote configuration will overwrite local configuration by default. 

support to set for single config
```yaml
spring:
  cloud:
    nacos:
      config:
        preference: remote
  config:
    import:
      - optional:nacos:test.yml?preference=local
```
