### PR TITLE
Fix sentinel datasource init error in jacocoagent environment

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-datasource/src/main/java/com/alibaba/cloud/sentinel/datasource/config/DataSourcePropertiesConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-datasource/src/main/java/com/alibaba/cloud/sentinel/datasource/config/DataSourcePropertiesConfiguration.java
@@ -127,17 +127,21 @@ public class DataSourcePropertiesConfiguration {
 
 	@JsonIgnore
 	public List<String> getValidField() {
-		return Arrays.stream(this.getClass().getDeclaredFields()).map(field -> {
-			try {
-				if (!ObjectUtils.isEmpty(field.get(this))) {
-					return field.getName();
-				}
-			}
-			catch (IllegalAccessException e) {
-				// won't happen
-			}
-			return null;
-		}).filter(Objects::nonNull).collect(Collectors.toList());
+		return Arrays
+				.stream(this.getClass().getDeclaredFields())
+				.filter(field -> !field.isSynthetic())
+				.map(field -> {
+					try {
+						if (!ObjectUtils.isEmpty(field.get(this))) {
+							return field.getName();
+						}
+					} catch (IllegalAccessException e) {
+						// won't happen
+					}
+					return null;
+				})
+				.filter(Objects::nonNull)
+				.collect(Collectors.toList());
 	}
 
 	@JsonIgnore

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-datasource/src/main/java/com/alibaba/cloud/sentinel/datasource/config/DataSourcePropertiesConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-datasource/src/main/java/com/alibaba/cloud/sentinel/datasource/config/DataSourcePropertiesConfiguration.java
@@ -135,7 +135,8 @@ public class DataSourcePropertiesConfiguration {
 						if (!ObjectUtils.isEmpty(field.get(this))) {
 							return field.getName();
 						}
-					} catch (IllegalAccessException e) {
+					}
+					catch (IllegalAccessException e) {
 						// won't happen
 					}
 					return null;

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-datasource/src/test/java/com/alibaba/cloud/sentinel/datasource/DataSourcePropertiesConfigurationTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-datasource/src/test/java/com/alibaba/cloud/sentinel/datasource/DataSourcePropertiesConfigurationTests.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.sentinel.datasource;
+
+import com.alibaba.cloud.sentinel.datasource.config.ApolloDataSourceProperties;
+import com.alibaba.cloud.sentinel.datasource.config.DataSourcePropertiesConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author <a href="mailto:i@5icodes.com">hnyyghk</a>
+ */
+public class DataSourcePropertiesConfigurationTests {
+
+	@Test
+	public void testGetValidField() {
+		DataSourcePropertiesConfiguration configuration = new DataSourcePropertiesConfiguration();
+		ApolloDataSourceProperties apollo = new ApolloDataSourceProperties();
+		apollo.setNamespaceName("application");
+		apollo.setFlowRulesKey("test-flow-rules");
+		apollo.setDefaultFlowRuleValue("[]");
+		apollo.setDataType("json");
+		apollo.setRuleType(RuleType.FLOW);
+		configuration.setApollo(apollo);
+
+		List<String> validField = configuration.getValidField();
+
+		assertThat(validField.size()).isEqualTo(1);
+		assertThat(validField).doesNotContain("$jacocoData");
+		assertThat(validField).contains("apollo");
+	}
+
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-datasource/src/test/java/com/alibaba/cloud/sentinel/datasource/DataSourcePropertiesConfigurationTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-datasource/src/test/java/com/alibaba/cloud/sentinel/datasource/DataSourcePropertiesConfigurationTests.java
@@ -16,11 +16,11 @@
 
 package com.alibaba.cloud.sentinel.datasource;
 
+import java.util.List;
+
 import com.alibaba.cloud.sentinel.datasource.config.ApolloDataSourceProperties;
 import com.alibaba.cloud.sentinel.datasource.config.DataSourcePropertiesConfiguration;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-datasource/src/test/java/com/alibaba/cloud/sentinel/datasource/DataSourcePropertiesConfigurationTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-datasource/src/test/java/com/alibaba/cloud/sentinel/datasource/DataSourcePropertiesConfigurationTests.java
@@ -25,10 +25,17 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
+ * Test cases for {@link DataSourcePropertiesConfiguration}.
+ *
  * @author <a href="mailto:i@5icodes.com">hnyyghk</a>
  */
 public class DataSourcePropertiesConfigurationTests {
 
+	/**
+	 * Test cases for {@link DataSourcePropertiesConfiguration#getValidField()}.
+	 *
+	 * @see com.alibaba.cloud.sentinel.custom.SentinelDataSourceHandler#afterSingletonsInstantiated()
+	 */
 	@Test
 	public void testGetValidField() {
 		DataSourcePropertiesConfiguration configuration = new DataSourcePropertiesConfiguration();
@@ -40,8 +47,10 @@ public class DataSourcePropertiesConfigurationTests {
 		apollo.setRuleType(RuleType.FLOW);
 		configuration.setApollo(apollo);
 
+		//indicate which datasource active
 		List<String> validField = configuration.getValidField();
 
+		//not allowed multi datasource active, $jacocoData should not be included
 		assertThat(validField.size()).isEqualTo(1);
 		assertThat(validField).doesNotContain("$jacocoData");
 		assertThat(validField).contains("apollo");

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/custom/SentinelDataSourceHandler.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/custom/SentinelDataSourceHandler.java
@@ -101,7 +101,7 @@ public class SentinelDataSourceHandler implements SmartInitializingSingleton {
 	}
 
 	protected BeanDefinitionBuilder parseBeanDefinition(final AbstractDataSourceProperties dataSourceProperties,
-									 String dataSourceName) {
+														String dataSourceName) {
 		Map<String, Object> propertyMap = Arrays
 				.stream(dataSourceProperties.getClass().getDeclaredFields())
 				.filter(field -> !field.isSynthetic())

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/test/java/com/alibaba/cloud/sentinel/custom/SentinelDataSourceHandlerTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/test/java/com/alibaba/cloud/sentinel/custom/SentinelDataSourceHandlerTests.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.sentinel.custom;
+
+import com.alibaba.cloud.sentinel.SentinelProperties;
+import com.alibaba.cloud.sentinel.datasource.RuleType;
+import com.alibaba.cloud.sentinel.datasource.config.ApolloDataSourceProperties;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.MutablePropertyValues;
+import org.springframework.beans.factory.config.RuntimeBeanReference;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.core.env.Environment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Test cases for {@link SentinelDataSourceHandler}.
+ *
+ * @author <a href="mailto:i@5icodes.com">hnyyghk</a>
+ */
+public class SentinelDataSourceHandlerTests {
+
+	private SentinelDataSourceHandler sentinelDataSourceHandler;
+
+	private DefaultListableBeanFactory beanFactory;
+
+	private SentinelProperties sentinelProperties;
+
+	private Environment env;
+
+	@Before
+	public void setUp() {
+		beanFactory = mock(DefaultListableBeanFactory.class);
+		sentinelProperties = mock(SentinelProperties.class);
+		env = mock(Environment.class);
+		sentinelDataSourceHandler = new SentinelDataSourceHandler(beanFactory, sentinelProperties, env);
+	}
+
+	@Test
+	public void testParseBeanDefinition() {
+		ApolloDataSourceProperties dataSourceProperties = new ApolloDataSourceProperties();
+		dataSourceProperties.setNamespaceName("application");
+		dataSourceProperties.setFlowRulesKey("test-flow-rules");
+		dataSourceProperties.setDefaultFlowRuleValue("[]");
+		dataSourceProperties.setDataType("json");
+		dataSourceProperties.setRuleType(RuleType.FLOW);
+		String dataSourceName = "ds1" + "-sentinel-" + "apollo" + "-datasource";
+
+		BeanDefinitionBuilder builder = sentinelDataSourceHandler.parseBeanDefinition(dataSourceProperties, dataSourceName);
+		MutablePropertyValues propertyValues = builder.getBeanDefinition().getPropertyValues();
+
+		assertThat(propertyValues.size()).isEqualTo(4);
+		assertThat(propertyValues).noneMatch(propertyValue -> "$jacocoData".equals(propertyValue.getName()));
+		assertThat(propertyValues).anyMatch(propertyValue -> "flowRulesKey".equals(propertyValue.getName())
+				&& dataSourceProperties.getFlowRulesKey().equals(propertyValue.getValue()));
+		assertThat(propertyValues).anyMatch(propertyValue -> "defaultFlowRuleValue".equals(propertyValue.getName())
+				&& dataSourceProperties.getDefaultFlowRuleValue().equals(propertyValue.getValue()));
+		assertThat(propertyValues).anyMatch(propertyValue -> "namespaceName".equals(propertyValue.getName())
+				&& dataSourceProperties.getNamespaceName().equals(propertyValue.getValue()));
+		assertThat(propertyValues).anyMatch(propertyValue -> "converter".equals(propertyValue.getName())
+				&& propertyValue.getValue() instanceof RuntimeBeanReference
+				&& ((RuntimeBeanReference) propertyValue.getValue()).getBeanName().equals("sentinel-" + dataSourceProperties.getDataType() + "-" + dataSourceProperties.getRuleType().getName() + "-converter"));
+	}
+
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/test/java/com/alibaba/cloud/sentinel/custom/SentinelDataSourceHandlerTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/test/java/com/alibaba/cloud/sentinel/custom/SentinelDataSourceHandlerTests.java
@@ -22,6 +22,7 @@ import com.alibaba.cloud.sentinel.datasource.config.AbstractDataSourceProperties
 import com.alibaba.cloud.sentinel.datasource.config.ApolloDataSourceProperties;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.springframework.beans.MutablePropertyValues;
 import org.springframework.beans.factory.config.RuntimeBeanReference;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/test/java/com/alibaba/cloud/sentinel/custom/SentinelDataSourceHandlerTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/test/java/com/alibaba/cloud/sentinel/custom/SentinelDataSourceHandlerTests.java
@@ -18,6 +18,7 @@ package com.alibaba.cloud.sentinel.custom;
 
 import com.alibaba.cloud.sentinel.SentinelProperties;
 import com.alibaba.cloud.sentinel.datasource.RuleType;
+import com.alibaba.cloud.sentinel.datasource.config.AbstractDataSourceProperties;
 import com.alibaba.cloud.sentinel.datasource.config.ApolloDataSourceProperties;
 import org.junit.Before;
 import org.junit.Test;
@@ -53,6 +54,12 @@ public class SentinelDataSourceHandlerTests {
 		sentinelDataSourceHandler = new SentinelDataSourceHandler(beanFactory, sentinelProperties, env);
 	}
 
+	/**
+	 * Test cases for {@link SentinelDataSourceHandler#parseBeanDefinition(AbstractDataSourceProperties, String)}.
+	 *
+	 * @see com.alibaba.cloud.sentinel.datasource.config.ApolloDataSourceProperties
+	 * @see com.alibaba.cloud.sentinel.datasource.factorybean.ApolloDataSourceFactoryBean
+	 */
 	@Test
 	public void testParseBeanDefinition() {
 		ApolloDataSourceProperties dataSourceProperties = new ApolloDataSourceProperties();
@@ -63,9 +70,11 @@ public class SentinelDataSourceHandlerTests {
 		dataSourceProperties.setRuleType(RuleType.FLOW);
 		String dataSourceName = "ds1" + "-sentinel-" + "apollo" + "-datasource";
 
+		//init BeanDefinitionBuilder for ApolloDataSourceFactoryBean
 		BeanDefinitionBuilder builder = sentinelDataSourceHandler.parseBeanDefinition(dataSourceProperties, dataSourceName);
 		MutablePropertyValues propertyValues = builder.getBeanDefinition().getPropertyValues();
 
+		//ApolloDataSourceFactoryBean has four parameters, $jacocoData should not be included
 		assertThat(propertyValues.size()).isEqualTo(4);
 		assertThat(propertyValues).noneMatch(propertyValue -> "$jacocoData".equals(propertyValue.getName()));
 		assertThat(propertyValues).anyMatch(propertyValue -> "flowRulesKey".equals(propertyValue.getName())


### PR DESCRIPTION
### Describe what this PR does / why we need it
Fix sentinel datasource init error in jacocoagent environment

### Does this pull request fix one issue?
Fixes #2476

### Describe how you did it
1. add isSynthetic check
2. wrote some unit test for DataSourcePropertiesConfiguration and SentinelDataSourceHandler

### Describe how to verify it
1. download jacoco library files:https://www.eclemma.org/jacoco/
2. run unit test with jacocoagent.jar, VM options like:
-javaagent:D:\Users\Test\Desktop\jacoco-0.8.7\lib/jacocoagent.jar=includes=*,output=tcpserver,port=6271,address=127.0.0.1,append=true

### Special notes for reviews
