### PR TITLE
Update readme.md

### DIFF
--- a/spring-cloud-alibaba-examples/nacos-example/nacos-config-example/readme-zh.md
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-config-example/readme-zh.md
@@ -166,9 +166,9 @@ Spring Boot 2.x 可以通过访问 http://127.0.0.1:18084/actuator/nacosconfig �
 配置项|key|默认值|说明
 ----|----|-----|-----
 服务端地址|spring.cloud.nacos.config.server-addr||服务器ip和端口
-DataId前缀|spring.cloud.nacos.config.prefix|${spring.application.name}|
+DataId前缀|spring.cloud.nacos.config.prefix|${spring.application.name}|DataId的前缀，默认值为应用名称
 Group|spring.cloud.nacos.config.group|DEFAULT_GROUP|
-dataID后缀及内容文件格式|spring.cloud.nacos.config.file-extension|properties|dataId的后缀，同时也是配置内容的文件格式，目前只支持 properties
+DataId后缀及内容文件格式|spring.cloud.nacos.config.file-extension|properties|DataId的后缀，同时也是配置内容的文件格式，目前只支持 properties
 配置内容的编码方式|spring.cloud.nacos.config.encode|UTF-8|配置的编码
 获取配置的超时时间|spring.cloud.nacos.config.timeout|3000|单位为 ms
 配置的命名空间|spring.cloud.nacos.config.namespace||常用场景之一是不同环境的配置的区分隔离，例如开发测试环境和生产环境的资源隔离等。

--- a/spring-cloud-alibaba-examples/nacos-example/nacos-config-example/readme.md
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-config-example/readme.md
@@ -171,9 +171,9 @@ As shown in the figure above, Sources indicates which Nacos Config configuration
 Configuration item|key|default value|Description
 ----|----|-----|-----
 server address|spring.cloud.nacos.config.server-addr||server id and port
-DataId prefix|spring.cloud.nacos.config.prefix||${spring.application.name}|
+DataId prefix|spring.cloud.nacos.config.prefix|${spring.application.name}|the prefix of nacos config DataId
 Group|spring.cloud.nacos.config.group|DEFAULT_GROUP|
-dataID suffix|spring.cloud.nacos.config.file-extension|properties|the suffix of nacos config dataId, also the file extension of config content.
+DataID suffix|spring.cloud.nacos.config.file-extension|properties|the suffix of nacos config DataId, also the file extension of config content.
 encoding |spring.cloud.nacos.config.encode|UTF-8|Content encoding
 timeout|spring.cloud.nacos.config.timeout|3000|Get the configuration timeout period,unit is ms
 namespace|spring.cloud.nacos.config.namespace||One of the common scenarios is the separation of the configuration of different environments, such as the development of the test environment and the resource isolation of the production environment.

--- a/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/readme-zh.md
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/readme-zh.md
@@ -187,7 +187,7 @@ Spring Boot 2.x 可以通过访问 http://127.0.0.1:18083/actuator/nacos-discove
 配置项|key|默认值|说明
 ----|----|-----|-----
 服务端地址|spring.cloud.nacos.discovery.server-addr||
-服务名|spring.cloud.nacos.discovery.service|spring.application.name|
+服务名|spring.cloud.nacos.discovery.service|${spring.application.name}|注册到Nacos上的服务名称，默认值为应用名称
 权重|spring.cloud.nacos.discovery.weight|1|取值范围 1 到 100，数值越大，权重越大
 网卡名|spring.cloud.nacos.discovery.network-interface||当IP未配置时，注册的IP为此网卡所对应的IP地址，如果此项也未配置，则默认取第一块网卡的地址
 注册的IP地址|spring.cloud.nacos.discovery.ip||优先级最高

--- a/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/readme.md
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/readme.md
@@ -195,7 +195,7 @@ As shown in the figure above, NacosDiscoveryProperties is the configuration of N
 Configuration item|key|default value|Description
 ----|----|-----|-----
 server address|spring.cloud.nacos.discovery.server-addr||
-service|spring.cloud.nacos.discovery.service|spring.application.name|service id to registry
+service|spring.cloud.nacos.discovery.service|${spring.application.name}|service id to registry
 weight|spring.cloud.nacos.discovery.weight|1|value from 1 to 100, The larger the value, the larger the weight
 ip|spring.cloud.nacos.discovery.ip||ip address to registry, Highest priority
 network interface|spring.cloud.nacos.discovery.network-interface||When the IP is not configured, the registered IP address is the IP address corresponding to the network-interface. If this item is not configured, the address of the first network-interface is taken by default.


### PR DESCRIPTION
### Describe what this PR does / why we need it

文档中，Nacos配置项的描述修改：

- spring.application.name取值的表达式修改。
- dataId与DataId未统一，看了Nacos官网的表述统一改为DataId。
- Spring Cloud Alibaba 2021.0.1.0版本是不是已经删除ribbon.nacos.enabled配置项了？文档中这个配置项还没删，这个我不确定，所以没有改。

最近在写一个Spring Cloud Alibaba 2021.0.1.0的文档，所以就来GitHub查一下官方描述，看到不合适的地方就修改然后提了两个pr。**多有打扰，见谅。**
