### PR TITLE
rocketmq anonymous group supports.

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/RocketMQMessageChannelBinder.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/RocketMQMessageChannelBinder.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.cloud.stream.binder.rocketmq;
 
+import com.alibaba.cloud.stream.binder.rocketmq.constant.RocketMQConst;
 import com.alibaba.cloud.stream.binder.rocketmq.custom.RocketMQBeanContainerCache;
 import com.alibaba.cloud.stream.binder.rocketmq.extend.ErrorAcknowledgeHandler;
 import com.alibaba.cloud.stream.binder.rocketmq.integration.inbound.RocketMQInboundChannelAdapter;
@@ -28,6 +29,7 @@ import com.alibaba.cloud.stream.binder.rocketmq.properties.RocketMQExtendedBindi
 import com.alibaba.cloud.stream.binder.rocketmq.properties.RocketMQProducerProperties;
 import com.alibaba.cloud.stream.binder.rocketmq.provisioning.RocketMQTopicProvisioner;
 import com.alibaba.cloud.stream.binder.rocketmq.utils.RocketMQUtils;
+import org.apache.rocketmq.common.protocol.NamespaceUtil;
 
 import org.springframework.cloud.stream.binder.AbstractMessageChannelBinder;
 import org.springframework.cloud.stream.binder.BinderSpecificPropertiesProvider;
@@ -47,6 +49,7 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessagingException;
 import org.springframework.util.StringUtils;
+
 
 /**
  * A {@link org.springframework.cloud.stream.binder.Binder} that uses RocketMQ as the
@@ -113,15 +116,17 @@ public class RocketMQMessageChannelBinder extends
 			String group,
 			ExtendedConsumerProperties<RocketMQConsumerProperties> extendedConsumerProperties)
 			throws Exception {
-		/**
-		 * todo support anymous consumer
-		 * but anymous consumer will create diff SubscriptionGroup
-		 * consumption progress will be recalculated.
- 		 */
-		if (!StringUtils.hasLength(group)) {
+		boolean anonymous = !StringUtils.hasLength(group);
+		/***
+		 * 	When using DLQ, at least the group property must be provided for proper naming of the DLQ destination
+		 *  According to https://docs.spring.io/spring-cloud-stream/docs/3.2.1/reference/html/spring-cloud-stream.html#spring-cloud-stream-reference
+		 */
+		if (anonymous && NamespaceUtil.isDLQTopic(destination.getName())) {
 			throw new RuntimeException(
-					"'group must be configured for channel " + destination.getName());
+					"group must be configured for DLQ" + destination.getName());
 		}
+		group = anonymous ? anonymousGroup(destination.getName()) : group;
+
 		RocketMQUtils.mergeRocketMQProperties(binderConfigurationProperties,
 				extendedConsumerProperties.getExtension());
 		extendedConsumerProperties.getExtension().setGroup(group);
@@ -178,6 +183,15 @@ public class RocketMQMessageChannelBinder extends
 	}
 
 	/**
+	 * generate anonymous group.
+	 * @param destination not null
+	 * @return anonymous group name.
+	 */
+	private static String anonymousGroup(final String destination) {
+		return RocketMQConst.DEFAULT_GROUP + "_" + destination;
+	}
+
+	/**
 	 * Binders can return an {@link ErrorMessageStrategy} for building error messages;
 	 * binder implementations typically might add extra headers to the error message.
 	 * @return the implementation - may be null.
@@ -207,5 +221,4 @@ public class RocketMQMessageChannelBinder extends
 	public Class<? extends BinderSpecificPropertiesProvider> getExtendedPropertiesEntryClass() {
 		return this.extendedBindingProperties.getExtendedPropertiesEntryClass();
 	}
-
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/constant/RocketMQConst.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/constant/RocketMQConst.java
@@ -31,7 +31,7 @@ public class RocketMQConst extends MessageConst {
 	/**
 	 * Default group for SCS RocketMQ Binder.
 	 */
-	public static final String DEFAULT_GROUP = "binder_default_group_name";
+	public static final String DEFAULT_GROUP = "anonymous";
 
 	/**
 	 * user args for SCS RocketMQ Binder.

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/test/java/com/alibaba/cloud/stream/binder/rocketmq/RocketMQMessageChannelBinderTest.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/test/java/com/alibaba/cloud/stream/binder/rocketmq/RocketMQMessageChannelBinderTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.stream.binder.rocketmq;
+
+import javax.annotation.Resource;
+
+import com.alibaba.cloud.stream.binder.rocketmq.autoconfigurate.ExtendedBindingHandlerMappingsProviderConfiguration;
+import com.alibaba.cloud.stream.binder.rocketmq.autoconfigurate.RocketMQBinderAutoConfiguration;
+import com.alibaba.cloud.stream.binder.rocketmq.constant.RocketMQConst;
+import com.alibaba.cloud.stream.binder.rocketmq.properties.RocketMQConsumerProperties;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.core.MessageProducer;
+
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
+
+
+@SpringBootTest(classes = RocketMQMessageChannelBinderTest.TestConfig.class,
+	webEnvironment = NONE,
+	properties = {
+			"spring.cloud.stream.rocketmq.binder.name-server=127.0.0.1:9876",
+			"spring.cloud.stream.bindings.output.destination=TopicOrderTest",
+			"spring.cloud.stream.bindings.output.content-type=application/json",
+
+			"spring.cloud.stream.bindings.input1.destination=TopicOrderTest",
+			"spring.cloud.stream.bindings.input1.content-type=application/json",
+			"spring.cloud.stream.bindings.input1.group=test-group1",
+			"spring.cloud.stream.rocketmq.bindings.input1.consumer.push.orderly=true",
+			"spring.cloud.stream.bindings.input1.consumer.maxAttempts=1",
+			"spring.cloud.stream.bindings.input2.destination=TopicOrderTest",
+			"spring.cloud.stream.bindings.input2.content-type=application/json",
+			"spring.cloud.stream.bindings.input2.group=test-group2",
+			"spring.cloud.stream.rocketmq.bindings.input2.consumer.push.orderly=false",
+			"spring.cloud.stream.rocketmq.bindings.input2.consumer.subscription=tag1"
+	})
+public class RocketMQMessageChannelBinderTest {
+	@Resource
+	RocketMQMessageChannelBinder binder;
+	@Test
+	public void createConsumerEndpoint() throws Exception {
+		TestConsumerDestination destination = new TestConsumerDestination("test");
+		MessageProducer consumerEndpoint = binder.createConsumerEndpoint(destination, "test",
+				new ExtendedConsumerProperties<>(new RocketMQConsumerProperties()));
+		Assertions.assertNotNull(consumerEndpoint);
+	}
+
+	@Test
+	public void createAnymousConsumerEndpoint() throws Exception {
+		ExtendedConsumerProperties<RocketMQConsumerProperties> extendedConsumerProperties
+				= new ExtendedConsumerProperties<>(new RocketMQConsumerProperties());
+
+		TestConsumerDestination destination = new TestConsumerDestination("test");
+		MessageProducer consumerEndpoint = binder.createConsumerEndpoint(destination, null,
+				extendedConsumerProperties);
+		Assertions.assertNotNull(consumerEndpoint);
+		Assertions.assertEquals(RocketMQConst.DEFAULT_GROUP + "_test", extendedConsumerProperties.getExtension().getGroup());
+	}
+
+	@Test
+	public void createDLQAnymousConsumerEndpoint() throws Exception {
+		TestConsumerDestination destination = new TestConsumerDestination("%DLQ%test");
+		Assertions.assertThrows(RuntimeException.class, () -> {
+			MessageProducer consumerEndpoint = binder.createConsumerEndpoint(destination, null,
+					new ExtendedConsumerProperties<>(new RocketMQConsumerProperties()));
+		});
+	}
+
+	@Configuration
+	@EnableAutoConfiguration
+	@ImportAutoConfiguration({ ExtendedBindingHandlerMappingsProviderConfiguration.class,
+			RocketMQBinderAutoConfiguration.class})
+	public static class TestConfig {
+
+	}
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/test/java/com/alibaba/cloud/stream/binder/rocketmq/RocketMQMessageChannelBinderTest.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/test/java/com/alibaba/cloud/stream/binder/rocketmq/RocketMQMessageChannelBinderTest.java
@@ -73,7 +73,7 @@ public class RocketMQMessageChannelBinderTest {
 		MessageProducer consumerEndpoint = binder.createConsumerEndpoint(destination, null,
 				extendedConsumerProperties);
 		Assertions.assertThat(consumerEndpoint).isNotNull();
-		Assertions.assertThat( extendedConsumerProperties.getExtension().getGroup())
+		Assertions.assertThat(extendedConsumerProperties.getExtension().getGroup())
 				.isEqualTo(RocketMQConst.DEFAULT_GROUP + "_test");
 	}
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/test/java/com/alibaba/cloud/stream/binder/rocketmq/RocketMQMessageChannelBinderTest.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/test/java/com/alibaba/cloud/stream/binder/rocketmq/RocketMQMessageChannelBinderTest.java
@@ -22,7 +22,7 @@ import com.alibaba.cloud.stream.binder.rocketmq.autoconfigurate.ExtendedBindingH
 import com.alibaba.cloud.stream.binder.rocketmq.autoconfigurate.RocketMQBinderAutoConfiguration;
 import com.alibaba.cloud.stream.binder.rocketmq.constant.RocketMQConst;
 import com.alibaba.cloud.stream.binder.rocketmq.properties.RocketMQConsumerProperties;
-import org.junit.jupiter.api.Assertions;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -61,7 +61,7 @@ public class RocketMQMessageChannelBinderTest {
 		TestConsumerDestination destination = new TestConsumerDestination("test");
 		MessageProducer consumerEndpoint = binder.createConsumerEndpoint(destination, "test",
 				new ExtendedConsumerProperties<>(new RocketMQConsumerProperties()));
-		Assertions.assertNotNull(consumerEndpoint);
+		Assertions.assertThat(consumerEndpoint).isNotNull();
 	}
 
 	@Test
@@ -72,14 +72,15 @@ public class RocketMQMessageChannelBinderTest {
 		TestConsumerDestination destination = new TestConsumerDestination("test");
 		MessageProducer consumerEndpoint = binder.createConsumerEndpoint(destination, null,
 				extendedConsumerProperties);
-		Assertions.assertNotNull(consumerEndpoint);
-		Assertions.assertEquals(RocketMQConst.DEFAULT_GROUP + "_test", extendedConsumerProperties.getExtension().getGroup());
+		Assertions.assertThat(consumerEndpoint).isNotNull();
+		Assertions.assertThat( extendedConsumerProperties.getExtension().getGroup())
+				.isEqualTo(RocketMQConst.DEFAULT_GROUP + "_test");
 	}
 
 	@Test
 	public void createDLQAnymousConsumerEndpoint() throws Exception {
 		TestConsumerDestination destination = new TestConsumerDestination("%DLQ%test");
-		Assertions.assertThrows(RuntimeException.class, () -> {
+		Assertions.assertThatThrownBy(() -> {
 			MessageProducer consumerEndpoint = binder.createConsumerEndpoint(destination, null,
 					new ExtendedConsumerProperties<>(new RocketMQConsumerProperties()));
 		});

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/test/java/com/alibaba/cloud/stream/binder/rocketmq/TestConsumerDestination.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/test/java/com/alibaba/cloud/stream/binder/rocketmq/TestConsumerDestination.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.stream.binder.rocketmq;
+
+import org.springframework.cloud.stream.provisioning.ConsumerDestination;
+
+public class TestConsumerDestination implements ConsumerDestination {
+	private String name;
+
+	public TestConsumerDestination(String name) {
+		this.name = name;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it


### Does this pull request fix one issue?
Provide Rocketmq anonymous group support.
Now anonymous group will be setting as "anonymous_" + destination.
It is a fix for #2501
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
Anonymous group will be setting as "anonymous_" + destination.

### Describe how to verify it
1. mvn clean install
2. manual test by runing example.

### Special notes for reviews
