### PR TITLE
支持Opensergo接入SCA

### DIFF
--- a/spring-cloud-alibaba-dependencies/pom.xml
+++ b/spring-cloud-alibaba-dependencies/pom.xml
@@ -20,6 +20,7 @@
     <properties>
         <revision>2021.0.1.1-SNAPSHOT</revision>
         <sentinel.version>1.8.3</sentinel.version>
+        <opensergo.version>0.0.1</opensergo.version>
         <seata.version>1.4.2</seata.version>
         <nacos.client.version>1.4.2</nacos.client.version>
         <nacos.config.version>0.8.0</nacos.config.version>
@@ -122,6 +123,18 @@
 
             <dependency>
                 <groupId>com.alibaba.csp</groupId>
+                <artifactId>sentinel-dubbo-adapter</artifactId>
+                <version>${sentinel.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.alibaba.csp</groupId>
+                <artifactId>sentinel-apache-dubbo-adapter</artifactId>
+                <version>${sentinel.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.alibaba.csp</groupId>
                 <artifactId>sentinel-reactor-adapter</artifactId>
                 <version>${sentinel.version}</version>
             </dependency>
@@ -153,6 +166,12 @@
                 <groupId>com.alibaba.csp</groupId>
                 <artifactId>sentinel-spring-webmvc-adapter</artifactId>
                 <version>${sentinel.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.opensergo</groupId>
+                <artifactId>opensergo-java</artifactId>
+                <version>${opensergo.version}</version>
             </dependency>
 
             <!--Alibaba Seata-->
@@ -231,6 +250,13 @@
             <dependency>
                 <groupId>com.alibaba.cloud</groupId>
                 <artifactId>spring-cloud-alibaba-commons</artifactId>
+                <version>${revision}</version>
+            </dependency>
+
+            <!-- Dubbo -->
+            <dependency>
+                <groupId>com.alibaba.cloud</groupId>
+                <artifactId>spring-cloud-starter-dubbo</artifactId>
                 <version>${revision}</version>
             </dependency>
 

--- a/spring-cloud-alibaba-starters/pom.xml
+++ b/spring-cloud-alibaba-starters/pom.xml
@@ -22,7 +22,6 @@
         <module>spring-cloud-starter-alibaba-seata</module>
         <module>spring-cloud-starter-stream-rocketmq</module>
         <module>spring-cloud-starter-bus-rocketmq</module>
-        <module>spring-cloud-starter-dubbo</module>
         <module>spring-cloud-starter-alibaba-sidecar</module>
         <module>spring-cloud-circuitbreaker-sentinel</module>
         <module>spring-cloud-starter-alibaba-sentinel</module>

--- a/spring-cloud-alibaba-starters/pom.xml
+++ b/spring-cloud-alibaba-starters/pom.xml
@@ -13,14 +13,16 @@
     <packaging>pom</packaging>
     <name>Spring Cloud Alibaba Starters</name>
     <description>Spring Cloud Alibaba Starters</description>
-    
+
     <modules>
         <module>spring-cloud-starter-alibaba-nacos-config</module>
         <module>spring-cloud-starter-alibaba-nacos-config-server</module>
         <module>spring-cloud-starter-alibaba-nacos-discovery</module>
+        <module>spring-cloud-starter-alibaba-opensergo</module>
         <module>spring-cloud-starter-alibaba-seata</module>
         <module>spring-cloud-starter-stream-rocketmq</module>
         <module>spring-cloud-starter-bus-rocketmq</module>
+        <module>spring-cloud-starter-dubbo</module>
         <module>spring-cloud-starter-alibaba-sidecar</module>
         <module>spring-cloud-circuitbreaker-sentinel</module>
         <module>spring-cloud-starter-alibaba-sentinel</module>

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-opensergo/pom.xml
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-opensergo/pom.xml
@@ -1,0 +1,104 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.alibaba.cloud</groupId>
+        <artifactId>spring-cloud-alibaba-starters</artifactId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>spring-cloud-starter-alibaba-opensergo</artifactId>
+    <name>Spring Cloud Starter Alibaba OpenSergo</name>
+
+    <dependencies>
+
+        <!--spring boot-->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-actuator</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-actuator-autoconfigure</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-commons</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opensergo</groupId>
+            <artifactId>opensergo-java</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-okhttp</artifactId>
+            <version>1.44.1</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-opensergo/src/main/java/com/alibaba/cloud/opensergo/OpenSergoAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-opensergo/src/main/java/com/alibaba/cloud/opensergo/OpenSergoAutoConfiguration.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.opensergo;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import com.alibaba.cloud.opensergo.condition.OnEnvCondition;
+import com.alibaba.cloud.opensergo.reportor.ServiceContractReporter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
+
+/**
+ * @author luyanbo
+ */
+@Configuration(proxyBeanMethods = false)
+@Conditional(OnEnvCondition.class)
+public class OpenSergoAutoConfiguration {
+	private static final Logger log = LoggerFactory
+			.getLogger(OpenSergoAutoConfiguration.class);
+
+	@Bean
+	public ServiceContractReporter serviceContractReporter(ApplicationContext context)
+			throws IOException {
+		String bootstrap = context.getEnvironment()
+				.getProperty(OpenSergoConstants.OPENSERGO_BOOTSTRAP);
+		String bootstrapConfig = context.getEnvironment()
+				.getProperty(OpenSergoConstants.OPENSERGO_BOOTSTRAP_CONFIG);
+
+		if (!StringUtils.hasLength(bootstrapConfig) && StringUtils.hasLength(bootstrap)) {
+			byte[] encoded = Files.readAllBytes(Paths.get(bootstrap));
+			bootstrapConfig = new String(encoded, StandardCharsets.UTF_8);
+		}
+
+		ObjectMapper objectMapper = new ObjectMapper();
+		OpenSergoProperties properties = objectMapper.readValue(bootstrapConfig,
+				OpenSergoProperties.class);
+
+		ServiceContractReporter reporter = new ServiceContractReporter(
+				properties.getEndpoint());
+		reporter.setApplicationContext(context);
+		return reporter;
+	}
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-opensergo/src/main/java/com/alibaba/cloud/opensergo/OpenSergoAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-opensergo/src/main/java/com/alibaba/cloud/opensergo/OpenSergoAutoConfiguration.java
@@ -34,7 +34,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.util.StringUtils;
 
 /**
- * @author luyanbo
+ * @author complone
  */
 @Configuration(proxyBeanMethods = false)
 @Conditional(OnEnvCondition.class)

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-opensergo/src/main/java/com/alibaba/cloud/opensergo/OpenSergoConstants.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-opensergo/src/main/java/com/alibaba/cloud/opensergo/OpenSergoConstants.java
@@ -17,7 +17,7 @@
 package com.alibaba.cloud.opensergo;
 
 /**
- * @author luyanbo
+ * @author complone
  */
 public final class OpenSergoConstants {
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-opensergo/src/main/java/com/alibaba/cloud/opensergo/OpenSergoConstants.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-opensergo/src/main/java/com/alibaba/cloud/opensergo/OpenSergoConstants.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.opensergo;
+
+/**
+ * @author luyanbo
+ */
+public final class OpenSergoConstants {
+
+    /**
+     * Prefix of {@link OpenSergoProperties}.
+     */
+    public static final String OPENSERGO_BOOTSTRAP = "OPENSERGO_BOOTSTRAP";
+
+    /**
+     * Prefix of {@link OpenSergoProperties}.
+     */
+    public static final String OPENSERGO_BOOTSTRAP_CONFIG = "OPENSERGO_BOOTSTRAP_CONFIG";
+
+    private OpenSergoConstants() {
+        throw new AssertionError("Must not instantiate constant utility class");
+    }
+
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-opensergo/src/main/java/com/alibaba/cloud/opensergo/OpenSergoProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-opensergo/src/main/java/com/alibaba/cloud/opensergo/OpenSergoProperties.java
@@ -22,7 +22,7 @@ import org.springframework.validation.annotation.Validated;
 /**
  * {@link ConfigurationProperties} for OpenSergo.
  *
- * @author luyanbo
+ * @author complone
  */
 @Validated
 public class OpenSergoProperties {

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-opensergo/src/main/java/com/alibaba/cloud/opensergo/OpenSergoProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-opensergo/src/main/java/com/alibaba/cloud/opensergo/OpenSergoProperties.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.opensergo;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * {@link ConfigurationProperties} for OpenSergo.
+ *
+ * @author luyanbo
+ */
+@Validated
+public class OpenSergoProperties {
+
+    /**
+     * Earlier initialize heart-beat when the spring container starts when the transport
+     * dependency is on classpath, the configuration is effective.
+     */
+    private String endpoint = "";
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-opensergo/src/main/java/com/alibaba/cloud/opensergo/condition/OnEnvCondition.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-opensergo/src/main/java/com/alibaba/cloud/opensergo/condition/OnEnvCondition.java
@@ -27,7 +27,7 @@ import org.springframework.util.StringUtils;
 /**
  * A condition that checks if OpenSergo is configured.
  *
- * @author luyanbo
+ * @author complone
  */
 public class OnEnvCondition implements Condition {
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-opensergo/src/main/java/com/alibaba/cloud/opensergo/condition/OnEnvCondition.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-opensergo/src/main/java/com/alibaba/cloud/opensergo/condition/OnEnvCondition.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.opensergo.condition;
+
+import com.alibaba.cloud.opensergo.OpenSergoConstants;
+
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.util.StringUtils;
+
+
+/**
+ * A condition that checks if OpenSergo is configured.
+ *
+ * @author luyanbo
+ */
+public class OnEnvCondition implements Condition {
+
+    @Override
+    public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+        String bootstrap = context.getEnvironment()
+                .getProperty(OpenSergoConstants.OPENSERGO_BOOTSTRAP);
+        String bootstrapConfig = context.getEnvironment()
+                .getProperty(OpenSergoConstants.OPENSERGO_BOOTSTRAP_CONFIG);
+        return StringUtils.hasLength(bootstrap) || StringUtils.hasLength(bootstrapConfig);
+    }
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-opensergo/src/main/java/com/alibaba/cloud/opensergo/description/HandlerMappingDescriptionProvider.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-opensergo/src/main/java/com/alibaba/cloud/opensergo/description/HandlerMappingDescriptionProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.opensergo.description;
+
+import io.opensergo.proto.service_contract.v1.ServiceDescriptor;
+
+public interface HandlerMappingDescriptionProvider<T> {
+
+    Class<T> getMappingClass();
+
+    void process(T handlerMapping, ServiceDescriptor.Builder serviceBuilder);
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-opensergo/src/main/java/com/alibaba/cloud/opensergo/description/RequestMappingInfoHandlerMappingDescriptionProvider.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-opensergo/src/main/java/com/alibaba/cloud/opensergo/description/RequestMappingInfoHandlerMappingDescriptionProvider.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.opensergo.description;
+
+import java.util.Map;
+
+import io.opensergo.proto.service_contract.v1.MethodDescriptor;
+import io.opensergo.proto.service_contract.v1.ServiceDescriptor;
+
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfoHandlerMapping;
+import org.springframework.web.util.pattern.PathPattern;
+
+public final class RequestMappingInfoHandlerMappingDescriptionProvider
+        implements HandlerMappingDescriptionProvider<RequestMappingInfoHandlerMapping> {
+
+    @Override
+    public Class<RequestMappingInfoHandlerMapping> getMappingClass() {
+        return RequestMappingInfoHandlerMapping.class;
+    }
+
+    @Override
+    public void process(RequestMappingInfoHandlerMapping handlerMapping,
+                        ServiceDescriptor.Builder serviceBuilder) {
+        Map<RequestMappingInfo, HandlerMethod> handlerMethods = handlerMapping
+                .getHandlerMethods();
+        for (Map.Entry<RequestMappingInfo, HandlerMethod> entry : handlerMethods
+                .entrySet()) {
+            RequestMappingInfo k = entry.getKey();
+            HandlerMethod v = entry.getValue();
+
+            MethodDescriptor.Builder builder = MethodDescriptor.newBuilder();
+
+            if (k.getPathPatternsCondition() != null) {
+                for (PathPattern pattern : k.getPathPatternsCondition().getPatterns()) {
+                    builder.addHttpPaths(pattern.getPatternString());
+                }
+            }
+            for (RequestMethod method : k.getMethodsCondition().getMethods()) {
+                builder.addHttpMethods(method.name());
+            }
+            serviceBuilder.addMethods(builder.build());
+        }
+    }
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-opensergo/src/main/java/com/alibaba/cloud/opensergo/reportor/ServiceContractReporter.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-opensergo/src/main/java/com/alibaba/cloud/opensergo/reportor/ServiceContractReporter.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.opensergo.reportor;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import javax.servlet.Servlet;
+import javax.servlet.ServletException;
+
+import com.alibaba.cloud.opensergo.description.HandlerMappingDescriptionProvider;
+import com.alibaba.cloud.opensergo.description.RequestMappingInfoHandlerMappingDescriptionProvider;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.opensergo.proto.service_contract.v1.MetadataServiceGrpc;
+import io.opensergo.proto.service_contract.v1.ReportMetadataRequest;
+import io.opensergo.proto.service_contract.v1.ServiceContract;
+import io.opensergo.proto.service_contract.v1.ServiceDescriptor;
+import io.opensergo.proto.service_contract.v1.ServiceMetadata;
+import org.apache.catalina.Container;
+import org.apache.catalina.Context;
+import org.apache.catalina.core.StandardWrapper;
+
+import org.springframework.boot.web.embedded.tomcat.TomcatWebServer;
+import org.springframework.boot.web.embedded.undertow.UndertowServletWebServer;
+import org.springframework.boot.web.server.WebServer;
+import org.springframework.boot.web.servlet.ServletRegistrationBean;
+import org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext;
+import org.springframework.context.ApplicationContext;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.servlet.DispatcherServlet;
+import org.springframework.web.servlet.HandlerMapping;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfoHandlerMapping;
+
+public class ServiceContractReporter {
+    private MetadataServiceGrpc.MetadataServiceBlockingStub blockingStub;
+    private ApplicationContext applicationContext;
+
+    public ServiceContractReporter(String endpoint) {
+        ManagedChannel channel = ManagedChannelBuilder.forTarget(endpoint).usePlaintext()
+                .build();
+        blockingStub = MetadataServiceGrpc.newBlockingStub(channel);
+    }
+
+    public void setApplicationContext(ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+
+        String appName = applicationContext.getId();
+        if (appName == null || appName.isEmpty()) {
+            appName = "unknown_app";
+        }
+        ReportMetadataRequest.Builder reportBuilder = ReportMetadataRequest.newBuilder()
+                .setAppName(appName);
+
+        ServiceContract.Builder contractBuilder = ServiceContract.newBuilder();
+        ServiceDescriptor.Builder descBuilder = ServiceDescriptor.newBuilder()
+                .setName(appName);
+
+        if (applicationContext instanceof WebApplicationContext) {
+            determineDispatcherServlets((WebApplicationContext) applicationContext)
+                    .forEach((name, dispatcherServlet) -> {
+                        processHandlerMappings(dispatcherServlet, name, descBuilder);
+                    });
+        }
+        contractBuilder.addServices(descBuilder.build());
+        ServiceMetadata.Builder metadataBuilder = ServiceMetadata.newBuilder();
+        metadataBuilder.setServiceContract(contractBuilder.build()).addProtocols("http");
+        reportBuilder.addServiceMetadata(metadataBuilder.build());
+
+        blockingStub.reportMetadata(reportBuilder.build());
+    }
+
+    private Map<String, DispatcherServlet> determineDispatcherServlets(
+            WebApplicationContext context) {
+        Map<String, DispatcherServlet> dispatcherServlets = new LinkedHashMap<>();
+        context.getBeansOfType(ServletRegistrationBean.class).values()
+                .forEach((registration) -> {
+                    Servlet servlet = registration.getServlet();
+                    if (servlet instanceof DispatcherServlet
+                            && !dispatcherServlets.containsValue(servlet)) {
+                        dispatcherServlets.put(registration.getServletName(),
+                                (DispatcherServlet) servlet);
+                    }
+                });
+        context.getBeansOfType(DispatcherServlet.class)
+                .forEach((name, dispatcherServlet) -> {
+                    if (!dispatcherServlets.containsValue(dispatcherServlet)) {
+                        dispatcherServlets.put(name, dispatcherServlet);
+                    }
+                });
+        return dispatcherServlets;
+    }
+
+    void processHandlerMappings(DispatcherServlet dispatcherServlet, String name,
+                                ServiceDescriptor.Builder descBuilder) {
+        List<HandlerMapping> handlerMappings = dispatcherServlet.getHandlerMappings();
+        HandlerMappingDescriptionProvider<RequestMappingInfoHandlerMapping> descriptionProvider = new RequestMappingInfoHandlerMappingDescriptionProvider();
+
+        if (handlerMappings == null) {
+            initializeDispatcherServletIfPossible(name);
+            handlerMappings = dispatcherServlet.getHandlerMappings();
+            for (HandlerMapping handlerMapping : handlerMappings) {
+                if (descriptionProvider.getMappingClass().isInstance(handlerMapping)) {
+                    descriptionProvider.process(
+                            (RequestMappingInfoHandlerMapping) handlerMapping,
+                            descBuilder);
+                }
+            }
+        }
+    }
+
+    private void initializeDispatcherServletIfPossible(String name) {
+        if (!(this.applicationContext instanceof ServletWebServerApplicationContext)) {
+            return;
+        }
+        WebServer webServer = ((ServletWebServerApplicationContext) this.applicationContext)
+                .getWebServer();
+        if (webServer instanceof UndertowServletWebServer) {
+            // UndertowServletInitializer is not supported yet.
+            // new UndertowServletInitializer((UndertowServletWebServer)
+            // webServer).initializeServlet(this.name);
+        }
+        else if (webServer instanceof TomcatWebServer) {
+            new TomcatServletInitializer((TomcatWebServer) webServer)
+                    .initializeServlet(name);
+        }
+    }
+
+    private static final class TomcatServletInitializer {
+
+        private final TomcatWebServer webServer;
+
+        private TomcatServletInitializer(TomcatWebServer webServer) {
+            this.webServer = webServer;
+        }
+
+        void initializeServlet(String name) {
+            findContext().ifPresent((context) -> initializeServlet(context, name));
+        }
+
+        private Optional<Context> findContext() {
+            return Stream.of(this.webServer.getTomcat().getHost().findChildren())
+                    .filter(Context.class::isInstance).map(Context.class::cast)
+                    .findFirst();
+        }
+
+        private void initializeServlet(Context context, String name) {
+            Container child = context.findChild(name);
+            if (child instanceof StandardWrapper) {
+                try {
+                    StandardWrapper wrapper = (StandardWrapper) child;
+                    wrapper.deallocate(wrapper.allocate());
+                }
+                catch (ServletException ex) {
+                    // Continue
+                }
+            }
+        }
+    }
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-opensergo/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-opensergo/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+com.alibaba.cloud.opensergo.OpenSergoAutoConfiguration


### PR DESCRIPTION
### Describe what this PR does / why we need it

需求背景:
OpenSergo作为微服务治理的标准和控制面，并提供SDK取对接各个框架，比如SCA
所以为支持[服务契约能力](https://github.com/alibaba/spring-cloud-alibaba/issues/2362) 先将业务进程基于grpc的协议的请求状态数据上报到管控面

该PR主要实现的是业务进程通过OpenSergo-pilot上报请求状态数据到mysql的逻辑

![12121](https://user-images.githubusercontent.com/20021404/164952384-1a74fafd-17c6-4c0d-9f1b-2adf190965d4.png)

目前第一版先支持
1.支持Opensergo接入SCA时 请求匹配符合URL格式
2.开放Opensergo启动配置，接管管控面


通过与 @robberphex 的沟通 当该PR合并后
接入demo参考: https://github.com/robberphex/example-opensergo-sca


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
