### PR TITLE
NacosServiceRegistryCallback interface facilitates the initialization…

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosServiceRegistry.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosServiceRegistry.java
@@ -37,6 +37,7 @@ import static org.springframework.util.ReflectionUtils.rethrowRuntimeException;
  * @author xiaojing
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
  * @author <a href="mailto:78552423@qq.com">eshun</a>
+ * @author changjin wei(魏昌进)
  */
 public class NacosServiceRegistry implements ServiceRegistry<Registration> {
 
@@ -50,10 +51,14 @@ public class NacosServiceRegistry implements ServiceRegistry<Registration> {
 
 	private final NacosServiceManager nacosServiceManager;
 
+	private final List<NacosServiceRegistryCallback> nacosServiceRegistryCallbacks;
+
 	public NacosServiceRegistry(NacosServiceManager nacosServiceManager,
-			NacosDiscoveryProperties nacosDiscoveryProperties) {
+								NacosDiscoveryProperties nacosDiscoveryProperties,
+								List<NacosServiceRegistryCallback> nacosServiceRegistryCallbacks) {
 		this.nacosDiscoveryProperties = nacosDiscoveryProperties;
 		this.nacosServiceManager = nacosServiceManager;
+		this.nacosServiceRegistryCallbacks = nacosServiceRegistryCallbacks;
 	}
 
 	@Override
@@ -72,10 +77,12 @@ public class NacosServiceRegistry implements ServiceRegistry<Registration> {
 
 		try {
 			namingService.registerInstance(serviceId, group, instance);
+			nacosServiceRegistryCallbacks.forEach(NacosServiceRegistryCallback::success);
 			log.info("nacos registry, {} {} {}:{} register finished", group, serviceId,
 					instance.getIp(), instance.getPort());
 		}
 		catch (Exception e) {
+			nacosServiceRegistryCallbacks.forEach(NacosServiceRegistryCallback::fail);
 			if (nacosDiscoveryProperties.isFailFast()) {
 				log.error("nacos registry, {} register failed...{},", serviceId,
 						registration.toString(), e);

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosServiceRegistryAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosServiceRegistryAutoConfiguration.java
@@ -38,6 +38,7 @@ import org.springframework.context.annotation.Configuration;
 /**
  * @author xiaojing
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @author changjin wei(魏昌进)
  */
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties
@@ -52,8 +53,10 @@ public class NacosServiceRegistryAutoConfiguration {
 	@Bean
 	public NacosServiceRegistry nacosServiceRegistry(
 			NacosServiceManager nacosServiceManager,
-			NacosDiscoveryProperties nacosDiscoveryProperties) {
-		return new NacosServiceRegistry(nacosServiceManager, nacosDiscoveryProperties);
+			NacosDiscoveryProperties nacosDiscoveryProperties,
+			ObjectProvider<List<NacosServiceRegistryCallback>> nacosServiceRegistryCallbacks) {
+		return new NacosServiceRegistry(nacosServiceManager, nacosDiscoveryProperties,
+										nacosServiceRegistryCallbacks.getIfAvailable());
 	}
 
 	@Bean

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosServiceRegistryCallback.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosServiceRegistryCallback.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.alibaba.cloud.nacos.registry;
 
 /**
@@ -6,13 +22,13 @@ package com.alibaba.cloud.nacos.registry;
  */
 public interface NacosServiceRegistryCallback {
 
-    /**
-     * Nacos Service Registry finished Callback
-     */
-    void success();
+	/**
+	 * Nacos Service Registry finished Callback
+	 */
+	void success();
 
-    /**
-     * Nacos Service Registry fail Callback
-     */
-    void fail();
+	/**
+	 * Nacos Service Registry fail Callback
+	 */
+	void fail();
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosServiceRegistryCallback.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosServiceRegistryCallback.java
@@ -1,0 +1,18 @@
+package com.alibaba.cloud.nacos.registry;
+
+/**
+ * @author changjin wei(魏昌进)
+ * @since 2022/5/6
+ */
+public interface NacosServiceRegistryCallback {
+
+    /**
+     * Nacos Service Registry finished Callback
+     */
+    void success();
+
+    /**
+     * Nacos Service Registry fail Callback
+     */
+    void fail();
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosServiceRegistryCallback.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosServiceRegistryCallback.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *	  https://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,12 +23,12 @@ package com.alibaba.cloud.nacos.registry;
 public interface NacosServiceRegistryCallback {
 
 	/**
-	 * Nacos Service Registry finished Callback
+	 * Nacos Service Registry finished Callback.
 	 */
 	void success();
 
 	/**
-	 * Nacos Service Registry fail Callback
+	 * Nacos Service Registry fail Callback.
 	 */
 	void fail();
 }


### PR DESCRIPTION
… of some other resources


### Describe what this PR does / why we need it

nacosserviceregistrycallback interface facilitates the initialization of some other resources

主要用于初始化一些其他资源， 用于初始化 Apache APISIX 网关中routes和Upstream的初始化，当然还能用于其他的作用

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
