### PR TITLE
Fix deregister issue of the Nacos persistence instance .

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosServiceRegistry.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosServiceRegistry.java
@@ -102,9 +102,10 @@ public class NacosServiceRegistry implements ServiceRegistry<Registration> {
 		String serviceId = registration.getServiceId();
 		String group = nacosDiscoveryProperties.getGroup();
 
+		Instance instance = getNacosInstanceFromRegistration(registration);
+
 		try {
-			namingService.deregisterInstance(serviceId, group, registration.getHost(),
-					registration.getPort(), nacosDiscoveryProperties.getClusterName());
+			namingService.deregisterInstance(serviceId, group, instance);
 		}
 		catch (Exception e) {
 			log.error("ERR_NACOS_DEREGISTER, de-register failed...{},",


### PR DESCRIPTION
### Describe what this PR does / why we need it

Fix deregister issue of the Nacos persistence instance .

### Does this pull request fix one issue?

Fixes #2492 .

### Describe how you did it

Use 
```java
NamingService#deregisterInstance(String serviceName, String groupName, Instance instance)
```

instead of 
```java
NamingService#deregisterInstance(String serviceName, String groupName, String ip, int port, String clusterName)
``` 

### Describe how to verify it

Run example by `nacos-discovery-provider-example` .

### Special notes for reviews

None.