### PR TITLE
2021.x. rocketmq multi-broker offset error and blank header support

### DIFF
--- a/spring-cloud-alibaba-examples/pom.xml
+++ b/spring-cloud-alibaba-examples/pom.xml
@@ -26,14 +26,11 @@
         <module>nacos-example/nacos-discovery-example</module>
         <module>nacos-example/nacos-config-example</module>
         <module>nacos-example/nacos-config-2.4.x-example</module>
-        <module>nacos-example/nacos-config-preference-example</module>
         <module>nacos-example/nacos-gateway-example</module>
         <module>seata-example/business-service</module>
         <module>seata-example/order-service</module>
         <module>seata-example/storage-service</module>
         <module>seata-example/account-service</module>
-        <module>rocketmq-example/rocketmq-consume-example</module>
-        <module>rocketmq-example/rocketmq-produce-example</module>
         <module>rocketmq-example/rocketmq-comprehensive-example</module>
         <module>rocketmq-example/rocketmq-orderly-consume-example</module>
         <module>rocketmq-example/rocketmq-broadcast-example/rocketmq-broadcast-producer-example</module>

--- a/spring-cloud-alibaba-examples/pom.xml
+++ b/spring-cloud-alibaba-examples/pom.xml
@@ -32,8 +32,6 @@
         <module>seata-example/order-service</module>
         <module>seata-example/storage-service</module>
         <module>seata-example/account-service</module>
-        <module>rocketmq-example/rocketmq-consume-example</module>
-        <module>rocketmq-example/rocketmq-produce-example</module>
         <module>rocketmq-example/rocketmq-comprehensive-example</module>
         <module>rocketmq-example/rocketmq-orderly-consume-example</module>
         <module>rocketmq-example/rocketmq-broadcast-example/rocketmq-broadcast-producer-example</module>

--- a/spring-cloud-alibaba-examples/pom.xml
+++ b/spring-cloud-alibaba-examples/pom.xml
@@ -26,7 +26,6 @@
         <module>nacos-example/nacos-discovery-example</module>
         <module>nacos-example/nacos-config-example</module>
         <module>nacos-example/nacos-config-2.4.x-example</module>
-        <module>nacos-example/nacos-config-preference-example</module>
         <module>nacos-example/nacos-gateway-example</module>
         <module>seata-example/business-service</module>
         <module>seata-example/order-service</module>

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/integration/inbound/pull/RocketMQMessageSource.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/integration/inbound/pull/RocketMQMessageSource.java
@@ -110,14 +110,15 @@ public class RocketMQMessageSource extends AbstractMessageSource<Object>
 		this.running = true;
 	}
 
-	private MessageQueue acquireCurrentMessageQueue(String topic,int queueId, String brokerName) {
-		Collection<MessageQueue> messageQueueSet =  messageQueuesForTopic.get(topic);
-		if(CollectionUtils.isEmpty(messageQueueSet)){
+	private MessageQueue acquireCurrentMessageQueue(String topic, int queueId,
+			String brokerName) {
+		Collection<MessageQueue> messageQueueSet = messageQueuesForTopic.get(topic);
+		if (CollectionUtils.isEmpty(messageQueueSet)) {
 			return null;
 		}
 		for (MessageQueue messageQueue : messageQueueSet) {
-			if (messageQueue.getQueueId() == queueId &&
-					ObjectUtils.nullSafeEquals(brokerName, messageQueue.getBrokerName())) {
+			if (messageQueue.getQueueId() == queueId && ObjectUtils
+					.nullSafeEquals(brokerName, messageQueue.getBrokerName())) {
 				return messageQueue;
 			}
 		}
@@ -154,8 +155,8 @@ public class RocketMQMessageSource extends AbstractMessageSource<Object>
 		if (null == messageExt) {
 			return null;
 		}
-		MessageQueue messageQueue = this.acquireCurrentMessageQueue(messageExt.getTopic(), messageExt.getQueueId(),
-				messageExt.getBrokerName());
+		MessageQueue messageQueue = this.acquireCurrentMessageQueue(messageExt.getTopic(),
+				messageExt.getQueueId(), messageExt.getBrokerName());
 		if (messageQueue == null) {
 			throw new IllegalArgumentException(
 					"The message queue is not in assigned list");

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/integration/inbound/pull/RocketMQMessageSource.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/integration/inbound/pull/RocketMQMessageSource.java
@@ -44,6 +44,7 @@ import org.springframework.integration.endpoint.AbstractMessageSource;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.ObjectUtils;
 
 /**
  * @author <a href="mailto:fangjian0423@gmail.com">Jim</a>
@@ -109,13 +110,14 @@ public class RocketMQMessageSource extends AbstractMessageSource<Object>
 		this.running = true;
 	}
 
-	private MessageQueue acquireCurrentMessageQueue(String topic, int queueId) {
-		Collection<MessageQueue> messageQueueSet = messageQueuesForTopic.get(topic);
-		if (CollectionUtils.isEmpty(messageQueueSet)) {
+	private MessageQueue acquireCurrentMessageQueue(String topic,int queueId, String brokerName) {
+		Collection<MessageQueue> messageQueueSet =  messageQueuesForTopic.get(topic);
+		if(CollectionUtils.isEmpty(messageQueueSet)){
 			return null;
 		}
 		for (MessageQueue messageQueue : messageQueueSet) {
-			if (messageQueue.getQueueId() == queueId) {
+			if (messageQueue.getQueueId() == queueId &&
+					ObjectUtils.nullSafeEquals(brokerName, messageQueue.getBrokerName())) {
 				return messageQueue;
 			}
 		}
@@ -152,8 +154,8 @@ public class RocketMQMessageSource extends AbstractMessageSource<Object>
 		if (null == messageExt) {
 			return null;
 		}
-		MessageQueue messageQueue = this.acquireCurrentMessageQueue(messageExt.getTopic(),
-				messageExt.getQueueId());
+		MessageQueue messageQueue = this.acquireCurrentMessageQueue(messageExt.getTopic(), messageExt.getQueueId(),
+				messageExt.getBrokerName());
 		if (messageQueue == null) {
 			throw new IllegalArgumentException(
 					"The message queue is not in assigned list");

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/support/RocketMQMessageConverterSupport.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/support/RocketMQMessageConverterSupport.java
@@ -175,8 +175,11 @@ public final class RocketMQMessageConverterSupport {
 					.filter(entry -> !Objects.equals(entry.getKey(), Headers.FLAG))
 					.forEach(entry -> {
 						if (!MessageConst.STRING_HASH_SET.contains(entry.getKey())) {
-							rocketMsg.putUserProperty(entry.getKey(),
-									String.valueOf(entry.getValue()));
+							String val = String.valueOf(entry.getValue());
+							// Remove All blank header(rocketmq not support).
+							if (org.apache.commons.lang3.StringUtils.isNotBlank(val)) {
+								rocketMsg.putUserProperty(entry.getKey(), val);
+							}
 						}
 					});
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/test/java/com/alibaba/cloud/stream/binder/rocketmq/RocketMQMessageConverterSupportTest.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/test/java/com/alibaba/cloud/stream/binder/rocketmq/RocketMQMessageConverterSupportTest.java
@@ -1,0 +1,30 @@
+package com.alibaba.cloud.stream.binder.rocketmq;
+
+import com.alibaba.cloud.stream.binder.rocketmq.support.RocketMQMessageConverterSupport;
+import org.apache.rocketmq.common.message.MessageConst;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Sorie
+ */
+public class RocketMQMessageConverterSupportTest {
+
+	@Test
+	public void convertMessage2MQBlankHeaderTest() {
+		String destination = "test";
+		Message message = MessageBuilder.withPayload("msg")
+				.setHeader(MessageConst.PROPERTY_TAGS, "a")
+				.setHeader("test", "")
+				.build();
+		org.apache.rocketmq.common.message.Message rkmqMsg =
+				RocketMQMessageConverterSupport.convertMessage2MQ(destination, message);
+		String testProp = rkmqMsg.getProperty("test");
+		String tagProp = rkmqMsg.getProperty(MessageConst.PROPERTY_TAGS);
+		assertThat(testProp).isNull();
+		assertThat(tagProp).isEqualTo("a");
+	}
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/test/java/com/alibaba/cloud/stream/binder/rocketmq/RocketMQMessageConverterSupportTest.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/test/java/com/alibaba/cloud/stream/binder/rocketmq/RocketMQMessageConverterSupportTest.java
@@ -1,8 +1,25 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.alibaba.cloud.stream.binder.rocketmq;
 
 import com.alibaba.cloud.stream.binder.rocketmq.support.RocketMQMessageConverterSupport;
 import org.apache.rocketmq.common.message.MessageConst;
 import org.junit.jupiter.api.Test;
+
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
 


### PR DESCRIPTION
### Describe what this PR does / why we need it
Fix some bugs.

### Does this pull request fix one issue?
Fixes #2469
Fixes #2552
Fixes a pom error.
### Describe how you did it
#2552 :
Remove all blank value header before sending msgs to rocketmq, because rocketmq is not support blank or null value header.
#2469 : 
To find MsgQueue by queueId equal and brokerName equal, rather than just queueId equal.
### Describe how to verify it
Munual and unit test(unit test for#2552)
### Special notes for reviews
或许可以请冰封review一下