### PR TITLE
Correct erroneous content in documentation sca-upgrade-guide.adoc 

### DIFF
--- a/spring-cloud-alibaba-docs/src/main/asciidoc-zh/sca-upgrade-guide.adoc
+++ b/spring-cloud-alibaba-docs/src/main/asciidoc-zh/sca-upgrade-guide.adoc
@@ -117,7 +117,7 @@ Add a spring.config.import=nacos: property to your configuration.
 </dependency>
 ```
 
-这里有两个 FeignClint
+这里有两个 FeignClient
 ```java
 @FeignClient(value = "user", fallback = UserFallback.class)
 public interface UserClient {

--- a/spring-cloud-alibaba-docs/src/main/asciidoc/sca-upgrade-guide.adoc
+++ b/spring-cloud-alibaba-docs/src/main/asciidoc/sca-upgrade-guide.adoc
@@ -116,7 +116,7 @@ Add dependency.
 </dependency>
 ```
 
-And here are two FeignClint
+And here are two FeignClient
 ```java
 @FeignClient(value = "user", fallback = UserFallback.class)
 public interface UserClient {


### PR DESCRIPTION
### Describe what this PR does / why we need it

Fix the wrong word in the document.
eg: FeignClint->FeignClient


### Does this pull request fix one issue?
NONE
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
将 2021.x/spring-cloud-alibaba-docs/src/main/asciidoc-zh/sca-upgrade-guide.adoc中的120行处的错误单词FeignClint修改为正确单词为FeignClient

将 2021.x/spring-cloud-alibaba-docs/src/main/asciidoc/sca-upgrade-guide.adoc中的119行的错误单词FeignClint修改为正确单词为FeignClient


### Describe how to verify it
You can check Google Translate to verify the incorrect word

### Special notes for reviews
