### PR TITLE
add preferredIPversion to resolve ipv4/ipv6  address or both

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
@@ -26,7 +26,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.cloud.commons.util.InetUtils;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
@@ -222,9 +221,6 @@ public class NacosDiscoveryProperties {
 	private boolean failFast = true;
 
 	@Autowired
-	private InetUtils inetUtils;
-
-	@Autowired
 	private Environment environment;
 
 	@Autowired
@@ -370,10 +366,6 @@ public class NacosDiscoveryProperties {
 
 	public void setLogName(String logName) {
 		this.logName = logName;
-	}
-
-	public void setInetUtils(InetUtils inetUtils) {
-		this.inetUtils = inetUtils;
 	}
 
 	public float getWeight() {


### PR DESCRIPTION
### Describe what this PR does / why we need it
add preferredIPversion to register for your service instance with ipv4, ipv6 or both.

### Does this pull request fix one issue?

Ref #2593

### Describe how you did it
As coded, get ipv4 while v4 preferred, get ipv6 while v6 preferred, return ip with `IPV4,IPV6` if both preferred and register for your service instance twice later.

And how about to enhance org.springframework.cloud.commons.util.InetUtils with ipv6?  @ralf0131 

### Describe how to verify it
not verified yet.

### Special notes for reviews
NONE