### PR TITLE
update overview pic url in readme of rocketmq-example

### DIFF
--- a/spring-cloud-alibaba-examples/rocketmq-example/readme-zh.md
+++ b/spring-cloud-alibaba-examples/rocketmq-example/readme-zh.md
@@ -26,7 +26,7 @@ Binding 在消息中间件与应用程序提供的 Provider 和 Consumer 之间�
 
 下图是 Spring Cloud Stream 的架构设计。
 
-![](https://docs.spring.io/spring-cloud-stream/docs/current/reference/htmlsingle/images/SCSt-overview.png)
+![](https://docs.spring.io/spring-cloud-stream/docs/current/reference/html/images/SCSt-with-binder.png)
 
 
 

--- a/spring-cloud-alibaba-examples/rocketmq-example/readme.md
+++ b/spring-cloud-alibaba-examples/rocketmq-example/readme.md
@@ -22,7 +22,7 @@ Binding is Bridge between the external messaging systems and application provide
 
 This is a overview of Spring Cloud Stream.
 
-![](https://docs.spring.io/spring-cloud-stream/docs/current/reference/htmlsingle/images/SCSt-overview.png)
+![](https://docs.spring.io/spring-cloud-stream/docs/current/reference/html/images/SCSt-with-binder.png)
 
 ## Preparation
 


### PR DESCRIPTION
### Describe what this PR does / why we need it
after the pr https://github.com/alibaba/spring-cloud-alibaba/pull/2643 the pic url in readme-zh.md has up-to-date ,but the pic url in branch 2021.x is still failed to display