### PR TITLE
Update SentinelAutoConfiguration.java

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/custom/SentinelAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/custom/SentinelAutoConfiguration.java
@@ -147,7 +147,7 @@ public class SentinelAutoConfiguration {
 	@ConditionalOnClass(name = "org.springframework.web.client.RestTemplate")
 	@ConditionalOnProperty(name = "resttemplate.sentinel.enabled", havingValue = "true",
 			matchIfMissing = true)
-	public SentinelBeanPostProcessor sentinelBeanPostProcessor(
+	public static SentinelBeanPostProcessor sentinelBeanPostProcessor(
 			ApplicationContext applicationContext) {
 		return new SentinelBeanPostProcessor(applicationContext);
 	}


### PR DESCRIPTION
Update sentinelbeanprocess creation,
Sentinelautoconfiguration is not created in the post processor


### Describe what this PR does / why we need it
SentinelBeanPostProcessor在初始化时，把SentinelAutoConfiguration也初始化了。加上static防止SentinelBeanPostProcessor的factoryBean 也初始化

### Does this pull request fix one issue?
#2651 

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
使用static方法修饰。让RootBeanDefinition#getFactoryBeanName为空。不提前加载SentinelAutoConfiguration

### Describe how to verify it
https://gitlab.com/poo0054/test
地址存在有一个案例，里面有自定义一个Validator，初始化自定义的Validator时，把datasource也提前初始化了

### Special notes for reviews
None .