### PR TITLE
solve #2658 SeataRestTemplateAutoConfiguration Circular dependency in

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/java/com/alibaba/cloud/seata/rest/SeataRestTemplateAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/java/com/alibaba/cloud/seata/rest/SeataRestTemplateAutoConfiguration.java
@@ -16,17 +16,8 @@
 
 package com.alibaba.cloud.seata.rest;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
-import javax.annotation.PostConstruct;
-
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.client.ClientHttpRequestInterceptor;
-import org.springframework.web.client.RestTemplate;
 
 /**
  * @author xiaojing
@@ -35,32 +26,14 @@ import org.springframework.web.client.RestTemplate;
 @Configuration(proxyBeanMethods = false)
 public class SeataRestTemplateAutoConfiguration {
 
-	@Autowired(required = false)
-	private Collection<RestTemplate> restTemplates;
-
-	@Autowired
-	private SeataRestTemplateInterceptor seataRestTemplateInterceptor;
-
-	@PostConstruct
-	public void init() {
-		if (this.restTemplates != null) {
-			for (RestTemplate restTemplate : restTemplates) {
-				List<ClientHttpRequestInterceptor> interceptors = new ArrayList<ClientHttpRequestInterceptor>(
-						restTemplate.getInterceptors());
-				interceptors.add(this.seataRestTemplateInterceptor);
-				restTemplate.setInterceptors(interceptors);
-			}
-		}
+	@Bean
+	public SeataRestTemplateInterceptor seataRestTemplateInterceptor() {
+		return new SeataRestTemplateInterceptor();
 	}
 
-	@Configuration(proxyBeanMethods = false)
-	static class SeataRestTemplateInterceptorConfiguration {
-
-		@Bean
-		public SeataRestTemplateInterceptor seataRestTemplateInterceptor() {
-			return new SeataRestTemplateInterceptor();
-		}
-
+	@Bean
+	public SeataRestTemplateInterceptorAfterPropertiesSet seataRestTemplateInterceptorConfiguration() {
+		return new SeataRestTemplateInterceptorAfterPropertiesSet();
 	}
 
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/java/com/alibaba/cloud/seata/rest/SeataRestTemplateInterceptorAfterPropertiesSet.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/java/com/alibaba/cloud/seata/rest/SeataRestTemplateInterceptorAfterPropertiesSet.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.seata.rest;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * @author ZhangZhi
+ */
+public class SeataRestTemplateInterceptorAfterPropertiesSet implements InitializingBean {
+
+	@Autowired(required = false)
+	private Collection<RestTemplate> restTemplates;
+
+	@Autowired
+	private SeataRestTemplateInterceptor seataRestTemplateInterceptor;
+
+	@Override
+	public void afterPropertiesSet() {
+		if (this.restTemplates != null) {
+			for (RestTemplate restTemplate : restTemplates) {
+				List<ClientHttpRequestInterceptor> interceptors = new ArrayList<>(
+						restTemplate.getInterceptors());
+				interceptors.add(this.seataRestTemplateInterceptor);
+				restTemplate.setInterceptors(interceptors);
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it
Fixed #2658

### Does this pull request fix one issue?
#2658
solve seataresttemplateautoconfiguration  circular dependencies

### Describe how you did it
Separate seataresttemplateautoconfiguration from seataresttemplateinterceptorconfiguration,
seataresttemplateinterceptorconfiguration change SeataRestTemplateInterceptorAfterPropertiesSet
