### PR TITLE
Reorder import statement in seata starter to pass checkstyle

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/java/com/alibaba/cloud/seata/rest/SeataRestTemplateInterceptorAfterPropertiesSet.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/java/com/alibaba/cloud/seata/rest/SeataRestTemplateInterceptorAfterPropertiesSet.java
@@ -16,14 +16,14 @@
 
 package com.alibaba.cloud.seata.rest;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.web.client.RestTemplate;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 
 /**
  * @author ZhangZhi


### PR DESCRIPTION
### Describe what this PR does / why we need it
When fetch the newest code and build with maven, the import statement in Seata starter can not pass the maven checkstyle plugin and failed due to the wrong order of the import statement
In order to build completely, the import statement should be reordered
### Does this pull request fix one issue?

Fixes #2681

### Describe how you did it
find the file log `spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/target/checkstyle-result.xml` and target the specific line of the import statement
The problem is that the dictionary order of `import java.xxx` is more forward than `import org.xxx` and should be declared in a more forward position
### Describe how to verify it
after rerun `mvn clean install -DskipTests` the whole project build with success