### PR TITLE
Support consumer subscribe multiple topics

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/provisioning/RocketMQTopicProvisioner.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/provisioning/RocketMQTopicProvisioner.java
@@ -27,6 +27,7 @@ import org.springframework.cloud.stream.provisioning.ConsumerDestination;
 import org.springframework.cloud.stream.provisioning.ProducerDestination;
 import org.springframework.cloud.stream.provisioning.ProvisioningException;
 import org.springframework.cloud.stream.provisioning.ProvisioningProvider;
+import org.springframework.util.StringUtils;
 
 /**
  * @author Timur Valiev
@@ -39,7 +40,7 @@ public class RocketMQTopicProvisioner implements
 	public ProducerDestination provisionProducerDestination(String name,
 			ExtendedProducerProperties<RocketMQProducerProperties> properties)
 			throws ProvisioningException {
-		checkTopic(name);
+		checkDestination(name);
 		return new RocketProducerDestination(name);
 	}
 
@@ -47,13 +48,16 @@ public class RocketMQTopicProvisioner implements
 	public ConsumerDestination provisionConsumerDestination(String name, String group,
 			ExtendedConsumerProperties<RocketMQConsumerProperties> properties)
 			throws ProvisioningException {
-		checkTopic(name);
+		checkDestination(name);
 		return new RocketConsumerDestination(name);
 	}
 
-	private void checkTopic(String topic) {
+	private void checkDestination(String destination) {
+		String[] topics = StringUtils.commaDelimitedListToStringArray(destination);
 		try {
-			Validators.checkTopic(topic);
+			for (String topic: topics) {
+				Validators.checkTopic(topic);
+			}
 		}
 		catch (MQClientException e) {
 			throw new AssertionError(e);

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/utils/RocketMQUtils.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/utils/RocketMQUtils.java
@@ -91,6 +91,9 @@ public final class RocketMQUtils {
 		return nameServer.replaceAll(",", ";");
 	}
 
+	/**
+	 * the prefix of subscription when using SQL92 expression.
+	 */
 	public static final String SQL = "sql:";
 
 	public static MessageSelector getMessageSelector(String expression) {

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/utils/RocketMQUtils.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/utils/RocketMQUtils.java
@@ -91,7 +91,7 @@ public final class RocketMQUtils {
 		return nameServer.replaceAll(",", ";");
 	}
 
-	private static final String SQL = "sql:";
+	public static final String SQL = "sql:";
 
 	public static MessageSelector getMessageSelector(String expression) {
 		if (StringUtils.hasText(expression) && expression.startsWith(SQL)) {


### PR DESCRIPTION
### Describe what this PR does / why we need it
For now, the consumer can only subscribe one topic (destination).
Sometimes we need to subscribe multiple topics in one consumer (which is also one consumer binding in SCA).

In this PR, we can subscribe multiple topics in one consumer binding.


### Does this pull request fix one issue?

Part of #2712.

### Describe how to use it
1. Set `multiplex` in ConsumerProperties to `true`.
2. Write multiple topics in the `destination` with comma seperated, e.g., `topic-1,topic-2`.
3. The consumer binding will subscribe multiple topics.


### Special notes for reviews
