### PR TITLE
Fix network interface test case issues .

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/registry/NacosAutoServiceRegistrationIpNetworkInterfaceTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/registry/NacosAutoServiceRegistrationIpNetworkInterfaceTests.java
@@ -19,6 +19,7 @@ package com.alibaba.cloud.nacos.registry;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.net.Inet4Address;
+import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.util.Enumeration;
@@ -119,7 +120,8 @@ public class NacosAutoServiceRegistrationIpNetworkInterfaceTests {
 			while (inetAddress.hasMoreElements()) {
 				InetAddress currentAddress = inetAddress.nextElement();
 				if (currentAddress instanceof Inet4Address
-						&& !currentAddress.isLoopbackAddress()) {
+						|| currentAddress instanceof Inet6Address
+								&& !currentAddress.isLoopbackAddress()) {
 					return currentAddress.getHostAddress();
 				}
 			}
@@ -152,7 +154,8 @@ public class NacosAutoServiceRegistrationIpNetworkInterfaceTests {
 					while (inetAddress.hasMoreElements()) {
 						InetAddress currentAddress = inetAddress.nextElement();
 						if (currentAddress instanceof Inet4Address
-								&& !currentAddress.isLoopbackAddress()) {
+								|| currentAddress instanceof Inet6Address
+										&& !currentAddress.isLoopbackAddress()) {
 							hasValidNetworkInterface = true;
 							netWorkInterfaceName = networkInterface.getName();
 							System.setProperty(


### PR DESCRIPTION
### Describe what this PR does / why we need it

Fix `NacosAutoServiceRegistrationIpNetworkInterfaceTests#contextLoads` test case execute failed issues .

Exception :
```java
org.opentest4j.AssertionFailedError: 
expected: "192.168.34.186"
 but was: "fe80:0:0:0:107e:d451:fe7b:5f73%en1"
Expected :"192.168.34.186"
Actual   :"fe80:0:0:0:107e:d451:fe7b:5f73%en1"
```

### Does this pull request fix one issue?
NONE

### Describe how you did it
Add IPv6 judgment condition .

### Describe how to verify it
NONE

### Special notes for reviews
NONE
