### PR TITLE
Fix issue 2698: resolve errors in generating javadocs by mvn install

### DIFF
--- a/spring-cloud-alibaba-examples/nacos-example/nacos-config-example/src/main/java/com/alibaba/cloud/examples/example/ExtensionConfigExample.java
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-config-example/src/main/java/com/alibaba/cloud/examples/example/ExtensionConfigExample.java
@@ -28,7 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * Example of extended configuration. When a configuration in the shared configuration
  * does not meet the requirements, the extended configuration can be used to override the
- * shared configuration. Priority: Main Configuration > Extended Configuration > Shared
+ * shared configuration. Priority: Main Configuration &gt; Extended Configuration &gt; Shared
  * Configuration.
  * @author lixiaoshuang
  */

--- a/spring-cloud-alibaba-examples/rocketmq-example/rocketmq-pollable-consume-example/src/main/java/com/alibaba/cloud/examples/pollable/RocketMQPollableConsumeApplication.java
+++ b/spring-cloud-alibaba-examples/rocketmq-example/rocketmq-pollable-consume-example/src/main/java/com/alibaba/cloud/examples/pollable/RocketMQPollableConsumeApplication.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.alibaba.cloud.examples.orderly;
+package com.alibaba.cloud.examples.pollable;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/parser/AbstractPropertySourceLoader.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/parser/AbstractPropertySourceLoader.java
@@ -35,9 +35,9 @@ import org.springframework.core.io.Resource;
  * Nacos-specific loader, If need to support other methods of parsing,you need to do the
  * following steps:
  * <p>
- * 1.inherit {@link AbstractPropertySourceLoader} ;<br/>
+ * 1.inherit {@link AbstractPropertySourceLoader};<br>
  * 2. define the file{@code spring.factories} and append
- * {@code org.springframework.boot.env.PropertySourceLoader=..}; <br/>
+ * {@code org.springframework.boot.env.PropertySourceLoader=..};<br>
  * 3.the last step validate.
  * </p>
  * Notice the use of {@link NacosByteArrayResource} .

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/parser/NacosXmlPropertySourceLoader.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/parser/NacosXmlPropertySourceLoader.java
@@ -40,7 +40,7 @@ import org.springframework.core.io.Resource;
 /**
  * Parsing for XML requires overwriting the default
  * {@link PropertiesPropertySourceLoader}, because it internally rigorously validates
- * ({@conde DOCTYPE}) THE XML in a way that makes it difficult to customize the
+ * ({@code DOCTYPE}) THE XML in a way that makes it difficult to customize the
  * configuration; at finally, make sure it's in the first place.
  *
  * @author zkz

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/SentinelWebMvcConfigurer.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/SentinelWebMvcConfigurer.java
@@ -27,7 +27,7 @@ import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 /**
- * @author: chao.wu
+ * @author chao.wu
  */
 public class SentinelWebMvcConfigurer implements WebMvcConfigurer {
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/properties/RocketMQConsumerProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/properties/RocketMQConsumerProperties.java
@@ -49,9 +49,9 @@ public class RocketMQConsumerProperties extends RocketMQCommonProperties {
 
 	/**
 	 * The expressions include tags or SQL,as follow:
-	 * <p/>
+	 * <p>
 	 * tag: {@code tag1||tag2||tag3 }; sql: {@code 'color'='blue' AND 'price'>100 } .
-	 * <p/>
+	 * </p>
 	 * Determines whether there are specific characters "{@code ||}" in the expression to
 	 * determine how the message is filtered,tags or SQL.
 	 */

--- a/spring-cloud-alibaba-tests/spring-cloud-alibaba-test-support/src/main/java/com/alibaba/cloud/testsupport/Tester.java
+++ b/spring-cloud-alibaba-tests/spring-cloud-alibaba-test-support/src/main/java/com/alibaba/cloud/testsupport/Tester.java
@@ -19,7 +19,7 @@ package com.alibaba.cloud.testsupport;
 /**
  *
  * @author freeman
- * @date 2021.0.1.0
+ * @since 2021.0.1.0
  */
 public class Tester {
 


### PR DESCRIPTION
### Describe what this PR does / why we need it
Fix errors that are reported when generating javadocs by mvn install in branch 2021.x.

### Does this pull request fix one issue?
Fixes #2698 in branch 2021.x

### Describe how you did it


### Describe how to verify it
run `mvn install`, `mvn javadoc:javadoc`(build faster) or `mvn javadoc:javadoc-no-fork`(build faster)

### Special notes for reviews
