### PR TITLE
fix: spring cloud bus default environment initialization error

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-bus-rocketmq/src/main/java/com/alibaba/cloud/bus/rocketmq/env/RocketMQBusEnvironmentPostProcessor.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-bus-rocketmq/src/main/java/com/alibaba/cloud/bus/rocketmq/env/RocketMQBusEnvironmentPostProcessor.java
@@ -19,6 +19,7 @@ package com.alibaba.cloud.bus.rocketmq.env;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.rocketmq.common.protocol.heartbeat.MessageModel;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.env.EnvironmentPostProcessor;
 import org.springframework.cloud.bus.BusEnvironmentPostProcessor;
@@ -68,12 +69,15 @@ public class RocketMQBusEnvironmentPostProcessor
 		String groupBindingPropertyName = createBindingPropertyName(INPUT, "group");
 		String broadcastingPropertyName = createRocketMQPropertyName(INPUT,
 				"broadcasting");
+		// adapting spring cloud stream rocketmq new properties {@link com.alibaba.cloud.stream.binder.rocketmq.properties.RocketMQConsumerProperties }
+		String newBroadcastingPropertyName = createRocketMQPropertyName(INPUT, "messageModel");
 		source.put(groupBindingPropertyName, "rocketmq-bus-group");
 		source.put(broadcastingPropertyName, "true");
+		source.put(newBroadcastingPropertyName, MessageModel.BROADCASTING.getModeCN());
 	}
 
 	private String createRocketMQPropertyName(String channel, String propertyName) {
-		return "spring.cloud.stream.rocketmq.bindings." + INPUT + ".consumer."
+		return "spring.cloud.stream.rocketmq.bindings." + channel + ".consumer."
 				+ propertyName;
 	}
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-bus-rocketmq/src/main/java/com/alibaba/cloud/bus/rocketmq/env/RocketMQBusEnvironmentPostProcessor.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-bus-rocketmq/src/main/java/com/alibaba/cloud/bus/rocketmq/env/RocketMQBusEnvironmentPostProcessor.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.rocketmq.common.protocol.heartbeat.MessageModel;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.env.EnvironmentPostProcessor;
 import org.springframework.cloud.bus.BusEnvironmentPostProcessor;


### PR DESCRIPTION
### Describe what this PR does / why we need it
In 2021.x branch, spring-cloud-starter-stream-rocketmq has been refactored.However, the bus is not adapted to the new properties. Lead consumption group mode is CLUSTERING but not BROADCASTING.

### Does this pull request fix one issue?
NONE
### Describe how you did it
change the spring-cloud-starter-stream-rocketmq EnvironmentPostProcessor

### Describe how to verify it
Open two customers, see if it is possible to receive remoteEvent

### Special notes for reviews
