### PR TITLE
When ipType is IPv6 but there's no IPv6 found, find IPv4(Fixes gh-2802)

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
@@ -269,7 +269,7 @@ public class NacosDiscoveryProperties {
 				else if ("IPv6".equalsIgnoreCase(ipType)) {
 					ip = inetIPv6Util.findIPv6Address();
 					if (StringUtils.isEmpty(ip)) {
-						log.error("There is no available IPv6 found. SCA will automatically find IPv4.");
+						log.warn("There is no available IPv6 found. Spring Cloud Alibaba will automatically find IPv4.");
 						ip = inetUtils.findFirstNonLoopbackHostInfo().getIpAddress();
 					}
 				}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
@@ -166,6 +166,8 @@ public class NacosDiscoveryProperties {
 
 	/**
 	 * choose IPv4 or IPv6,if you don't set it will choose IPv4.
+	 * When IPv6 is chosen but no IPv6 can be found, system will automatically finds IPv4 to ensure there is an
+	 * available service address.
 	 */
 	private String ipType = "IPv4";
 
@@ -266,6 +268,10 @@ public class NacosDiscoveryProperties {
 				}
 				else if ("IPv6".equalsIgnoreCase(ipType)) {
 					ip = inetIPv6Util.findIPv6Address();
+					if (StringUtils.isEmpty(ip)) {
+						log.error("There is no available IPv6 found. SCA will automatically find IPv4.");
+						ip = inetUtils.findFirstNonLoopbackHostInfo().getIpAddress();
+					}
 				}
 				else {
 					throw new IllegalArgumentException(

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
@@ -166,7 +166,7 @@ public class NacosDiscoveryProperties {
 
 	/**
 	 * choose IPv4 or IPv6,if you don't set it will choose IPv4.
-	 * When IPv6 is chosen but no IPv6 can be found, system will automatically finds IPv4 to ensure there is an
+	 * When IPv6 is chosen but no IPv6 can be found, system will automatically find IPv4 to ensure there is an
 	 * available service address.
 	 */
 	private String ipType = "IPv4";

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/utils/InetIPv6Util.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/utils/InetIPv6Util.java
@@ -29,13 +29,12 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import com.alibaba.cloud.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.cloud.commons.util.InetUtils;
 import org.springframework.cloud.commons.util.InetUtilsProperties;
-
-import com.alibaba.cloud.commons.lang.StringUtils;
 
 /**
  * @author HH

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/utils/InetIPv6Util.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/utils/InetIPv6Util.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
-import java.net.UnknownHostException;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -31,9 +30,10 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.springframework.cloud.commons.util.InetUtils;
 import org.springframework.cloud.commons.util.InetUtilsProperties;
+
+import com.alibaba.cloud.commons.lang.StringUtils;
 
 /**
  * @author HH
@@ -66,13 +66,7 @@ public class InetIPv6Util implements Closeable {
 		if (address != null) {
 			return this.convertAddress(address);
 		}
-		else {
-			InetUtils.HostInfo hostInfo = new InetUtils.HostInfo();
-			this.properties.setDefaultIpAddress("0:0:0:0:0:0:0:1");
-			hostInfo.setHostname(this.properties.getDefaultHostname());
-			hostInfo.setIpAddress(this.properties.getDefaultIpAddress());
-			return hostInfo;
-		}
+		return null;
 	}
 
 	public InetAddress findFirstNonLoopbackIPv6Address() {
@@ -112,25 +106,18 @@ public class InetIPv6Util implements Closeable {
 			log.error("Cannot get first non-loopback address", e);
 		}
 
-		if (address != null) {
-			return address;
-		}
-
-		try {
-			return InetAddress.getLocalHost();
-		}
-		catch (UnknownHostException e) {
-			log.warn("Unable to retrieve localhost");
-		}
-
-		return null;
+		return address;
 	}
 
 	public String findIPv6Address() {
-		String ip = findFirstNonLoopbackHostInfo().getIpAddress();
-		int index = ip.indexOf('%');
-		ip = index > 0 ? ip.substring(0, index) : ip;
-		return iPv6Format(ip);
+		InetUtils.HostInfo hostInfo = findFirstNonLoopbackHostInfo();
+		String ip = hostInfo != null ? hostInfo.getIpAddress() : "";
+		if (!StringUtils.isEmpty(ip)) {
+			int index = ip.indexOf('%');
+			ip = index > 0 ? ip.substring(0, index) : ip;
+			return iPv6Format(ip);
+		}
+		return ip;
 	}
 
 	public String iPv6Format(String ip) {


### PR DESCRIPTION
### Describe what this PR does / why we need it
When `spring.cloud.nacos.discovery.ip-type` is IPv6 but no IPv6 can be found out, SCA will automatically find IPv4. Thus a available service address is more likely to be provided. 

### Does this pull request fix one issue?
Fixes #2802

### Describe how you did it


### Describe how to verify it
Use a machine which doesn't support IPv6 to register. Or in application, set `spring.cloud.inetutils.preferred-networks` to exclude any IPv6.

### Special notes for reviews
