### PR TITLE
When ipType is IPv6 but there's no IPv6 found, find IPv4(Fixes gh-2802)

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
@@ -166,6 +166,8 @@ public class NacosDiscoveryProperties {
 
 	/**
 	 * choose IPv4 or IPv6,if you don't set it will choose IPv4.
+	 * When IPv6 is chosen but no IPv6 can be found, system will automatically find IPv4 to ensure there is an
+	 * available service address.
 	 */
 	private String ipType = "IPv4";
 
@@ -260,6 +262,10 @@ public class NacosDiscoveryProperties {
 				}
 				else if ("IPv6".equalsIgnoreCase(ipType)) {
 					ip = inetIPv6Utils.findIPv6Address();
+					if (StringUtils.isEmpty(ip)) {
+						log.warn("There is no available IPv6 found. Spring Cloud Alibaba will automatically find IPv4.");
+						ip = inetUtils.findFirstNonLoopbackHostInfo().getIpAddress();
+					}
 				}
 				else {
 					throw new IllegalArgumentException(

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/util/InetIPv6Utils.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/util/InetIPv6Utils.java
@@ -66,13 +66,7 @@ public class InetIPv6Utils implements Closeable {
 		if (address != null) {
 			return this.convertAddress(address);
 		}
-		else {
-			InetUtils.HostInfo hostInfo = new InetUtils.HostInfo();
-			this.properties.setDefaultIpAddress("0:0:0:0:0:0:0:1");
-			hostInfo.setHostname(this.properties.getDefaultHostname());
-			hostInfo.setIpAddress(this.properties.getDefaultIpAddress());
-			return hostInfo;
-		}
+		return null;
 	}
 
 	public InetAddress findFirstNonLoopbackIPv6Address() {
@@ -111,19 +105,19 @@ public class InetIPv6Utils implements Closeable {
 		catch (IOException e) {
 			log.error("Cannot get first non-loopback address", e);
 		}
-
-		if (address != null) {
-			return address;
+		if (address == null) {
+			try {
+				InetAddress localHost = InetAddress.getLocalHost();
+				if (localHost instanceof Inet6Address && !localHost.isLoopbackAddress()
+						&& isPreferredAddress(localHost)) {
+					address = localHost;
+				}
+			}
+			catch (UnknownHostException e) {
+				log.warn("Unable to retrieve localhost");
+			}
 		}
-
-		try {
-			return InetAddress.getLocalHost();
-		}
-		catch (UnknownHostException e) {
-			log.warn("Unable to retrieve localhost");
-		}
-
-		return null;
+		return address;
 	}
 
 	public String findIPv6Address() {

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/util/InetIPv6Utils.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/util/InetIPv6Utils.java
@@ -29,6 +29,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import com.alibaba.cloud.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/util/InetIPv6Utils.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/util/InetIPv6Utils.java
@@ -121,10 +121,14 @@ public class InetIPv6Utils implements Closeable {
 	}
 
 	public String findIPv6Address() {
-		String ip = findFirstNonLoopbackHostInfo().getIpAddress();
-		int index = ip.indexOf('%');
-		ip = index > 0 ? ip.substring(0, index) : ip;
-		return iPv6Format(ip);
+		InetUtils.HostInfo hostInfo = findFirstNonLoopbackHostInfo();
+		String ip = hostInfo != null ? hostInfo.getIpAddress() : "";
+		if (!StringUtils.isEmpty(ip)) {
+			int index = ip.indexOf('%');
+			ip = index > 0 ? ip.substring(0, index) : ip;
+			return iPv6Format(ip);
+		}
+		return ip;
 	}
 
 	public String iPv6Format(String ip) {


### PR DESCRIPTION
### Describe what this PR does / why we need it
When `spring.cloud.nacos.discovery.ip-type` is IPv6 but no IPv6 can be found out, SCA will automatically find IPv4. Thus a available service address is more likely to be provided.

### Does this pull request fix one issue?
Fixes #2802

### Describe how you did it


### Describe how to verify it
Use a machine which doesn't support IPv6 to register. Or in application, set spring.cloud.inetutils.preferred-networks to exclude any IPv6.

### Special notes for reviews
