### PR TITLE
add support for consul ack-token

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-datasource/src/main/java/com/alibaba/cloud/sentinel/datasource/config/ConsulDataSourceProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-datasource/src/main/java/com/alibaba/cloud/sentinel/datasource/config/ConsulDataSourceProperties.java
@@ -43,6 +43,12 @@ public class ConsulDataSourceProperties extends AbstractDataSourceProperties {
 	private int port = 8500;
 
 	/**
+	 * consul acl-token.
+	 */
+
+	private String token;
+
+	/**
 	 * data key in Redis.
 	 */
 	private String ruleKey;
@@ -95,4 +101,11 @@ public class ConsulDataSourceProperties extends AbstractDataSourceProperties {
 		this.waitTimeoutInSecond = waitTimeoutInSecond;
 	}
 
+	public String getToken() {
+		return token;
+	}
+
+	public void setToken(String token) {
+		this.token = token;
+	}
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-datasource/src/main/java/com/alibaba/cloud/sentinel/datasource/factorybean/ConsulDataSourceFactoryBean.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-datasource/src/main/java/com/alibaba/cloud/sentinel/datasource/factorybean/ConsulDataSourceFactoryBean.java
@@ -35,13 +35,15 @@ public class ConsulDataSourceFactoryBean implements FactoryBean<ConsulDataSource
 
 	private String ruleKey;
 
+	private String token;
+
 	private int waitTimeoutInSecond;
 
 	private Converter converter;
 
 	@Override
 	public ConsulDataSource getObject() throws Exception {
-		return new ConsulDataSource(host, port, ruleKey, waitTimeoutInSecond, converter);
+		return new ConsulDataSource(host, port, token, ruleKey, waitTimeoutInSecond, converter);
 	}
 
 	@Override
@@ -89,4 +91,11 @@ public class ConsulDataSourceFactoryBean implements FactoryBean<ConsulDataSource
 		this.converter = converter;
 	}
 
+	public String getToken() {
+		return token;
+	}
+
+	public void setToken(String token) {
+		this.token = token;
+	}
 }


### PR DESCRIPTION
add support for consul ack-token

Fixes #2859

add `token` field to `ConsulDataSourceProperties` and `ConsulDataSourceFactoryBean`,with the value to create `ConsulDataSource`
