### PR TITLE
fix: disabled NacosWatch and avoid tests failed

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/ribbon/NacosRibbonClientPropertyOverrideTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/ribbon/NacosRibbonClientPropertyOverrideTests.java
@@ -48,6 +48,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 				"localApp.ribbon.NIWSServerListClassName="
 						+ "com.netflix.loadbalancer.ConfigurationBasedServerList",
 				"localApp.ribbon.listOfServers=127.0.0.1:19090",
+				"spring.cloud.nacos.discovery.watch.enabled=false",
 				"localApp.ribbon.ServerListRefreshInterval=15000" })
 public class NacosRibbonClientPropertyOverrideTests {
 


### PR DESCRIPTION
### Describe what this PR does / why we need it

 Disabled NacosWatch and avoid tests failed

### Does this pull request fix one issue?

#2696 

