### PR TITLE
#2862 improve seata beanPostProcessor order

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/java/com/alibaba/cloud/seata/feign/SeataBeanPostProcessor.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/java/com/alibaba/cloud/seata/feign/SeataBeanPostProcessor.java
@@ -18,16 +18,22 @@ package com.alibaba.cloud.seata.feign;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.core.Ordered;
 
 /**
  * @author xiaojing
  */
-public class SeataBeanPostProcessor implements BeanPostProcessor {
+public class SeataBeanPostProcessor implements BeanPostProcessor, Ordered {
 
 	private final SeataFeignObjectWrapper seataFeignObjectWrapper;
 
 	SeataBeanPostProcessor(SeataFeignObjectWrapper seataFeignObjectWrapper) {
 		this.seataFeignObjectWrapper = seataFeignObjectWrapper;
+	}
+
+	@Override
+	public int getOrder() {
+		return HIGHEST_PRECEDENCE;
 	}
 
 	@Override


### PR DESCRIPTION
### Describe what this PR does / why we need it
SeataBeanPostProcessor had better has a higher init order, for fare some beans be initialized early along with some business beanPostProcessor, in that situation, this bean will not be proxyed by Seata like SeataFeignClient. 

### Does this pull request fix one issue?
Fixed #2862 
