### PR TITLE
Refactor NacosWatch and add GatewayLocatorHeartBeatPublisher

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/GatewayLocatorHeartBeatPublisher.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/GatewayLocatorHeartBeatPublisher.java
@@ -54,7 +54,7 @@ public class GatewayLocatorHeartBeatPublisher implements ApplicationEventPublish
 
 	private static ThreadPoolTaskScheduler getTaskScheduler() {
 		ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
-		taskScheduler.setBeanName("Nacos-SCG-HeartBeat-Task-Scheduler");
+		taskScheduler.setBeanName("HeartBeat-Task-Scheduler");
 		taskScheduler.initialize();
 		return taskScheduler;
 	}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/GatewayLocatorHeartBeatPublisher.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/GatewayLocatorHeartBeatPublisher.java
@@ -35,9 +35,9 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
  * @author yuhuangbin
  * @author ruansheng
  */
-public class NacosGatewayLocatorHeartBeat implements ApplicationEventPublisherAware, SmartLifecycle {
+public class GatewayLocatorHeartBeatPublisher implements ApplicationEventPublisherAware, SmartLifecycle {
 
-	private static final Logger log = LoggerFactory.getLogger(NacosGatewayLocatorHeartBeat.class);
+	private static final Logger log = LoggerFactory.getLogger(GatewayLocatorHeartBeatPublisher.class);
 
 	private final NacosDiscoveryProperties nacosDiscoveryProperties;
 
@@ -47,7 +47,7 @@ public class NacosGatewayLocatorHeartBeat implements ApplicationEventPublisherAw
 	private ApplicationEventPublisher publisher;
 	private ScheduledFuture<?> watchFuture;
 
-	public NacosGatewayLocatorHeartBeat(NacosDiscoveryProperties nacosDiscoveryProperties) {
+	public GatewayLocatorHeartBeatPublisher(NacosDiscoveryProperties nacosDiscoveryProperties) {
 		this.nacosDiscoveryProperties = nacosDiscoveryProperties;
 		this.taskScheduler = getTaskScheduler();
 	}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryClientConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryClientConfiguration.java
@@ -35,6 +35,7 @@ import org.springframework.context.annotation.Configuration;
 /**
  * @author xiaojing
  * @author echooymxq
+ * @author ruansheng
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnDiscoveryEnabled
@@ -51,12 +52,28 @@ public class NacosDiscoveryClientConfiguration {
 		return new NacosDiscoveryClient(nacosServiceDiscovery);
 	}
 
+	/**
+	 * NacosWatch is no longer enabled by default .
+	 * see https://github.com/alibaba/spring-cloud-alibaba/issues/2868
+	 */
 	@Bean
 	@ConditionalOnMissingBean
-	@ConditionalOnProperty(value = "spring.cloud.nacos.discovery.watch.enabled", matchIfMissing = true)
+	@ConditionalOnProperty(value = "spring.cloud.nacos.discovery.watch.enabled", matchIfMissing = false)
 	public NacosWatch nacosWatch(NacosServiceManager nacosServiceManager,
 			NacosDiscoveryProperties nacosDiscoveryProperties) {
 		return new NacosWatch(nacosServiceManager, nacosDiscoveryProperties);
+	}
+
+	/**
+	 * Spring Cloud Gateway HeartBeat .
+	 * publish an event every 30 seconds
+	 * see https://github.com/alibaba/spring-cloud-alibaba/issues/2868
+	 */
+	@Bean
+	@ConditionalOnMissingBean
+	@ConditionalOnProperty(value = "spring.cloud.gateway.discovery.locator.enabled", matchIfMissing = false)
+	public NacosGatewayLocatorHeartBeat nacosGatewayHeartBeat(NacosDiscoveryProperties nacosDiscoveryProperties) {
+		return new NacosGatewayLocatorHeartBeat(nacosDiscoveryProperties);
 	}
 
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryClientConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryClientConfiguration.java
@@ -72,8 +72,8 @@ public class NacosDiscoveryClientConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnProperty(value = "spring.cloud.gateway.discovery.locator.enabled", matchIfMissing = false)
-	public NacosGatewayLocatorHeartBeat nacosGatewayHeartBeat(NacosDiscoveryProperties nacosDiscoveryProperties) {
-		return new NacosGatewayLocatorHeartBeat(nacosDiscoveryProperties);
+	public GatewayLocatorHeartBeatPublisher gatewayLocatorHeartBeatPublisher(NacosDiscoveryProperties nacosDiscoveryProperties) {
+		return new GatewayLocatorHeartBeatPublisher(nacosDiscoveryProperties);
 	}
 
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/NacosGatewayLocatorHeartBeat.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/NacosGatewayLocatorHeartBeat.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.nacos.discovery;
+
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.alibaba.cloud.nacos.NacosDiscoveryProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.cloud.client.discovery.event.HeartbeatEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ApplicationEventPublisherAware;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+
+/**
+ * @author yuhuangbin
+ * @author ruansheng
+ */
+public class NacosGatewayLocatorHeartBeat implements ApplicationEventPublisherAware, SmartLifecycle {
+
+	private static final Logger log = LoggerFactory.getLogger(NacosGatewayLocatorHeartBeat.class);
+
+	private final NacosDiscoveryProperties nacosDiscoveryProperties;
+
+	private final ThreadPoolTaskScheduler taskScheduler;
+	private final AtomicLong nacosWatchIndex = new AtomicLong(0);
+	private final AtomicBoolean running = new AtomicBoolean(false);
+	private ApplicationEventPublisher publisher;
+	private ScheduledFuture<?> watchFuture;
+
+	public NacosGatewayLocatorHeartBeat(NacosDiscoveryProperties nacosDiscoveryProperties) {
+		this.nacosDiscoveryProperties = nacosDiscoveryProperties;
+		this.taskScheduler = getTaskScheduler();
+	}
+
+	private static ThreadPoolTaskScheduler getTaskScheduler() {
+		ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
+		taskScheduler.setBeanName("Nacos-SCG-HeartBeat-Task-Scheduler");
+		taskScheduler.initialize();
+		return taskScheduler;
+	}
+
+	@Override
+	public void start() {
+		log.info("Start nacos gateway locator heartBeat task scheduler.");
+		this.watchFuture = this.taskScheduler.scheduleWithFixedDelay(
+				this::publishHeartBeat, this.nacosDiscoveryProperties.getWatchDelay());
+
+	}
+
+	@Override
+	public void stop() {
+		if (this.watchFuture != null) {
+			// shutdown current user-thread,
+			// then the other daemon-threads will terminate automatic.
+			this.taskScheduler.shutdown();
+			this.watchFuture.cancel(true);
+		}
+	}
+
+	@Override
+	public boolean isAutoStartup() {
+		return true;
+	}
+
+	@Override
+	public boolean isRunning() {
+		return this.running.get();
+	}
+
+	@Override
+	public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
+		this.publisher = applicationEventPublisher;
+	}
+
+	/**
+	 * nacos doesn't support watch now , publish an event every 30 seconds.
+	 */
+	public void publishHeartBeat() {
+		HeartbeatEvent event = new HeartbeatEvent(this, nacosWatchIndex.getAndIncrement());
+		this.publisher.publishEvent(event);
+	}
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -44,7 +44,7 @@
     {
       "name": "spring.cloud.nacos.discovery.watch.enabled",
       "type": "java.lang.Boolean",
-      "defaultValue": "true",
+      "defaultValue": "false",
       "description": "enable nacos discovery watch or not ."
     },
     {

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryClientConfigurationTest.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryClientConfigurationTest.java
@@ -70,4 +70,26 @@ public class NacosDiscoveryClientConfigurationTest {
 				});
 	}
 
+	@Test
+	public void testNacosWatchEnabled() {
+		contextRunner.withPropertyValues("spring.cloud.nacos.discovery.watch.enabled=true")
+				.run(context -> assertThat(context).hasSingleBean(NacosWatch.class));
+	}
+
+	@Test
+	public void testDefaultNacosGatewayLocatorHeartBeat() {
+		contextRunner.run(context ->
+				assertThat(context).doesNotHaveBean(NacosGatewayLocatorHeartBeat.class)
+		);
+	}
+
+	@Test
+	public void testNacosGatewayLocatorHeartBeatEnabled() {
+		contextRunner
+				.withPropertyValues("spring.cloud.gateway.discovery.locator.enabled=true")
+				.run(context ->
+						assertThat(context).hasSingleBean(NacosGatewayLocatorHeartBeat.class)
+				);
+	}
+
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryClientConfigurationTest.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryClientConfigurationTest.java
@@ -56,7 +56,8 @@ public class NacosDiscoveryClientConfigurationTest {
 	public void testDefaultInitialization() {
 		contextRunner.run(context -> {
 			assertThat(context).hasSingleBean(DiscoveryClient.class);
-			assertThat(context).hasSingleBean(NacosWatch.class);
+			// NacosWatch is no longer enabled by default
+			assertThat(context).doesNotHaveBean(NacosWatch.class);
 		});
 	}
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryClientConfigurationTest.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryClientConfigurationTest.java
@@ -77,18 +77,18 @@ public class NacosDiscoveryClientConfigurationTest {
 	}
 
 	@Test
-	public void testDefaultNacosGatewayLocatorHeartBeat() {
+	public void testDefaultGatewayLocatorHeartBeatPublisher() {
 		contextRunner.run(context ->
-				assertThat(context).doesNotHaveBean(NacosGatewayLocatorHeartBeat.class)
+				assertThat(context).doesNotHaveBean(GatewayLocatorHeartBeatPublisher.class)
 		);
 	}
 
 	@Test
-	public void testNacosGatewayLocatorHeartBeatEnabled() {
+	public void testGatewayLocatorHeartBeatPublisherEnabled() {
 		contextRunner
 				.withPropertyValues("spring.cloud.gateway.discovery.locator.enabled=true")
 				.run(context ->
-						assertThat(context).hasSingleBean(NacosGatewayLocatorHeartBeat.class)
+						assertThat(context).hasSingleBean(GatewayLocatorHeartBeatPublisher.class)
 				);
 	}
 


### PR DESCRIPTION
### Describe what this PR does / why we need it
Refactor NacosWatch
### Does this pull request fix one issue?

Refer #2868

### Describe how you did it
#### 1. NacosWatch is no longer enabled by default .
Using `spring.cloud.nacos.discovery.watch.enabled=true` to enabled it.
#### 2. NacosWatch#heartBeat migrate to `GatewayLocatorHeartBeatPublisher`
`GatewayLocatorHeartBeatPublisher` is disabled by default , It will enabled if `spring.cloud.gateway.discovery.locator.enabled` is `true` 
#### 3. GatewayLocatorHeartBeatPublisher no longer support zuul , will continue to be supported in `2.2.x` version

