### PR TITLE
registry instance-id and set default value

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
@@ -120,6 +120,11 @@ public class NacosDiscoveryProperties {
 	private String service;
 
 	/**
+	 * service instance-id to registry.
+	 */
+	private String instanceId;
+
+	/**
 	 * weight for service instance, the larger the value, the larger the weight.
 	 */
 	private float weight = 1;
@@ -332,6 +337,14 @@ public class NacosDiscoveryProperties {
 
 	public void setService(String service) {
 		this.service = service;
+	}
+
+	public String getInstanceId() {
+		return instanceId;
+	}
+
+	public void setInstanceId(String instanceId) {
+		this.instanceId = instanceId;
 	}
 
 	public boolean isRegisterEnabled() {
@@ -582,6 +595,9 @@ public class NacosDiscoveryProperties {
 		}
 		if (StringUtils.isEmpty(this.getPassword())) {
 			this.setPassword(env.resolvePlaceholders("${spring.cloud.nacos.password:}"));
+		}
+		if (StringUtils.isEmpty(this.getInstanceId())) {
+			this.setInstanceId(env.resolvePlaceholders("${spring.application.name}:" + ip + ":" + port));
 		}
 	}
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosServiceInstance.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosServiceInstance.java
@@ -29,6 +29,8 @@ public class NacosServiceInstance implements ServiceInstance {
 
 	private String serviceId;
 
+	private String instanceId;
+
 	private String host;
 
 	private int port;
@@ -40,6 +42,11 @@ public class NacosServiceInstance implements ServiceInstance {
 	@Override
 	public String getServiceId() {
 		return serviceId;
+	}
+
+	@Override
+	public String getInstanceId() {
+		return instanceId;
 	}
 
 	@Override
@@ -69,6 +76,10 @@ public class NacosServiceInstance implements ServiceInstance {
 
 	public void setServiceId(String serviceId) {
 		this.serviceId = serviceId;
+	}
+
+	public void setInstanceId(String instanceId) {
+		this.instanceId = instanceId;
 	}
 
 	public void setHost(String host) {

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/NacosServiceDiscovery.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/NacosServiceDiscovery.java
@@ -92,6 +92,7 @@ public class NacosServiceDiscovery {
 		nacosServiceInstance.setHost(instance.getIp());
 		nacosServiceInstance.setPort(instance.getPort());
 		nacosServiceInstance.setServiceId(serviceId);
+		nacosServiceInstance.setInstanceId(instance.getInstanceId());
 
 		Map<String, String> metadata = new HashMap<>();
 		metadata.put("nacos.instanceId", instance.getInstanceId());

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosServiceRegistry.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosServiceRegistry.java
@@ -159,7 +159,8 @@ public class NacosServiceRegistry implements ServiceRegistry<Registration> {
 			List<Instance> instances = namingService().getAllInstances(serviceName);
 			for (Instance instance : instances) {
 				if (instance.getIp().equalsIgnoreCase(nacosDiscoveryProperties.getIp())
-						&& instance.getPort() == nacosDiscoveryProperties.getPort()) {
+						&& instance.getPort() == nacosDiscoveryProperties.getPort()
+				        && instance.getInstanceId().equals(nacosDiscoveryProperties.getInstanceId())) {
 					return instance.isEnabled() ? "UP" : "DOWN";
 				}
 			}
@@ -179,6 +180,7 @@ public class NacosServiceRegistry implements ServiceRegistry<Registration> {
 		instance.setEnabled(nacosDiscoveryProperties.isInstanceEnabled());
 		instance.setMetadata(registration.getMetadata());
 		instance.setEphemeral(nacosDiscoveryProperties.isEphemeral());
+		instance.setInstanceId(nacosDiscoveryProperties.getInstanceId());
 		return instance;
 	}
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -18,6 +18,12 @@
       "description": "the service name to register, default value is ${spring.application.name}."
     },
     {
+    "name": "spring.cloud.nacos.discovery.instance-id",
+    "type": "java.lang.String",
+    "defaultValue": "${spring.cloud.nacos.instance-id}",
+    "description": "the service instance-id to register, default value is ${spring.cloud.nacos.instance-id}."
+    },
+    {
       "name": "spring.cloud.nacos.discovery.enabled",
       "type": "java.lang.Boolean",
       "defaultValue": true,

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/discovery/NacosServiceDiscoveryTest.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/discovery/NacosServiceDiscoveryTest.java
@@ -16,10 +16,7 @@
 
 package com.alibaba.cloud.nacos.discovery;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 
 import com.alibaba.cloud.nacos.NacosDiscoveryProperties;
 import com.alibaba.cloud.nacos.NacosServiceManager;
@@ -57,7 +54,8 @@ public class NacosServiceDiscoveryTest {
 		map.put("test-key", "test-value");
 		map.put("secure", "true");
 
-		instances.add(serviceInstance(serviceName, true, host, port, map));
+		String instanceId = UUID.randomUUID().toString();
+		instances.add(serviceInstance(serviceName, instanceId,true, host, port, map));
 
 		NacosDiscoveryProperties nacosDiscoveryProperties = mock(
 				NacosDiscoveryProperties.class);
@@ -83,6 +81,8 @@ public class NacosServiceDiscoveryTest {
 		ServiceInstance serviceInstance = serviceInstances.get(0);
 
 		assertThat(serviceInstance.getServiceId()).isEqualTo(serviceName);
+		assertThat(serviceInstance.getInstanceId()).isEqualTo(instanceId);
+
 		assertThat(serviceInstance.getHost()).isEqualTo(host);
 		assertThat(serviceInstance.getPort()).isEqualTo(port);
 		assertThat(serviceInstance.isSecure()).isEqualTo(true);

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/test/NacosMockTest.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/test/NacosMockTest.java
@@ -40,7 +40,7 @@ public final class NacosMockTest {
 		return instance;
 	}
 
-	public static Instance serviceInstance(String serviceName, boolean isHealthy,
+	public static Instance serviceInstance(String serviceName, String instanceId, boolean isHealthy,
 			String host, int port, Map<String, String> metadata) {
 		Instance instance = new Instance();
 		instance.setIp(host);
@@ -48,6 +48,7 @@ public final class NacosMockTest {
 		instance.setServiceName(serviceName);
 		instance.setHealthy(isHealthy);
 		instance.setMetadata(metadata);
+		instance.setInstanceId(instanceId);
 		return instance;
 	}
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/registry/DelegatingRegistration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-dubbo/src/main/java/com/alibaba/cloud/dubbo/registry/DelegatingRegistration.java
@@ -37,6 +37,11 @@ class DelegatingRegistration implements Registration {
 	}
 
 	@Override
+	public String getInstanceId() {
+		return delegate.getInstanceId();
+	}
+
+	@Override
 	public String getServiceId() {
 		return delegate.getServiceId();
 	}


### PR DESCRIPTION
### Describe what this PR does / why we need it

- In some scenarios, the service instance id is required as a registration or filter condition，and the version(tag: 2021.1) can not registry service instance-id and  get service instance-id is null

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

- Set default values
- Add features related to instance ids, such as registration and discovery

### Describe how to verify it


### Special notes for reviews
