### PR TITLE
fix(sec): upgrade mysql:mysql-connector-java to 8.0.28

### DIFF
--- a/spring-cloud-alibaba-examples/integrated-example/integrated-account/pom.xml
+++ b/spring-cloud-alibaba-examples/integrated-example/integrated-account/pom.xml
@@ -24,7 +24,7 @@
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>5.1.47</version>
+			<version>8.0.28</version>
 		</dependency>
 
 		<dependency>

--- a/spring-cloud-alibaba-examples/integrated-example/integrated-order/pom.xml
+++ b/spring-cloud-alibaba-examples/integrated-example/integrated-order/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.47</version>
+            <version>8.0.28</version>
         </dependency>
 
         <dependency>

--- a/spring-cloud-alibaba-examples/integrated-example/integrated-praise-consumer/pom.xml
+++ b/spring-cloud-alibaba-examples/integrated-example/integrated-praise-consumer/pom.xml
@@ -30,7 +30,7 @@
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>5.1.47</version>
+			<version>8.0.28</version>
 		</dependency>
 
 		<dependency>

--- a/spring-cloud-alibaba-examples/integrated-example/integrated-storage/pom.xml
+++ b/spring-cloud-alibaba-examples/integrated-example/integrated-storage/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.47</version>
+            <version>8.0.28</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in mysql:mysql-connector-java 5.1.47
- [CVE-2022-21363](https://www.oscs1024.com/hd/CVE-2022-21363)


### What did I do？
Upgrade mysql:mysql-connector-java from 5.1.47 to 8.0.28 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS