### PR TITLE
Refactor NacosWatch and support zuul in 2.2.x

### DIFF
--- a/spring-cloud-alibaba-docs/src/main/asciidoc/nacos-discovery.adoc
+++ b/spring-cloud-alibaba-docs/src/main/asciidoc/nacos-discovery.adoc
@@ -325,6 +325,6 @@ The following shows the other configurations of the starter of Nacos Discovery:
 |Cluster Name|`spring.cloud.nacos.discovery.cluster-name`|`DEFAULT`|Cluster name of Nacos
 |Endpoint|`spring.cloud.nacos.discovery.endpoint`||The domain name of a certain service in a specific region. You can retrieve the server address dynamically with this domain name
 |Integrate Ribbon or not|`ribbon.nacos.enabled`|`true`|Set to true in most cases
-|Enable Nacos Watch|`spring.cloud.nacos.discovery.watch.enabled`|`true`|set to false to close watch
+|Enable Nacos Watch|`spring.cloud.nacos.discovery.watch.enabled`|`false`|set to true to enable watch
 |===
 

--- a/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/readme-zh.md
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/readme-zh.md
@@ -201,7 +201,7 @@ Metadata|spring.cloud.nacos.discovery.metadata||使用Map格式配置
 接入点|spring.cloud.nacos.discovery.endpoint|UTF-8|地域的某个服务的入口域名，通过此域名可以动态地拿到服务端地址
 是否集成Ribbon|ribbon.nacos.enabled|true|
 集群|spring.cloud.nacos.discovery.cluster-name|DEFAULT|Nacos集群名称
-是否开启Nacos Watch|spring.cloud.nacos.discovery.watch.enabled|true|可以设置成false来关闭 watch
+是否开启Nacos Watch|spring.cloud.nacos.discovery.watch.enabled|false|可以设置成true来开启 watch
 是否启用Nacos|spring.cloud.nacos.discovery.enabled|true|默认启动，设置为false时会关闭自动向Nacos注册的功能
 
 

--- a/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/readme.md
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/readme.md
@@ -208,7 +208,7 @@ Metadata|spring.cloud.nacos.discovery.metadata||Extended data, Configure using M
 log name|spring.cloud.nacos.discovery.log-name||
 cluster|spring.cloud.nacos.discovery.cluster-name|DEFAULT|Nacos cluster name
 endpoint|spring.cloud.nacos.discovery.endpoint||The domain name of a service, through which the server address can be dynamically obtained.
-enable Nacos Watch|spring.cloud.nacos.discovery.watch.enabled|true|Switch it to false to disable nacos watch
+enable Nacos Watch|spring.cloud.nacos.discovery.watch.enabled|false|Switch it to true to enable nacos watch
 Integration Ribbon|ribbon.nacos.enabled|true|
 enabled|spring.cloud.nacos.discovery.enabled|true|The switch to enable or disable nacos service discovery
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/pom.xml
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/pom.xml
@@ -99,6 +99,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-netflix-zuul</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
             <scope>test</scope>

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/GatewayLocatorHeartBeatPublisher.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/GatewayLocatorHeartBeatPublisher.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.nacos.discovery;
+
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.alibaba.cloud.nacos.NacosDiscoveryProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.cloud.client.discovery.event.HeartbeatEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ApplicationEventPublisherAware;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+/**
+ * @author yuhuangbin
+ * @author ruansheng
+ */
+public class GatewayLocatorHeartBeatPublisher
+		implements ApplicationEventPublisherAware, SmartLifecycle {
+
+	private static final Logger log = LoggerFactory
+			.getLogger(GatewayLocatorHeartBeatPublisher.class);
+
+	private final NacosDiscoveryProperties nacosDiscoveryProperties;
+
+	private final ThreadPoolTaskScheduler taskScheduler;
+
+	private final AtomicLong nacosWatchIndex = new AtomicLong(0);
+
+	private final AtomicBoolean running = new AtomicBoolean(false);
+
+	private ApplicationEventPublisher publisher;
+
+	private ScheduledFuture<?> watchFuture;
+
+	public GatewayLocatorHeartBeatPublisher(
+			NacosDiscoveryProperties nacosDiscoveryProperties) {
+		this.nacosDiscoveryProperties = nacosDiscoveryProperties;
+		this.taskScheduler = getTaskScheduler();
+	}
+
+	private static ThreadPoolTaskScheduler getTaskScheduler() {
+		ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
+		taskScheduler.setBeanName("HeartBeat-Task-Scheduler");
+		taskScheduler.initialize();
+		return taskScheduler;
+	}
+
+	@Override
+	public void start() {
+		log.info("Start nacos gateway locator heartBeat task scheduler.");
+		this.watchFuture = this.taskScheduler.scheduleWithFixedDelay(
+				this::publishHeartBeat, this.nacosDiscoveryProperties.getWatchDelay());
+
+	}
+
+	@Override
+	public void stop() {
+		if (this.watchFuture != null) {
+			// shutdown current user-thread,
+			// then the other daemon-threads will terminate automatic.
+			this.taskScheduler.shutdown();
+			this.watchFuture.cancel(true);
+		}
+	}
+
+	@Override
+	public boolean isAutoStartup() {
+		return true;
+	}
+
+	@Override
+	public boolean isRunning() {
+		return this.running.get();
+	}
+
+	@Override
+	public void setApplicationEventPublisher(
+			ApplicationEventPublisher applicationEventPublisher) {
+		this.publisher = applicationEventPublisher;
+	}
+
+	/**
+	 * nacos doesn't support watch now , publish an event every 30 seconds.
+	 */
+	public void publishHeartBeat() {
+		HeartbeatEvent event = new HeartbeatEvent(this,
+				nacosWatchIndex.getAndIncrement());
+		this.publisher.publishEvent(event);
+	}
+
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryClientConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryClientConfiguration.java
@@ -35,6 +35,7 @@ import org.springframework.context.annotation.Configuration;
 /**
  * @author xiaojing
  * @author echooymxq
+ * @author ruansheng
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnDiscoveryEnabled
@@ -51,13 +52,33 @@ public class NacosDiscoveryClientConfiguration {
 		return new NacosDiscoveryClient(nacosServiceDiscovery);
 	}
 
+	/**
+	 * NacosWatch is no longer enabled by default.
+	 * https://github.com/alibaba/spring-cloud-alibaba/issues/2868
+	 * @param nacosServiceManager nacosServiceManager
+	 * @param nacosDiscoveryProperties nacosDiscoveryProperties
+	 * @return nacosWatch.
+	 */
 	@Bean
 	@ConditionalOnMissingBean
-	@ConditionalOnProperty(value = "spring.cloud.nacos.discovery.watch.enabled",
-			matchIfMissing = true)
+	@ConditionalOnProperty("spring.cloud.nacos.discovery.watch.enabled")
 	public NacosWatch nacosWatch(NacosServiceManager nacosServiceManager,
 			NacosDiscoveryProperties nacosDiscoveryProperties) {
 		return new NacosWatch(nacosServiceManager, nacosDiscoveryProperties);
+	}
+
+	/**
+	 * Spring Cloud Gateway HeartBeat . publish an event every 30 seconds.
+	 * https://github.com/alibaba/spring-cloud-alibaba/issues/2868
+	 * @param nacosDiscoveryProperties nacosDiscoveryProperties
+	 * @return nacosWatch.
+	 */
+	@Bean
+	@ConditionalOnMissingBean
+	@ConditionalOnProperty("spring.cloud.gateway.discovery.locator.enabled")
+	public GatewayLocatorHeartBeatPublisher gatewayLocatorHeartBeatPublisher(
+			NacosDiscoveryProperties nacosDiscoveryProperties) {
+		return new GatewayLocatorHeartBeatPublisher(nacosDiscoveryProperties);
 	}
 
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/NacosWatch.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/NacosWatch.java
@@ -21,9 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
 
 import com.alibaba.cloud.nacos.NacosDiscoveryProperties;
 import com.alibaba.cloud.nacos.NacosServiceManager;
@@ -36,66 +34,30 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.beans.factory.DisposableBean;
-import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.cloud.client.discovery.event.HeartbeatEvent;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.context.SmartLifecycle;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 /**
  * @author xiaojing
  * @author yuhuangbin
  * @author pengfei.lu
+ * @author ruansheng
  */
-public class NacosWatch
-		implements ApplicationEventPublisherAware, SmartLifecycle, DisposableBean {
+public class NacosWatch implements SmartLifecycle, DisposableBean {
 
 	private static final Logger log = LoggerFactory.getLogger(NacosWatch.class);
 
-	private Map<String, EventListener> listenerMap = new ConcurrentHashMap<>(16);
+	private final Map<String, EventListener> listenerMap = new ConcurrentHashMap<>(16);
 
 	private final AtomicBoolean running = new AtomicBoolean(false);
 
-	private final AtomicLong nacosWatchIndex = new AtomicLong(0);
-
-	private ApplicationEventPublisher publisher;
-
-	private ScheduledFuture<?> watchFuture;
-
-	private NacosServiceManager nacosServiceManager;
+	private final NacosServiceManager nacosServiceManager;
 
 	private final NacosDiscoveryProperties properties;
-
-	private final ThreadPoolTaskScheduler taskScheduler;
 
 	public NacosWatch(NacosServiceManager nacosServiceManager,
 			NacosDiscoveryProperties properties) {
 		this.nacosServiceManager = nacosServiceManager;
 		this.properties = properties;
-		this.taskScheduler = getTaskScheduler();
-	}
-
-	@Deprecated
-	public NacosWatch(NacosServiceManager nacosServiceManager,
-			NacosDiscoveryProperties properties,
-			ObjectProvider<ThreadPoolTaskScheduler> taskScheduler) {
-		this.nacosServiceManager = nacosServiceManager;
-		this.properties = properties;
-		this.taskScheduler = taskScheduler.stream().findAny()
-				.orElseGet(NacosWatch::getTaskScheduler);
-	}
-
-	private static ThreadPoolTaskScheduler getTaskScheduler() {
-		ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
-		taskScheduler.setBeanName("Nacos-Watch-Task-Scheduler");
-		taskScheduler.initialize();
-		return taskScheduler;
-	}
-
-	@Override
-	public void setApplicationEventPublisher(ApplicationEventPublisher publisher) {
-		this.publisher = publisher;
 	}
 
 	@Override
@@ -137,8 +99,6 @@ public class NacosWatch
 				log.error("namingService subscribe failed, properties:{}", properties, e);
 			}
 
-			this.watchFuture = this.taskScheduler.scheduleWithFixedDelay(
-					this::nacosServicesWatch, this.properties.getWatchDelay());
 		}
 	}
 
@@ -162,12 +122,6 @@ public class NacosWatch
 	@Override
 	public void stop() {
 		if (this.running.compareAndSet(true, false)) {
-			if (this.watchFuture != null) {
-				// shutdown current user-thread,
-				// then the other daemon-threads will terminate automatic.
-				this.taskScheduler.shutdown();
-				this.watchFuture.cancel(true);
-			}
 
 			EventListener eventListener = listenerMap.get(buildKey());
 			try {
@@ -190,14 +144,6 @@ public class NacosWatch
 	@Override
 	public int getPhase() {
 		return 0;
-	}
-
-	public void nacosServicesWatch() {
-
-		// nacos doesn't support watch now , publish an event every 30 seconds.
-		this.publisher.publishEvent(
-				new HeartbeatEvent(this, nacosWatchIndex.getAndIncrement()));
-
 	}
 
 	@Override

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/ZuulGatewayLocatorAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/ZuulGatewayLocatorAutoConfiguration.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.nacos.discovery;
+
+import com.alibaba.cloud.nacos.NacosDiscoveryProperties;
+
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cloud.netflix.zuul.ZuulProxyMarkerConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author ruansheng
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass(ZuulProxyMarkerConfiguration.class)
+@AutoConfigureAfter(ZuulProxyMarkerConfiguration.class)
+public class ZuulGatewayLocatorAutoConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean
+	@ConditionalOnBean(name = "zuulProxyMarkerBean")
+	public GatewayLocatorHeartBeatPublisher gatewayLocatorHeartBeatPublisher(
+			NacosDiscoveryProperties nacosDiscoveryProperties) {
+		return new GatewayLocatorHeartBeatPublisher(nacosDiscoveryProperties);
+	}
+
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -44,7 +44,7 @@
     {
       "name": "spring.cloud.nacos.discovery.watch.enabled",
       "type": "java.lang.Boolean",
-      "defaultValue": "true",
+      "defaultValue": "false",
       "description": "enable nacos discovery watch or not ."
     },
     {

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/resources/META-INF/spring.factories
@@ -6,6 +6,7 @@ org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
   com.alibaba.cloud.nacos.discovery.NacosDiscoveryClientConfiguration,\
   com.alibaba.cloud.nacos.discovery.reactive.NacosReactiveDiscoveryClientConfiguration,\
   com.alibaba.cloud.nacos.discovery.configclient.NacosConfigServerAutoConfiguration,\
+  com.alibaba.cloud.nacos.discovery.ZuulGatewayLocatorAutoConfiguration,\
   com.alibaba.cloud.nacos.NacosServiceAutoConfiguration,\
   com.alibaba.cloud.nacos.util.UtilIPv6AutoConfiguration
 org.springframework.cloud.bootstrap.BootstrapConfiguration=\

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryClientConfigurationTest.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryClientConfigurationTest.java
@@ -26,6 +26,7 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationConfiguration;
 import org.springframework.cloud.commons.util.UtilAutoConfiguration;
+import org.springframework.cloud.netflix.zuul.ZuulProxyMarkerConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
@@ -34,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author <a href="mailto:echooy.mxq@gmail.com">echooymxq</a>
+ * @author <a href="mailto:chrisruans@gmail.com">ruansheng</a>
  **/
 public class NacosDiscoveryClientConfigurationTest {
 
@@ -44,7 +46,8 @@ public class NacosDiscoveryClientConfigurationTest {
 							UtilAutoConfiguration.class, UtilIPv6AutoConfiguration.class,
 							NacosServiceAutoConfiguration.class,
 							NacosDiscoveryAutoConfiguration.class,
-							NacosDiscoveryClientConfiguration.class, this.getClass()));
+							NacosDiscoveryClientConfiguration.class,
+							ZuulGatewayLocatorAutoConfiguration.class, this.getClass()));
 
 	@Bean
 	public TaskScheduler taskScheduler() {
@@ -55,7 +58,8 @@ public class NacosDiscoveryClientConfigurationTest {
 	public void testDefaultInitialization() {
 		contextRunner.run(context -> {
 			assertThat(context).hasSingleBean(DiscoveryClient.class);
-			assertThat(context).hasSingleBean(NacosWatch.class);
+			// NacosWatch is no longer enabled by default
+			assertThat(context).doesNotHaveBean(NacosWatch.class);
 		});
 	}
 
@@ -66,6 +70,42 @@ public class NacosDiscoveryClientConfigurationTest {
 					assertThat(context).doesNotHaveBean(DiscoveryClient.class);
 					assertThat(context).doesNotHaveBean(NacosWatch.class);
 				});
+	}
+
+	@Test
+	public void testNacosWatchEnabled() {
+		contextRunner
+				.withPropertyValues("spring.cloud.nacos.discovery.watch.enabled=true")
+				.run(context -> assertThat(context).hasSingleBean(NacosWatch.class));
+	}
+
+	@Test
+	public void testDefaultGatewayLocatorHeartBeatPublisher() {
+		contextRunner.run(context -> assertThat(context)
+				.doesNotHaveBean(GatewayLocatorHeartBeatPublisher.class));
+	}
+
+	@Test
+	public void testSpringCloudGatewayLocatorHeartBeatPublisherEnabled() {
+		contextRunner
+				.withPropertyValues("spring.cloud.gateway.discovery.locator.enabled=true")
+				.run(context -> assertThat(context).hasSingleBean(GatewayLocatorHeartBeatPublisher.class));
+	}
+
+	@Test
+	public void testZuulGatewayLocatorHeartBeatPublisherEnabled() {
+		contextRunner
+				.withConfiguration(AutoConfigurations.of(ZuulProxyMarkerConfiguration.class))
+				.run(context -> assertThat(context)
+                        .hasSingleBean(GatewayLocatorHeartBeatPublisher.class));
+	}
+
+	@Test
+	public void testZuulAndSpringCloudGatewayLocatorHeartBeatPublisherEnabled() {
+		contextRunner
+				.withPropertyValues("spring.cloud.gateway.discovery.locator.enabled=true")
+				.withConfiguration(AutoConfigurations.of(ZuulProxyMarkerConfiguration.class))
+				.run(context -> assertThat(context).hasSingleBean(GatewayLocatorHeartBeatPublisher.class));
 	}
 
 }


### PR DESCRIPTION
### Describe what this PR does / why we need it
Refactor NacosWatch
### Does this pull request fix one issue?

Refer #2868

### Describe how you did it
#### 1. NacosWatch is no longer enabled by default .
Using `spring.cloud.nacos.discovery.watch.enabled=true` to enabled it.
#### 2. NacosWatch#heartBeat migrate to `GatewayLocatorHeartBeatPublisher`
`GatewayLocatorHeartBeatPublisher` is disabled by default , It will enabled if `spring.cloud.gateway.discovery.locator.enabled` is `true` or using `@EnableZuulProxy`


