### PR TITLE
fix: modify setting of NacosWatch's the default

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -44,7 +44,7 @@
     {
       "name": "spring.cloud.nacos.discovery.watch.enabled",
       "type": "java.lang.Boolean",
-      "defaultValue": "true",
+      "defaultValue": "false",
       "description": "enable nacos discovery watch or not ."
     },
     {


### PR DESCRIPTION
Recently, we modified the switch of NacosWatch, but forgot to modify relevant content in `additional-spring-configuration-metadata.json`.