### PR TITLE
fix: the sidecar's ip not registe to nacos discovery

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sidecar/src/main/java/com/alibaba/cloud/sidecar/nacos/SidecarNacosDiscoveryProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sidecar/src/main/java/com/alibaba/cloud/sidecar/nacos/SidecarNacosDiscoveryProperties.java
@@ -37,7 +37,7 @@ public class SidecarNacosDiscoveryProperties extends NacosDiscoveryProperties {
 		super.init();
 
 		String ip = sidecarProperties.getIp();
-		if (!StringUtils.hasText(ip)) {
+		if (StringUtils.hasText(ip)) {
 			this.setIp(ip);
 		}
 


### PR DESCRIPTION
### Describe what this PR does / why we need it

the ip address of sidecar was not reset during the initialization.

Fixed #2912