### PR TITLE
make PostConstruct method public

### DIFF
--- a/spring-cloud-alibaba-examples/integrated-example/integrated-gateway/src/main/java/com/alibaba/cloud/integration/gateway/config/GatewayConfig.java
+++ b/spring-cloud-alibaba-examples/integrated-example/integrated-gateway/src/main/java/com/alibaba/cloud/integration/gateway/config/GatewayConfig.java
@@ -71,7 +71,7 @@ public class GatewayConfig {
 	}
 
 	@PostConstruct
-	private void initGatewayRules() {
+	public void initGatewayRules() {
 		Set<GatewayFlowRule> rules = new HashSet<>();
 		rules.add(
 				new GatewayFlowRule("praiseItemSentinel").setCount(5).setIntervalSec(1));

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-gateway/src/main/java/com/alibaba/cloud/sentinel/gateway/scg/SentinelSCGAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-gateway/src/main/java/com/alibaba/cloud/sentinel/gateway/scg/SentinelSCGAutoConfiguration.java
@@ -75,7 +75,7 @@ public class SentinelSCGAutoConfiguration {
 	private SentinelGatewayProperties gatewayProperties;
 
 	@PostConstruct
-	private void init() {
+	public void init() {
 		// blockRequestHandlerOptional has low priority
 		blockRequestHandlerOptional.ifPresent(GatewayCallbackManager::setBlockHandler);
 		initAppType();

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/custom/SentinelAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/custom/SentinelAutoConfiguration.java
@@ -69,7 +69,7 @@ public class SentinelAutoConfiguration {
 	private SentinelProperties properties;
 
 	@PostConstruct
-	private void init() {
+	public void init() {
 		if (StringUtils.isEmpty(System.getProperty(LogBase.LOG_DIR))
 				&& StringUtils.isNotBlank(properties.getLog().getDir())) {
 			System.setProperty(LogBase.LOG_DIR, properties.getLog().getDir());


### PR DESCRIPTION
### Describe what this PR does / why we need it
When using `AOT` build, the method marked by the annotation `@PostConstruct` must be public