### PR TITLE
feat: Add support for sentinel opensergo datasource

### DIFF
--- a/spring-cloud-alibaba-examples/sentinel-example/sentinel-core-example/src/main/resources/application.properties
+++ b/spring-cloud-alibaba-examples/sentinel-example/sentinel-core-example/src/main/resources/application.properties
@@ -38,3 +38,4 @@ spring.cloud.sentinel.datasource.ds4.file.rule-type=system
 
 spring.cloud.sentinel.datasource.ds5.file.file=classpath: param-flow.json
 spring.cloud.sentinel.datasource.ds5.file.rule-type=param_flow
+spring.cloud.sentinel.datasource.ds5.opensergo.rule-type=param_flow

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-datasource/pom.xml
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-datasource/pom.xml
@@ -14,6 +14,10 @@
     <artifactId>spring-cloud-alibaba-sentinel-datasource</artifactId>
     <name>Spring Cloud Alibaba Sentinel DataSource</name>
 
+    <properties>
+        <opensergo-datasource.version>2.0.0-SNAPSHOT</opensergo-datasource.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.alibaba.cloud</groupId>
@@ -79,6 +83,12 @@
             <groupId>com.alibaba.csp</groupId>
             <artifactId>sentinel-datasource-consul</artifactId>
             <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>com.alibaba.csp</groupId>
+            <artifactId>sentinel-datasource-opensergo</artifactId>
+            <version>${opensergo-datasource.version}</version>
         </dependency>
 
         <dependency>

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-datasource/pom.xml
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-datasource/pom.xml
@@ -15,7 +15,7 @@
     <name>Spring Cloud Alibaba Sentinel DataSource</name>
 
     <properties>
-        <opensergo-datasource.version>2.0.0-SNAPSHOT</opensergo-datasource.version>
+        <opensergo-datasource.version>0.1.0-beta</opensergo-datasource.version>
     </properties>
 
     <dependencies>

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-datasource/src/main/java/com/alibaba/cloud/sentinel/datasource/config/DataSourcePropertiesConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-datasource/src/main/java/com/alibaba/cloud/sentinel/datasource/config/DataSourcePropertiesConfiguration.java
@@ -50,6 +50,8 @@ public class DataSourcePropertiesConfiguration {
 
 	private ConsulDataSourceProperties consul;
 
+	private OpenSergoDataSourceProperties opensergo;
+
 	public DataSourcePropertiesConfiguration() {
 	}
 
@@ -123,6 +125,14 @@ public class DataSourcePropertiesConfiguration {
 
 	public void setRedis(RedisDataSourceProperties redis) {
 		this.redis = redis;
+	}
+
+	public OpenSergoDataSourceProperties getOpensergo() {
+		return opensergo;
+	}
+
+	public void setOpensergo(OpenSergoDataSourceProperties opensergo) {
+		this.opensergo = opensergo;
 	}
 
 	@JsonIgnore

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-datasource/src/main/java/com/alibaba/cloud/sentinel/datasource/config/OpenSergoDataSourceProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-datasource/src/main/java/com/alibaba/cloud/sentinel/datasource/config/OpenSergoDataSourceProperties.java
@@ -38,7 +38,8 @@ import org.springframework.util.CollectionUtils;
  * @author <a href="liuziming@buaa.edu.cn"></a>
  */
 public class OpenSergoDataSourceProperties extends AbstractDataSourceProperties {
-
+	private static final String FLOW = "flow";
+	private static final String DEGRADE = "degrade";
 	private String host = "127.0.0.1";
 
 	private int port = 10246;
@@ -55,10 +56,10 @@ public class OpenSergoDataSourceProperties extends AbstractDataSourceProperties 
 
 	public void postRegister(OpenSergoDataSourceGroup dataSourceGroup) {
 		// TODO: SystemRule and ParamFlowRule
-		if (enabledRules.contains(OpenSergoSentinelConstants.KIND_PARAM_FLOW_RULE)) {
+		if (enabledRules.contains(FLOW)) {
 			FlowRuleManager.register2Property(dataSourceGroup.subscribeFlowRules());
 		}
-		if (enabledRules.contains(OpenSergoSentinelConstants.KIND_CIRCUIT_BREAKER_RULE)) {
+		if (enabledRules.contains(DEGRADE)) {
 			DegradeRuleManager.register2Property(dataSourceGroup.subscribeDegradeRules());
 		}
 		// When there is no enabled-rules, try ruleType

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-datasource/src/main/java/com/alibaba/cloud/sentinel/datasource/config/OpenSergoDataSourceProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-datasource/src/main/java/com/alibaba/cloud/sentinel/datasource/config/OpenSergoDataSourceProperties.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.cloud.sentinel.datasource.config;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import com.alibaba.cloud.commons.lang.StringUtils;
@@ -46,7 +47,7 @@ public class OpenSergoDataSourceProperties extends AbstractDataSourceProperties 
 
 	private String app = AppNameUtil.getAppName();
 
-	private Set<String> enabledRules;
+	private Set<String> enabledRules = new HashSet<>();
 
 	public OpenSergoDataSourceProperties() {
 		super(OpenSergoDataSourceFactoryBean.class.getName());

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-datasource/src/main/java/com/alibaba/cloud/sentinel/datasource/config/OpenSergoDataSourceProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-datasource/src/main/java/com/alibaba/cloud/sentinel/datasource/config/OpenSergoDataSourceProperties.java
@@ -25,6 +25,7 @@ import com.alibaba.csp.sentinel.datasource.OpenSergoDataSourceGroup;
 import com.alibaba.csp.sentinel.datasource.OpenSergoSentinelConstants;
 import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRuleManager;
 import com.alibaba.csp.sentinel.slots.block.flow.FlowRuleManager;
+import com.alibaba.csp.sentinel.util.AppNameUtil;
 
 import org.springframework.util.CollectionUtils;
 
@@ -43,7 +44,7 @@ public class OpenSergoDataSourceProperties extends AbstractDataSourceProperties 
 
 	private String namespace = "default";
 
-	private String app;
+	private String app = AppNameUtil.getAppName();
 
 	private Set<String> enabledRules;
 
@@ -68,17 +69,6 @@ public class OpenSergoDataSourceProperties extends AbstractDataSourceProperties 
 		case DEGRADE:
 			DegradeRuleManager.register2Property(dataSourceGroup.subscribeDegradeRules());
 			break;
-		}
-	}
-
-	@Override
-	public void preCheck(String dataSourceName) {
-		if (StringUtils.isEmpty(app)) {
-			throw new IllegalArgumentException("OpenSergoDataSource app is empty");
-		}
-		if (CollectionUtils.isEmpty(enabledRules)) {
-			throw new IllegalArgumentException(
-					"OpenSergoDataSource enabled-rules is empty");
 		}
 	}
 

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-datasource/src/main/java/com/alibaba/cloud/sentinel/datasource/config/OpenSergoDataSourceProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-datasource/src/main/java/com/alibaba/cloud/sentinel/datasource/config/OpenSergoDataSourceProperties.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.sentinel.datasource.config;
+
+import java.util.Set;
+
+import com.alibaba.cloud.commons.lang.StringUtils;
+import com.alibaba.cloud.sentinel.datasource.RuleType;
+import com.alibaba.cloud.sentinel.datasource.factorybean.OpenSergoDataSourceFactoryBean;
+import com.alibaba.csp.sentinel.datasource.OpenSergoDataSourceGroup;
+import com.alibaba.csp.sentinel.datasource.OpenSergoSentinelConstants;
+import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRuleManager;
+import com.alibaba.csp.sentinel.slots.block.flow.FlowRuleManager;
+
+import org.springframework.util.CollectionUtils;
+
+/**
+ * OpenSergo Properties class Using by {@link DataSourcePropertiesConfiguration} and
+ * {@link OpenSergoDataSourceFactoryBean}.
+ *
+ * @author musi
+ * @author <a href="liuziming@buaa.edu.cn"></a>
+ */
+public class OpenSergoDataSourceProperties extends AbstractDataSourceProperties {
+
+	private String host = "127.0.0.1";
+
+	private int port = 10246;
+
+	private String namespace = "default";
+
+	private String app;
+
+	private Set<String> enabledRules;
+
+	public OpenSergoDataSourceProperties() {
+		super(OpenSergoDataSourceFactoryBean.class.getName());
+	}
+
+	public void postRegister(OpenSergoDataSourceGroup dataSourceGroup) {
+		// TODO: SystemRule and ParamFlowRule
+		if (enabledRules.contains(OpenSergoSentinelConstants.KIND_PARAM_FLOW_RULE)) {
+			FlowRuleManager.register2Property(dataSourceGroup.subscribeFlowRules());
+		}
+		if (enabledRules.contains(OpenSergoSentinelConstants.KIND_CIRCUIT_BREAKER_RULE)) {
+			DegradeRuleManager.register2Property(dataSourceGroup.subscribeDegradeRules());
+		}
+		// When there is no enabled-rules, try ruleType
+		RuleType ruleType = getRuleType();
+		switch (ruleType) {
+		case FLOW:
+			FlowRuleManager.register2Property(dataSourceGroup.subscribeFlowRules());
+			break;
+		case DEGRADE:
+			DegradeRuleManager.register2Property(dataSourceGroup.subscribeDegradeRules());
+			break;
+		}
+	}
+
+	@Override
+	public void preCheck(String dataSourceName) {
+		if (StringUtils.isEmpty(app)) {
+			throw new IllegalArgumentException("OpenSergoDataSource app is empty");
+		}
+		if (CollectionUtils.isEmpty(enabledRules)) {
+			throw new IllegalArgumentException(
+					"OpenSergoDataSource enabled-rules is empty");
+		}
+	}
+
+	public String getHost() {
+		return host;
+	}
+
+	public void setHost(String host) {
+		this.host = host;
+	}
+
+	public int getPort() {
+		return port;
+	}
+
+	public void setPort(int port) {
+		this.port = port;
+	}
+
+	public String getNamespace() {
+		return namespace;
+	}
+
+	public void setNamespace(String namespace) {
+		this.namespace = namespace;
+	}
+
+	public String getApp() {
+		return app;
+	}
+
+	public void setApp(String app) {
+		this.app = app;
+	}
+
+	public Set<String> getEnabledRules() {
+		return enabledRules;
+	}
+
+	public void setEnabledRules(Set<String> enabledRules) {
+		this.enabledRules = enabledRules;
+	}
+
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-datasource/src/main/java/com/alibaba/cloud/sentinel/datasource/factorybean/OpenSergoDataSourceFactoryBean.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-datasource/src/main/java/com/alibaba/cloud/sentinel/datasource/factorybean/OpenSergoDataSourceFactoryBean.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.sentinel.datasource.factorybean;
+
+import java.util.Set;
+
+import com.alibaba.csp.sentinel.datasource.Converter;
+import com.alibaba.csp.sentinel.datasource.OpenSergoDataSourceGroup;
+
+import org.springframework.beans.factory.FactoryBean;
+
+/**
+ * A {@link FactoryBean} for creating {@link OpenSergoDataSourceGroup} instance.
+ *
+ * @author musi
+ * @author <a href="liuziming@buaa.edu.cn"></a>
+ * @see OpenSergoDataSourceGroup
+ */
+public class OpenSergoDataSourceFactoryBean
+		implements FactoryBean<OpenSergoDataSourceGroup> {
+
+	private String host;
+
+	private int port;
+
+	private String namespace;
+
+	private String app;
+
+	private Set<String> enabledRules;
+
+	private Converter converter;
+
+	@Override
+	public OpenSergoDataSourceGroup getObject() throws Exception {
+		return new OpenSergoDataSourceGroup(host, port, namespace, app);
+	}
+
+	@Override
+	public Class<?> getObjectType() {
+		return OpenSergoDataSourceGroup.class;
+	}
+
+	public String getHost() {
+		return host;
+	}
+
+	public void setHost(String host) {
+		this.host = host;
+	}
+
+	public int getPort() {
+		return port;
+	}
+
+	public void setPort(int port) {
+		this.port = port;
+	}
+
+	public String getNamespace() {
+		return namespace;
+	}
+
+	public void setNamespace(String namespace) {
+		this.namespace = namespace;
+	}
+
+	public String getApp() {
+		return app;
+	}
+
+	public void setApp(String app) {
+		this.app = app;
+	}
+
+	public Set<String> getEnabledRules() {
+		return enabledRules;
+	}
+
+	public void setEnabledRules(Set<String> enabledRules) {
+		this.enabledRules = enabledRules;
+	}
+
+	public Converter getConverter() {
+		return converter;
+	}
+
+	public void setConverter(Converter converter) {
+		this.converter = converter;
+	}
+
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-datasource/src/main/resources/META-INF/sentinel-datasource.properties
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-datasource/src/main/resources/META-INF/sentinel-datasource.properties
@@ -4,3 +4,4 @@ apollo = com.alibaba.csp.sentinel.datasource.apollo.ApolloDataSource
 zk = com.alibaba.csp.sentinel.datasource.zookeeper.ZookeeperDataSource
 redis = com.alibaba.csp.sentinel.datasource.redis.RedisDataSource
 consul = com.alibaba.csp.sentinel.datasource.consul.ConsulDataSource
+opensergo = com.alibaba.csp.sentinel.datasource.OpenSergoDataSourceGroup


### PR DESCRIPTION
### Describe what this PR does / why we need it
Add out-of-box support for Sentinel OpenSergo data-source.

If you want to use OpenSergo datasource, you can configure the `application.yml` like NacosDatasource in Spring Cloud Alibaba:
```
# you can set single rule type by setting enabled-rules, like the other datasource in Spring Cloud Alibaba
spring.cloud.sentinel.datasource.ds5.opensergo.rule-type=flow
spring.cloud.sentinel.datasource.ds5.opensergo.host=127.0.0.1
spring.cloud.sentinel.datasource.ds5.opensergo.port=10246
spring.cloud.sentinel.datasource.ds5.opensergo.namespace=ns1
spring.cloud.sentinel.datasource.ds5.opensergo.app=app1
# you can set multiple rule type by setting enabled-rules
spring.cloud.sentinel.datasource.ds5.opensergo.enabled-rules[0]=flow
spring.cloud.sentinel.datasource.ds5.opensergo.enabled-rules[0]=degrade
```
### Does this pull request fix one issue?
#3075 

