### PR TITLE
Fix: nacos example method naming typo

### DIFF
--- a/spring-cloud-alibaba-examples/nacos-example/nacos-config-example/src/main/java/com/alibaba/cloud/examples/example/DockingInterfaceExample.java
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-config-example/src/main/java/com/alibaba/cloud/examples/example/DockingInterfaceExample.java
@@ -95,8 +95,8 @@ public class DockingInterfaceExample {
 	 * @param group group
 	 * @return boolean
 	 */
-	@RequestMapping("/remoteConfig")
-	public boolean remoteConfig(@RequestParam("dataId") String dataId,
+	@RequestMapping("/removeConfig")
+	public boolean removeConfig(@RequestParam("dataId") String dataId,
 			@RequestParam(value = "group", required = false) String group)
 			throws NacosException {
 		if (StringUtils.isEmpty(group)) {


### PR DESCRIPTION

com.alibaba.cloud.examples.example#remoteConfig maybe a typo,update the method name from remoteConfig to removeConfig