### PR TITLE
fix: Nacos integration with SpringBootAdmin.

### DIFF
--- a/spring-cloud-alibaba-docs/src/main/asciidoc-zh/sidecar.adoc
+++ b/spring-cloud-alibaba-docs/src/main/asciidoc-zh/sidecar.adoc
@@ -40,7 +40,7 @@ Gateway的新一代Sidecar，然而官方表示并没有该计划。详见：htt
 * 目前Mesh主要使用场景在Kubernetes领域（Istio、Linkerd
 2等，大多将Kubernetes作为First
 Class支持，虽然Istio也可部署在非Kubernetes环境），而目前业界，Spring
-Cloud应用未必有试试Mesh的环境；
+Cloud应用未必有 Service Mesh 的环境；
 * 使用Alibaba
 Sidecar一个小组件就能解决问题了（核心代码不超过200行），引入整套Mesh方案，颇有点屠龙刀杀黄鳝的意思。
 
@@ -66,7 +66,7 @@ Cloud本身就是基于HTTP的；
 === 使用示例
 
 * 如使用Nacos作为服务发现组件，详见`spring-cloud-alibaba-examples/spring-cloud-alibaba-sidecar-examples/spring-cloud-alibaba-sidecar-nacos-example`
-* 如使用Consul作为服务发现组件，详见`spring-cloud-alibaba-examples/spring-cloud-alibaba-sidecar-examples/spring-cloud-alibaba-sidecar-nacos-example`
+* 如使用Consul作为服务发现组件，详见`spring-cloud-alibaba-examples/spring-cloud-alibaba-sidecar-examples/spring-cloud-alibaba-sidecar-consul-example`
 
 ==== 示例代码（以Nacos服务发现为例）
 
@@ -178,7 +178,7 @@ Gateway还可以整合Sentinel或者Hystirx、Resilience4J，所以也带有了�
 === Alibaba Sidecar优缺点分析
 
 Alibaba
-Sidecar的设计和Sidecar基本一致，优缺点和Sidecar的优缺点也是一样的。
+Sidecar的设计和 Netfix Sidecar 基本一致，优缺点和 Netfix Sidecar 的优缺点也是一样的。
 
 优点：
 

--- a/spring-cloud-alibaba-docs/src/main/asciidoc/nacos-discovery.adoc
+++ b/spring-cloud-alibaba-docs/src/main/asciidoc/nacos-discovery.adoc
@@ -359,5 +359,5 @@ The following shows the other configurations of the starter of Nacos Discovery:
 |Endpoint|`spring.cloud.nacos.discovery.endpoint`||The domain name of a certain service in a specific region. You can retrieve the server address dynamically with this domain name
 |Integrate LoadBalancer or not|`spring.cloud.loadbalancer.nacos.enabled`|`false`|
 |Enable Nacos Watch|`spring.cloud.nacos.discovery.watch.enabled`|`false`|set to true to enable watch
+|Enable Nacos Discovery HeartBeat|`spring.cloud.nacos.discovery.heart-beat.enabled`|`false`|set to true to enable heart beat
 |===
-

--- a/spring-cloud-alibaba-docs/src/main/asciidoc/sidecar.adoc
+++ b/spring-cloud-alibaba-docs/src/main/asciidoc/sidecar.adoc
@@ -1,0 +1,193 @@
+== Spring Cloud Alibaba Sidecar
+
+`Spring Cloud Alibaba Sidecar` is a Spring Cloud for quick and perfect integration
+with * heterogeneous microservices * framework, inspired by
+https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-sidecar[Spring
+Cloud Netflix Sidecar]，currently supported service discovery components:
+
+* Nacos
+* Consul
+
+=== Terminology
+
+==== Heterogeneous microservice
+
+Non-spring Cloud applications are referred to as heterogeneous micro-services. Such as your legacy projects, or non-JVM applications.
+
+==== Three meanings of "perfect integration"
+
+* Take advantage of service discovery
+* There is load balancing
+* with circuit breaker
+
+=== Why or Why not?
+
+==== Why write Alibaba Sidecar?
+
+There are two reasons:
+
+* Spring Cloud subproject 'Spring Cloud Netflix Sidecar'
+It is possible to integrate heterogeneous microservices quickly. However, Sidecar only supports the use of Eureka as a service discovery, * if you use other service discovery components you are blinded *.
+* *Sidecar is based on Zuul 1.x *, Spring
+Cloud has officially stated that Zuul will be phased out in the future. Earlier this year, I gave it to Spring
+The Cloud official requested an official implementation based on the Spring Cloud
+Gateway's new Sidecar, though officials say there are no plans for it. See: https://github.com/spring-cloud/spring-cloud-gateway/issues/735
+
+Since I didn't, I wrote it myself.
+
+==== Why not use a Service Mesh?
+
+* Currently, Mesh is mainly used in Kubernetes (Istio, Linkerd
+2, etc., most of the Kubernetes as the First
+Class support, although Istio can also be deployed in non-Kubernetes environments), unlike the current industry, Spring
+Cloud applications may not have Service Mesh environments;
+* Use Alibaba
+Sidecar solves the problem in a single widget (no more than 200 lines of core code) and introduces a complete Mesh scheme, which is a bit like killing eel.
+
+=== principle
+
+* Alibaba
+Sidecar registers the IP/ port of heterogeneous micro-services to the service discovery component based on the configured IP and port of heterogeneous micro-services*
+.
+* Alibaba Sidecar implements * Health Check *, Alibaba
+Sidecar periodically checks whether heterogeneous microservices are healthy. If heterogeneous microservices are found to be unhealthy, Alibaba
+Sidecar will automatically represent the heterogeneous micro services of Alibaba
+Sidecar instance is offline. If the heterogeneous microservice recovers, it automatically goes online. The maximum delay is 30 seconds, see details
+`Alibaba SidecarChecker#check.`
+
+=== requirement
+
+* [Must] Your heterogeneous microservice needs to communicate using HTTP. This is not strictly a requirement because of Spring
+The Cloud itself is based on HTTP;
+* 【 Optional 】 If the microservice is configured with `sidecar.health-check-url`
+In this case, your heterogeneous micro service needs to implement health check (can be empty implementation, as long as an endpoint is exposed, return similar
+`{"status": "UP"}` is a string).
+
+=== Use an example
+
+* If Nacos is used as a service discovery component, See `spring-cloud-alibaba-examples/spring-cloud-alibaba-sidecar-examples/spring-cloud-alibaba-sidecar-nacos-example` for details
+* If you use Consul as a service discovery component, See `spring-cloud-alibaba-examples/spring-cloud-alibaba-sidecar-examples/spring-cloud-alibaba-sidecar-consul-example` for details
+
+==== Sample code (using Nacos service discovery as an example)
+
+* Plus dependence:
++
+[source,xml]
+----
+<dependency>
+<groupId>com.alibaba.cloud</groupId>
+<artifactId>spring-cloud-starter-alibaba-sidecar</artifactId>
+</dependency>
+----
+* Write configuration:
++
+[source,yaml]
+----
+server:
+  port: 8070
+spring:
+  cloud:
+    nacos:
+      discovery:
+        server-addr: 127.0.0.1:8848
+    gateway:
+      discovery:
+        locator:
+          enabled: true
+  application:
+    name: node-service
+sidecar:
+  # IP address of the heterogeneous microservice
+  ip: 127.0.0.1
+  # Port of the heterogeneous microservice
+  port: 8060
+  # Health check URL for heterogeneous microservices
+  health-check-url: http://localhost:8060/health.json
+management:
+endpoint:
+    health:
+      show-details: always
+----
++
+The configuration was simple, registering Alibaba Sidecar with Nacos and adding a few lines of Alibaba
+Sidecar configuration.
+
+==== Heterogeneous microservice
+
+I have prepared a simple microservice written in NodeJS.
+
+[source,javascript]
+----
+var http = require('http');
+var url = require("url");
+var path = require('path');
+
+// create server
+var server = http.createServer(function(req, res) {
+    // Get the path to the request
+    var pathname = url.parse(req.url).pathname;
+    res.writeHead(200, { 'Content-Type' : 'application/json; charset=utf-8' });
+    // Visit http://localhost:8060/ and {"index":" Welcome to Home page"}
+    if (pathname === '/') {
+        res.end(JSON.stringify({ "index" : "Welcome to Home page" }));
+    }
+    // Visit http://localhost:8060/health, will return to {" status ":" UP "}
+    else if (pathname === '/health.json') {
+        res.end(JSON.stringify({ "status" : "UP" }));
+    }
+    // In other cases, 404 is returned
+    else {
+        res.end("404");
+    }
+});
+// Create a listener and print a log
+server.listen(8060, function() {
+    console.log('listening on localhost:8060');
+});
+----
+
+==== Test
+===== Test 1: Spring Cloud microservices perfectly invoke heterogeneous microservices
+
+Integrate the Ribbon for your Spring Cloud microservice and build `http://node-service/**`
+, you can request the heterogeneous micro service `/**`.
+
+Example:
+
+Ribbon requests `http://node-service/` will request `http://localhost:8060/`
+And so on.
+
+As for the circuit breaker, normal for your Spring
+Just integrate Sentinel, Hystirx and Resilience4J with Cloud microservices.
+
+===== Test 2: Heterogeneous microservices perfectly invoke Spring Cloud microservices
+
+Alibaba Sidecar is based on the Spring Cloud Gateway, and the gateway has its own forwarding capability.
+
+Example:
+
+If you have a Spring Cloud microservice called `spring-cloud-microservice`
+Then the NodeJS application only needs to build
+`http://localhost:8070/spring-cloud-microservice/**`, Alibaba
+Sidecar then forwards the request to `spring-cloud-microservice`’s `/**` 。
+
+The Spring Cloud Gateway integrates the Ribbon to realize load balancing. Spring Cloud
+Gateway also has a circuit breaker for integrating Sentinel or Hystirx, Resilience4J.
+
+Analysis of advantages and disadvantages of Alibaba Sidecar
+
+Alibaba
+The design of Sidecar is basically the same as that of Netfix Sidecar, and the advantages and disadvantages are the same as those of Netfix Sidecar.
+
+Advantages:
+
+* Easy access, a few lines of code to integrate heterogeneous micro-services into the Spring Cloud ecosystem
+* Does not hack the original code
+
+Disadvantages:
+
+* You need to deploy an additional Alibaba for each heterogeneous microservice instance you connect to
+Sidecar instances, increasing the deployment cost (although this cost is almost negligible in a Kubernetes environment)
+Sidecar instances and heterogeneous microservices can be deployed as a Pod));
+* When a heterogeneous microservice calls a Spring Cloud microservice, it essentially takes Alibaba
+Sidecar When the gateway is in use, the gateway performance deteriorates after layer 1 forwarding.

--- a/spring-cloud-alibaba-docs/src/main/asciidoc/spring-cloud-alibaba.adoc
+++ b/spring-cloud-alibaba-docs/src/main/asciidoc/spring-cloud-alibaba.adoc
@@ -29,4 +29,6 @@ include::schedulerx.adoc[]
 
 include::sms.adoc[]
 
+include::sidecar.adoc[]
+
 include::graalvm.adoc[]

--- a/spring-cloud-alibaba-examples/nacos-example/nacos-config-example/src/main/java/com/alibaba/cloud/examples/example/DockingInterfaceExample.java
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-config-example/src/main/java/com/alibaba/cloud/examples/example/DockingInterfaceExample.java
@@ -95,8 +95,8 @@ public class DockingInterfaceExample {
 	 * @param group group
 	 * @return boolean
 	 */
-	@RequestMapping("/remoteConfig")
-	public boolean remoteConfig(@RequestParam("dataId") String dataId,
+	@RequestMapping("/removeConfig")
+	public boolean removeConfig(@RequestParam("dataId") String dataId,
 			@RequestParam(value = "group", required = false) String group)
 			throws NacosException {
 		if (StringUtils.isEmpty(group)) {

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
@@ -199,7 +199,7 @@ public class NacosDiscoveryProperties {
 	/**
 	 * Heart beat interval. Time unit: millisecond.
 	 */
-	private Integer heartBeatInterval = 30000;
+	private Integer heartBeatInterval;
 
 	/**
 	 * Heart beat timeout. Time unit: millisecond.

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
@@ -199,7 +199,7 @@ public class NacosDiscoveryProperties {
 	/**
 	 * Heart beat interval. Time unit: millisecond.
 	 */
-	private Integer heartBeatInterval;
+	private Integer heartBeatInterval = 30000;
 
 	/**
 	 * Heart beat timeout. Time unit: millisecond.

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryClientConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryClientConfiguration.java
@@ -72,7 +72,7 @@ public class NacosDiscoveryClientConfiguration {
 	 */
 	@Bean
 	@ConditionalOnMissingBean
-	@ConditionalOnProperty(value = "spring.cloud.nacos.discovery.watch.enabled", matchIfMissing = false)
+	@ConditionalOnProperty(value = "spring.cloud.nacos.discovery.heart-beat.enabled", matchIfMissing = false)
 	public NacosDiscoveryHeartBeatPublisher nacosDiscoveryHeartBeatPublisher(NacosDiscoveryProperties nacosDiscoveryProperties) {
 		return new NacosDiscoveryHeartBeatPublisher(nacosDiscoveryProperties);
 	}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryClientConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryClientConfiguration.java
@@ -64,17 +64,4 @@ public class NacosDiscoveryClientConfiguration {
 		return new NacosWatch(nacosServiceManager, nacosDiscoveryProperties);
 	}
 
-	/**
-	 * Nacos HeartBeat is no longer enabled by default .
-	 * publish an event every 30 seconds
-	 * see https://github.com/alibaba/spring-cloud-alibaba/issues/2868
-	 * see https://github.com/alibaba/spring-cloud-alibaba/issues/3258
-	 */
-	@Bean
-	@ConditionalOnMissingBean
-	@ConditionalOnProperty(value = "spring.cloud.nacos.discovery.heart-beat.enabled", matchIfMissing = false)
-	public NacosDiscoveryHeartBeatPublisher nacosDiscoveryHeartBeatPublisher(NacosDiscoveryProperties nacosDiscoveryProperties) {
-		return new NacosDiscoveryHeartBeatPublisher(nacosDiscoveryProperties);
-	}
-
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryClientConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryClientConfiguration.java
@@ -65,15 +65,16 @@ public class NacosDiscoveryClientConfiguration {
 	}
 
 	/**
-	 * Spring Cloud Gateway HeartBeat .
+	 * Nacos HeartBeat is no longer enabled by default .
 	 * publish an event every 30 seconds
 	 * see https://github.com/alibaba/spring-cloud-alibaba/issues/2868
+	 * see https://github.com/alibaba/spring-cloud-alibaba/issues/3258
 	 */
 	@Bean
 	@ConditionalOnMissingBean
-	@ConditionalOnProperty(value = "spring.cloud.gateway.discovery.locator.enabled", matchIfMissing = false)
-	public GatewayLocatorHeartBeatPublisher gatewayLocatorHeartBeatPublisher(NacosDiscoveryProperties nacosDiscoveryProperties) {
-		return new GatewayLocatorHeartBeatPublisher(nacosDiscoveryProperties);
+	@ConditionalOnProperty(value = "spring.cloud.nacos.discovery.watch.enabled", matchIfMissing = false)
+	public NacosDiscoveryHeartBeatPublisher nacosDiscoveryHeartBeatPublisher(NacosDiscoveryProperties nacosDiscoveryProperties) {
+		return new NacosDiscoveryHeartBeatPublisher(nacosDiscoveryProperties);
 	}
 
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryHeartBeatConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryHeartBeatConfiguration.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.nacos.discovery;
+
+import com.alibaba.cloud.nacos.ConditionalOnNacosDiscoveryEnabled;
+import com.alibaba.cloud.nacos.NacosDiscoveryProperties;
+
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.client.ConditionalOnBlockingDiscoveryEnabled;
+import org.springframework.cloud.client.ConditionalOnDiscoveryEnabled;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author xiaojing
+ * @author echooymxq
+ * @author ruansheng
+ * @author zhangbin
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnDiscoveryEnabled
+@ConditionalOnBlockingDiscoveryEnabled
+@ConditionalOnNacosDiscoveryEnabled
+@AutoConfigureAfter(value = NacosDiscoveryAutoConfiguration.class,
+		name = "de.codecentric.boot.admin.server.cloud.config.AdminServerDiscoveryAutoConfiguration")
+public class NacosDiscoveryHeartBeatConfiguration {
+
+	/**
+	 * Nacos HeartBeat is no longer enabled by default .
+	 * publish an event every 30 seconds
+	 * see https://github.com/alibaba/spring-cloud-alibaba/issues/2868
+	 * see https://github.com/alibaba/spring-cloud-alibaba/issues/3258
+	 */
+	@Bean
+	@ConditionalOnMissingBean
+	@Conditional(NacosDiscoveryHeartBeatCondition.class)
+	public NacosDiscoveryHeartBeatPublisher nacosDiscoveryHeartBeatPublisher(NacosDiscoveryProperties nacosDiscoveryProperties) {
+		return new NacosDiscoveryHeartBeatPublisher(nacosDiscoveryProperties);
+	}
+
+	private static class NacosDiscoveryHeartBeatCondition extends AnyNestedCondition {
+
+		NacosDiscoveryHeartBeatCondition()  {
+			super(ConfigurationPhase.REGISTER_BEAN);
+		}
+
+		/**
+         * Spring Cloud Gateway HeartBeat .
+		 */
+		@ConditionalOnProperty(value = "spring.cloud.gateway.discovery.locator.enabled", matchIfMissing = false)
+		static class GatewayLocatorHeartBeatEnabled { }
+
+		/**
+		 * Spring Boot Admin HeartBeat .
+		 */
+		@ConditionalOnBean(type = "de.codecentric.boot.admin.server.cloud.discovery.InstanceDiscoveryListener")
+		static class SpringBootAdminHeartBeatEnabled { }
+
+		/**
+		 * Nacos HeartBeat .
+		 */
+		@ConditionalOnProperty(value = "spring.cloud.nacos.discovery.heart-beat.enabled", matchIfMissing = false)
+		static class NacosDiscoveryHeartBeatEnabled { }
+	}
+
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryHeartBeatPublisher.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryHeartBeatPublisher.java
@@ -65,7 +65,7 @@ public class NacosDiscoveryHeartBeatPublisher implements ApplicationEventPublish
 		log.info("Start nacos heartBeat task scheduler.");
 		this.watchFuture = this.taskScheduler.scheduleWithFixedDelay(
 				this::publishHeartBeat, Duration.ofMillis(this.nacosDiscoveryProperties.getWatchDelay()));
-		this.running.compareAndExchange(false,true);
+		this.running.compareAndExchange(false, true);
 	}
 
 	@Override
@@ -75,7 +75,7 @@ public class NacosDiscoveryHeartBeatPublisher implements ApplicationEventPublish
 			// then the other daemon-threads will terminate automatic.
 			this.taskScheduler.shutdown();
 			this.watchFuture.cancel(true);
-            this.running.compareAndExchange(true,false);
+			this.running.compareAndExchange(true, false);
 		}
 	}
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryHeartBeatPublisher.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryHeartBeatPublisher.java
@@ -65,7 +65,7 @@ public class NacosDiscoveryHeartBeatPublisher implements ApplicationEventPublish
 		if (this.running.compareAndSet(false, true)) {
 			log.info("Start nacos heartBeat task scheduler.");
 			this.heartBeatFuture = this.taskScheduler.scheduleWithFixedDelay(
-					this::publishHeartBeat, Duration.ofMillis(this.nacosDiscoveryProperties.getHeartBeatInterval()));
+					this::publishHeartBeat, Duration.ofMillis(this.nacosDiscoveryProperties.getWatchDelay()));
 		}
 	}
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -48,6 +48,12 @@
       "description": "enable nacos discovery watch or not ."
     },
     {
+      "name": "spring.cloud.nacos.discovery.heart-beat.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": "false",
+      "description": "enable nacos discovery heart beat or not ."
+    },
+    {
       "name": "spring.cloud.nacos.discovery.username",
       "type": "java.lang.String",
       "defaultValue": "${spring.cloud.nacos.username}",

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -2,6 +2,7 @@ com.alibaba.cloud.nacos.discovery.NacosDiscoveryAutoConfiguration
 com.alibaba.cloud.nacos.endpoint.NacosDiscoveryEndpointAutoConfiguration
 com.alibaba.cloud.nacos.registry.NacosServiceRegistryAutoConfiguration
 com.alibaba.cloud.nacos.discovery.NacosDiscoveryClientConfiguration
+com.alibaba.cloud.nacos.discovery.NacosDiscoveryHeartBeatConfiguration
 com.alibaba.cloud.nacos.discovery.reactive.NacosReactiveDiscoveryClientConfiguration
 com.alibaba.cloud.nacos.discovery.configclient.NacosConfigServerAutoConfiguration
 com.alibaba.cloud.nacos.loadbalancer.LoadBalancerNacosAutoConfiguration

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryClientConfigurationTest.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryClientConfigurationTest.java
@@ -86,7 +86,7 @@ public class NacosDiscoveryClientConfigurationTest {
 	@Test
 	public void testNacosDiscoveryHeartBeatPublisherEnabled() {
 		contextRunner
-				.withPropertyValues("spring.cloud.nacos.discovery.watch.enabled=true")
+				.withPropertyValues("spring.cloud.nacos.discovery.heart-beat.enabled=true")
 				.run(context ->
 						assertThat(context).hasSingleBean(NacosDiscoveryHeartBeatPublisher.class)
 				);

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryClientConfigurationTest.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryClientConfigurationTest.java
@@ -77,18 +77,18 @@ public class NacosDiscoveryClientConfigurationTest {
 	}
 
 	@Test
-	public void testDefaultGatewayLocatorHeartBeatPublisher() {
+	public void testDefaultNacosDiscoveryHeartBeatPublisher() {
 		contextRunner.run(context ->
-				assertThat(context).doesNotHaveBean(GatewayLocatorHeartBeatPublisher.class)
+				assertThat(context).doesNotHaveBean(NacosDiscoveryHeartBeatPublisher.class)
 		);
 	}
 
 	@Test
-	public void testGatewayLocatorHeartBeatPublisherEnabled() {
+	public void testNacosDiscoveryHeartBeatPublisherEnabled() {
 		contextRunner
-				.withPropertyValues("spring.cloud.gateway.discovery.locator.enabled=true")
+				.withPropertyValues("spring.cloud.nacos.discovery.watch.enabled=true")
 				.run(context ->
-						assertThat(context).hasSingleBean(GatewayLocatorHeartBeatPublisher.class)
+						assertThat(context).hasSingleBean(NacosDiscoveryHeartBeatPublisher.class)
 				);
 	}
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryHeartBeatConfigurationTest.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryHeartBeatConfigurationTest.java
@@ -23,19 +23,15 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationConfiguration;
 import org.springframework.cloud.commons.util.UtilAutoConfiguration;
-import org.springframework.context.annotation.Bean;
-import org.springframework.scheduling.TaskScheduler;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author <a href="mailto:echooy.mxq@gmail.com">echooymxq</a>
  **/
-public class NacosDiscoveryClientConfigurationTest {
+public class NacosDiscoveryHeartBeatConfigurationTest {
 
 	private ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 			.withConfiguration(AutoConfigurations.of(
@@ -45,35 +41,32 @@ public class NacosDiscoveryClientConfigurationTest {
 					UtilIPv6AutoConfiguration.class,
 					NacosServiceAutoConfiguration.class,
 					NacosDiscoveryAutoConfiguration.class,
-					NacosDiscoveryClientConfiguration.class, this.getClass()));
+					NacosDiscoveryClientConfiguration.class,
+					NacosDiscoveryHeartBeatConfiguration.class, this.getClass()));
 
-	@Bean
-	public TaskScheduler taskScheduler() {
-		return new ThreadPoolTaskScheduler();
+	@Test
+	public void testDefaultNacosDiscoveryHeartBeatPublisher() {
+		contextRunner.run(context ->
+				assertThat(context).doesNotHaveBean(NacosDiscoveryHeartBeatPublisher.class)
+		);
 	}
 
 	@Test
-	public void testDefaultInitialization() {
-		contextRunner.run(context -> {
-			assertThat(context).hasSingleBean(DiscoveryClient.class);
-			// NacosWatch is no longer enabled by default
-			assertThat(context).doesNotHaveBean(NacosWatch.class);
-		});
+	public void testNacosDiscoveryHeartBeatPublisherEnabledForGateway() {
+		contextRunner
+				.withPropertyValues("spring.cloud.gateway.discovery.locator.enabled=true")
+				.run(context ->
+						assertThat(context).hasSingleBean(NacosDiscoveryHeartBeatPublisher.class)
+				);
 	}
 
 	@Test
-	public void testDiscoveryBlockingDisabled() {
-		contextRunner.withPropertyValues("spring.cloud.discovery.blocking.enabled=false")
-				.run(context -> {
-					assertThat(context).doesNotHaveBean(DiscoveryClient.class);
-					assertThat(context).doesNotHaveBean(NacosWatch.class);
-				});
-	}
-
-	@Test
-	public void testNacosWatchEnabled() {
-		contextRunner.withPropertyValues("spring.cloud.nacos.discovery.watch.enabled=true")
-				.run(context -> assertThat(context).hasSingleBean(NacosWatch.class));
+	public void testNacosDiscoveryHeartBeatPublisherEnabledForProperties() {
+		contextRunner
+				.withPropertyValues("spring.cloud.nacos.discovery.heart-beat.enabled=true")
+				.run(context ->
+						assertThat(context).hasSingleBean(NacosDiscoveryHeartBeatPublisher.class)
+				);
 	}
 
 }


### PR DESCRIPTION
### Describe what this PR does / why we need it

Refactor GatewayLocatorHeartBeatPublisher to enable friendly subscription to HeartBeat events in addition to the gateway

### Does this pull request fix one issue?

Refer #3258 

### Describe how you did it

1. GatewayLocatorHeartBeatPublisher migrate to NacosDiscoveryHeartBeatPublisher.
2. Enable NacosDiscoveryHeartBeatPublisher by setting `spring.cloud.nacos.discovery.heart-beat.enabled` to `true`.
3. Optimize the lifecycle of NacosDiscoveryHeartBeatPublisher, set running correctly after start and stop.