### PR TITLE
client 端的配置内容支持配置是否保存快照

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigManager.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigManager.java
@@ -22,6 +22,7 @@ import com.alibaba.cloud.nacos.diagnostics.analyzer.NacosConnectionFailureExcept
 import com.alibaba.nacos.api.NacosFactory;
 import com.alibaba.nacos.api.config.ConfigService;
 import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.client.config.utils.SnapShotSwitch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,6 +49,9 @@ public class NacosConfigManager {
 	 */
 	static ConfigService createConfigService(
 			NacosConfigProperties nacosConfigProperties) {
+		if (!nacosConfigProperties.isSnapshotEnabled()){
+			SnapShotSwitch.setIsSnapShot(false);
+		}
 		if (Objects.isNull(service)) {
 			synchronized (NacosConfigManager.class) {
 				try {

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigManager.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigManager.java
@@ -49,7 +49,7 @@ public class NacosConfigManager {
 	 */
 	static ConfigService createConfigService(
 			NacosConfigProperties nacosConfigProperties) {
-		if (!nacosConfigProperties.isSnapshotEnabled()){
+		if (!nacosConfigProperties.isSnapshotEnabled()) {
 			SnapShotSwitch.setIsSnapShot(false);
 		}
 		if (Objects.isNull(service)) {

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigManager.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigManager.java
@@ -22,6 +22,7 @@ import com.alibaba.cloud.nacos.diagnostics.analyzer.NacosConnectionFailureExcept
 import com.alibaba.nacos.api.NacosFactory;
 import com.alibaba.nacos.api.config.ConfigService;
 import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.client.config.impl.LocalConfigInfoProcessor;
 import com.alibaba.nacos.client.config.utils.SnapShotSwitch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,8 +50,12 @@ public class NacosConfigManager {
 	 */
 	static ConfigService createConfigService(
 			NacosConfigProperties nacosConfigProperties) {
+		SnapShotSwitch.setIsSnapShot(nacosConfigProperties.isSnapshotEnabled());
 		if (!nacosConfigProperties.isSnapshotEnabled()) {
-			SnapShotSwitch.setIsSnapShot(false);
+			if (log.isDebugEnabled()) {
+				log.debug("Clean all snapshot");
+			}
+			LocalConfigInfoProcessor.cleanAllSnapshot();
 		}
 		if (Objects.isNull(service)) {
 			synchronized (NacosConfigManager.class) {

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigProperties.java
@@ -248,7 +248,7 @@ public class NacosConfigProperties {
 	private boolean refreshEnabled = true;
 
 	/**
-	 *this master switch for save configuration content snapshot, it default opened(true);
+	 * this master switch for save configuration content snapshot, it default opened(true).
 	 */
 	private boolean snapshotEnabled = true;
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigProperties.java
@@ -247,6 +247,11 @@ public class NacosConfigProperties {
 	 */
 	private boolean refreshEnabled = true;
 
+	/**
+	 *this master switch for save configuration content snapshot, it default opened(true);
+	 */
+	private boolean snapshotEnabled = true;
+
 	// todo sts support
 
 	public String getServerAddr() {
@@ -439,6 +444,14 @@ public class NacosConfigProperties {
 
 	public void setRefreshEnabled(boolean refreshEnabled) {
 		this.refreshEnabled = refreshEnabled;
+	}
+
+	public boolean isSnapshotEnabled() {
+		return snapshotEnabled;
+	}
+
+	public void setSnapshotEnabled(boolean snapshotEnabled) {
+		this.snapshotEnabled = snapshotEnabled;
 	}
 
 	/**


### PR DESCRIPTION
nacos-client默认会在本地保存一份配置内容的快照，这在有些场景中是不可以的，在nacos-client中可以通过调用SnapShotSwitch.setIsSnapShot(false); 来关闭此功能。

https://github.com/alibaba/spring-cloud-alibaba/issues/3367

通过在NacosConfigProperties 配置中增加snapshotEnabled 参数，在NacosConfigManager中创建configService实列的时候判断nacosConfigProperties.isSnapshotEnabled()是否为false,并调用SnapShotSwitch.setIsSnapShot(false); 关闭此功能

在项目中配置spring.cloud.nacos.config.snapshot-enabled=false时，在用户目录下的nacos目录中没有配置相关的内容，去掉配置或配置为true时有配置内容的快照
