### PR TITLE
Seata example add LoadBalancerClient annotation

### DIFF
--- a/spring-cloud-alibaba-examples/seata-example/business-service/src/main/java/com/alibaba/cloud/examples/BusinessApplication.java
+++ b/spring-cloud-alibaba-examples/seata-example/business-service/src/main/java/com/alibaba/cloud/examples/BusinessApplication.java
@@ -19,6 +19,8 @@ package com.alibaba.cloud.examples;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.loadbalancer.annotation.LoadBalancerClient;
+import org.springframework.cloud.loadbalancer.annotation.LoadBalancerClients;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.context.annotation.Bean;
@@ -34,6 +36,11 @@ import org.springframework.web.client.RestTemplate;
 @SpringBootApplication
 @EnableFeignClients
 @EnableDiscoveryClient(autoRegister = false)
+@LoadBalancerClients({
+		@LoadBalancerClient("storage-service"),
+		@LoadBalancerClient("order-service"),
+		@LoadBalancerClient("service-provider")
+})
 public class BusinessApplication {
 
 	public static void main(String[] args) {


### PR DESCRIPTION
### Describe what this PR does / why we need it

Since `4.0.0`, Spring Cloud LoadBalancer supports `Spring AOT` transformations and native images. 

However, to use this feature, you need to explicitly define your `LoadBalancerClient` service IDs. 

You can do so by using the value or name attributes of the `@LoadBalancerClient` annotation or as values of the `spring.cloud.loadbalancer.eager-load.clients` property.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
