### PR TITLE
feat:Zero trust construction in Kubernates system｜功能:Kubernates 体系下零信任建设

### DIFF
--- a/spring-cloud-alibaba-starters/pom.xml
+++ b/spring-cloud-alibaba-starters/pom.xml
@@ -26,6 +26,7 @@
         <module>spring-cloud-alibaba-sentinel-datasource</module>
         <module>spring-cloud-alibaba-sentinel-gateway</module>
         <module>spring-cloud-alibaba-commons</module>
+        <module>spring-cloud-alibaba-starter-security</module>
     </modules>
 
     <build>

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-starter-security/pom.xml
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-starter-security/pom.xml
@@ -1,0 +1,84 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.alibaba.cloud</groupId>
+        <artifactId>spring-cloud-alibaba-starters</artifactId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <groupId>com.alibaba.cloud</groupId>
+    <artifactId>spring-cloud-alibaba-starter-security</artifactId>
+
+    <name>Spring Cloud Starter Security</name>
+
+
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.alibaba.csp</groupId>
+            <artifactId>sentinel-datasource-xds</artifactId>
+            <version>2.0.0-alpha2-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.alibaba.csp</groupId>
+            <artifactId>sentinel-security-core</artifactId>
+            <version>2.0.0-alpha2-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <version>9.0.46</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </dependency>
+
+
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk15on</artifactId>
+            <version>1.70</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-starter-security/src/main/java/com/alibaba/cloud/security/SecurityAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-starter-security/src/main/java/com/alibaba/cloud/security/SecurityAutoConfiguration.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.security;
+
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+
+import com.alibaba.cloud.security.trust.TlsModeListener;
+import com.alibaba.cloud.security.trust.TrustSslStoreProvider;
+import com.alibaba.cloud.security.trust.auth.SentinelTrustInterceptor;
+import com.alibaba.cloud.security.trust.auth.TrustWebMvcConfigurer;
+import com.alibaba.cloud.security.trust.rest.ClientRequestFactoryProvider;
+import com.alibaba.cloud.security.trust.rest.TrustRestBeanPostProcessor;
+import com.alibaba.cloud.security.trust.rest.TrustRestTemplateCallback;
+import com.alibaba.cloud.security.trust.tomcat.TrustTomcatConnectCustomizer;
+import com.alibaba.csp.sentinel.datasource.xds.XdsDataSource;
+import com.alibaba.csp.sentinel.datasource.xds.config.XdsConfigProperties;
+import com.alibaba.csp.sentinel.datasource.xds.constant.type.AsymCryptoType;
+import com.alibaba.csp.sentinel.datasource.xds.constant.type.HashType;
+import com.alibaba.csp.sentinel.datasource.xds.constant.type.JwtPolicyType;
+import com.alibaba.csp.sentinel.trust.TrustManager;
+
+import org.springframework.boot.autoconfigure.AutoConfigureOrder;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.embedded.tomcat.TomcatConnectorCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+/**
+ * @author <a href="liwj418@foxmail.com">lwj</a>
+ */
+@EnableConfigurationProperties(SecurityConfigProperties.class)
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnProperty(name = SecurityConfigProperties.PREFIX + ".open", matchIfMissing = true)
+@AutoConfigureOrder(100)
+public class SecurityAutoConfiguration {
+
+
+	@Bean
+	public XdsConfigProperties xdsConfigProperties(SecurityConfigProperties securityConfigProperties) {
+		XdsConfigProperties config = XdsConfigProperties.getFromXdsPropertiesEnv();
+
+		Optional.ofNullable(securityConfigProperties.getHost()).ifPresent(c -> config.setHost(c));
+		Optional.ofNullable(securityConfigProperties.getPort()).ifPresent(c -> config.setPort(c));
+		Optional.ofNullable(securityConfigProperties.getJwtPolicy()).ifPresent(c -> {
+			JwtPolicyType jwtPolicy = JwtPolicyType.getByKey(c);
+			if (null != jwtPolicy) {
+				config.setJwtPolicy(jwtPolicy);
+			}
+		});
+
+		Optional.ofNullable(securityConfigProperties.getIstiodToken()).ifPresent(c -> config.setIstiodToken(c));
+		Optional.ofNullable(securityConfigProperties.getCaAddr()).ifPresent(c -> config.setCaAddr(c));
+		Optional.ofNullable(securityConfigProperties.getCaCertPath()).ifPresent(c -> config.setCaCertPath(c));
+		Optional.ofNullable(securityConfigProperties.getNamespace()).ifPresent(c -> config.setNamespace(c));
+		Optional.ofNullable(securityConfigProperties.getPodName()).ifPresent(c -> config.setPodName(c));
+		Optional.ofNullable(securityConfigProperties.getClusterId()).ifPresent(c -> config.setClusterId(c));
+
+		Optional.ofNullable(securityConfigProperties.getAsymCryptoType()).ifPresent(c -> {
+			AsymCryptoType asymCryptoType = AsymCryptoType.getByKey(c);
+			if (null != asymCryptoType) {
+				config.setAsymCryptoType(asymCryptoType);
+			}
+		});
+
+		Optional.ofNullable(securityConfigProperties.getHashType()).ifPresent(c -> {
+			HashType hashType = HashType.getByKey(c);
+			if (null != hashType) {
+				config.setHashType(hashType);
+			}
+		});
+
+		Optional.ofNullable(securityConfigProperties.getGetCertTimeoutS()).ifPresent(c -> config.setGetCertTimeoutS(c));
+		Optional.ofNullable(securityConfigProperties.getCertValidityTimeS()).ifPresent(c -> config.setCertValidityTimeS(c));
+		Optional.ofNullable(securityConfigProperties.getCertPeriodRatio()).ifPresent(c -> config.setCertPeriodRatio(c));
+		Optional.ofNullable(securityConfigProperties.getReconnectionDelayS()).ifPresent(c -> config.setReconnectionDelayS(c));
+		Optional.ofNullable(securityConfigProperties.getInitAwaitTimeS()).ifPresent(c -> config.setInitAwaitTimeS(c));
+		return config;
+	}
+
+	@Bean
+	@ConditionalOnClass(XdsConfigProperties.class)
+	public TlsModeListener tlsModeListener(XdsDataSource xdsDataSource) {
+		TrustManager trustManager = TrustManager.getInstance();
+		TlsModeListener tlsModoListener = new TlsModeListener(xdsDataSource);
+		trustManager.registerTlsModeCallback(tlsMode -> tlsModoListener.onUpdate());
+		return tlsModoListener;
+	}
+
+
+	@Bean
+	@ConditionalOnClass(XdsConfigProperties.class)
+	public XdsDataSource xdsDataSource(XdsConfigProperties properties) throws InterruptedException {
+		XdsDataSource xdsDataSource = new XdsDataSource<>(properties);
+		TrustManager trustManager = TrustManager.getInstance();
+		xdsDataSource.registerTrustManager(trustManager);
+		CountDownLatch countDownLatch = new CountDownLatch(1);
+		trustManager.registerTlsModeCallback(tlsMode -> countDownLatch.countDown());
+		xdsDataSource.start();
+		countDownLatch.await();
+		return xdsDataSource;
+	}
+
+	@Bean
+	@ConditionalOnClass(XdsConfigProperties.class)
+	public TrustSslStoreProvider mtlsSslStoreProvider(XdsDataSource xdsDataSource) {
+		return new TrustSslStoreProvider();
+	}
+
+
+	@Bean
+	@ConditionalOnClass(XdsConfigProperties.class)
+	public SentinelTrustInterceptor trustSentinelInterceptor() {
+		return new SentinelTrustInterceptor();
+	}
+
+	@Bean
+	@ConditionalOnClass(XdsConfigProperties.class)
+	public TrustWebMvcConfigurer xdsWebMvcConfigurer(SentinelTrustInterceptor sentinelTrustInterceptor) {
+		return new TrustWebMvcConfigurer(sentinelTrustInterceptor);
+	}
+
+	@Bean
+	@ConditionalOnClass(XdsConfigProperties.class)
+	public TomcatConnectorCustomizer mtlsCustomizer(TrustSslStoreProvider sslStoreProvider, XdsDataSource xdsDataSource) {
+		return new TrustTomcatConnectCustomizer(sslStoreProvider);
+	}
+
+	@Bean
+	@ConditionalOnClass(XdsConfigProperties.class)
+	public TrustRestBeanPostProcessor restMtlsBeanPostProcessor(
+			ClientRequestFactoryProvider clientRequestFactoryProvider) {
+		return new TrustRestBeanPostProcessor(clientRequestFactoryProvider);
+	}
+
+
+	@Bean
+	@ConditionalOnClass(XdsConfigProperties.class)
+	public TrustRestTemplateCallback restTemplateCallback(ClientRequestFactoryProvider clientRequestFactoryProvider) {
+		TrustRestTemplateCallback trustRestTemplateCallback = new TrustRestTemplateCallback(clientRequestFactoryProvider);
+		TrustManager.getInstance().registerCertCallback(certPair -> trustRestTemplateCallback.onUpdateCert());
+		return trustRestTemplateCallback;
+	}
+
+
+	@Bean
+	@ConditionalOnClass(XdsConfigProperties.class)
+	public ClientRequestFactoryProvider clientRequestFactoryProvider(
+			TrustSslStoreProvider trustSslStoreProvider) {
+		return new ClientRequestFactoryProvider(trustSslStoreProvider);
+	}
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-starter-security/src/main/java/com/alibaba/cloud/security/SecurityConfigProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-starter-security/src/main/java/com/alibaba/cloud/security/SecurityConfigProperties.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.security;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+
+/**
+ * @author <a href="liweijian@foxmail.com">lwj</a>
+ */
+@ConfigurationProperties(SecurityConfigProperties.PREFIX)
+public class SecurityConfigProperties {
+	/**
+	 * Spring Cloud Security PREFIX.
+	 */
+	public static final String PREFIX = "spring.cloud.security";
+
+
+	private Boolean open;
+
+	private String host;
+
+	private Integer port;
+
+	private String jwtPolicy;
+
+	private String istiodToken;
+
+	private String caAddr;
+
+	private String caCertPath;
+
+	private String namespace;
+
+	private String podName;
+
+	private String clusterId;
+
+	private String asymCryptoType;
+
+	private String hashType;
+
+	private Integer getCertTimeoutS;
+
+	private Integer certValidityTimeS;
+
+	private Float certPeriodRatio;
+
+	private Integer reconnectionDelayS;
+
+	private Integer initAwaitTimeS;
+
+	public Boolean isOpen() {
+		return open;
+	}
+
+	public void setOpen(Boolean open) {
+		this.open = open;
+	}
+
+	public String getHost() {
+		return host;
+	}
+
+	public void setHost(String host) {
+		this.host = host;
+	}
+
+	public Integer getPort() {
+		return port;
+	}
+
+	public void setPort(Integer port) {
+		this.port = port;
+	}
+
+	public String getJwtPolicy() {
+		return jwtPolicy;
+	}
+
+	public void setJwtPolicy(String jwtPolicy) {
+		this.jwtPolicy = jwtPolicy;
+	}
+
+	public String getIstiodToken() {
+		return istiodToken;
+	}
+
+	public void setIstiodToken(String istiodToken) {
+		this.istiodToken = istiodToken;
+	}
+
+	public String getCaAddr() {
+		return caAddr;
+	}
+
+	public void setCaAddr(String caAddr) {
+		this.caAddr = caAddr;
+	}
+
+	public String getCaCertPath() {
+		return caCertPath;
+	}
+
+	public void setCaCertPath(String caCertPath) {
+		this.caCertPath = caCertPath;
+	}
+
+	public String getNamespace() {
+		return namespace;
+	}
+
+	public void setNamespace(String namespace) {
+		this.namespace = namespace;
+	}
+
+	public String getPodName() {
+		return podName;
+	}
+
+	public void setPodName(String podName) {
+		this.podName = podName;
+	}
+
+	public String getClusterId() {
+		return clusterId;
+	}
+
+	public void setClusterId(String clusterId) {
+		this.clusterId = clusterId;
+	}
+
+	public String getAsymCryptoType() {
+		return asymCryptoType;
+	}
+
+	public void setAsymCryptoType(String asymCryptoType) {
+		this.asymCryptoType = asymCryptoType;
+	}
+
+	public String getHashType() {
+		return hashType;
+	}
+
+	public void setHashType(String hashType) {
+		this.hashType = hashType;
+	}
+
+	public Integer getGetCertTimeoutS() {
+		return getCertTimeoutS;
+	}
+
+	public void setGetCertTimeoutS(Integer getCertTimeoutS) {
+		this.getCertTimeoutS = getCertTimeoutS;
+	}
+
+	public Integer getCertValidityTimeS() {
+		return certValidityTimeS;
+	}
+
+	public void setCertValidityTimeS(Integer certValidityTimeS) {
+		this.certValidityTimeS = certValidityTimeS;
+	}
+
+	public Float getCertPeriodRatio() {
+		return certPeriodRatio;
+	}
+
+	public void setCertPeriodRatio(Float certPeriodRatio) {
+		this.certPeriodRatio = certPeriodRatio;
+	}
+
+	public Integer getReconnectionDelayS() {
+		return reconnectionDelayS;
+	}
+
+	public void setReconnectionDelayS(Integer reconnectionDelayS) {
+		this.reconnectionDelayS = reconnectionDelayS;
+	}
+
+	public Integer getInitAwaitTimeS() {
+		return initAwaitTimeS;
+	}
+
+	public void setInitAwaitTimeS(Integer initAwaitTimeS) {
+		this.initAwaitTimeS = initAwaitTimeS;
+	}
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-starter-security/src/main/java/com/alibaba/cloud/security/trust/ApplicationPreparedEventListener.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-starter-security/src/main/java/com/alibaba/cloud/security/trust/ApplicationPreparedEventListener.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.security.trust;
+
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.context.event.ApplicationPreparedEvent;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.support.GenericApplicationContext;
+
+
+public class ApplicationPreparedEventListener implements ApplicationListener<ApplicationPreparedEvent> {
+
+	private static ConfigurableApplicationContext context;
+
+	private static SpringApplication application;
+
+	private static String[] args;
+
+	@Override
+	public void onApplicationEvent(ApplicationPreparedEvent event) {
+		synchronized (this) {
+			context = event.getApplicationContext();
+			args = event.getArgs();
+			application = event.getSpringApplication();
+			application.addInitializers(new PostProcessorInitializer());
+		}
+	}
+
+	public static ConfigurableApplicationContext getContext() {
+		return context;
+	}
+
+	public static SpringApplication getApplication() {
+		return application;
+	}
+
+	public static String[] getArgs() {
+		return args;
+	}
+
+
+	class PostProcessorInitializer
+			implements ApplicationContextInitializer<GenericApplicationContext> {
+
+		@Override
+		public void initialize(GenericApplicationContext context) {
+			context.registerBean(PostProcessor.class, () -> new PostProcessor());
+		}
+
+	}
+
+	class PostProcessor implements BeanPostProcessor {
+
+		@Override
+		public Object postProcessBeforeInitialization(Object bean, String beanName)
+				throws BeansException {
+			if (bean instanceof ApplicationPreparedEventListener) {
+				return ApplicationPreparedEventListener.this;
+			}
+			return bean;
+		}
+
+	}
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-starter-security/src/main/java/com/alibaba/cloud/security/trust/TlsModeListener.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-starter-security/src/main/java/com/alibaba/cloud/security/trust/TlsModeListener.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.security.trust;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+import com.alibaba.csp.sentinel.datasource.xds.XdsDataSource;
+import com.alibaba.csp.sentinel.trust.TrustManager;
+import com.alibaba.csp.sentinel.trust.tls.TlsMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.util.ClassUtils;
+
+public class TlsModeListener {
+	private Logger log = LoggerFactory.getLogger(TlsModeListener.class);
+
+
+	private ConfigurableApplicationContext context;
+	private SpringApplication application;
+	private String[] args;
+
+	private TlsMode tlsMode = null;
+
+	private XdsDataSource xdsDataSource;
+
+	public TlsModeListener(XdsDataSource xdsDataSource) {
+		context = ApplicationPreparedEventListener.getContext();
+		application = ApplicationPreparedEventListener.getApplication();
+		args = ApplicationPreparedEventListener.getArgs();
+		tlsMode = TrustManager.getInstance().getTlsMode();
+		this.xdsDataSource = xdsDataSource;
+
+	}
+
+
+	public void onUpdate() {
+		synchronized (this) {
+			if (tlsMode.equals(TrustManager.getInstance().getTlsMode())) {
+				return;
+			}
+			Thread thread = new Thread(this::restart);
+			thread.setDaemon(false);
+			thread.start();
+		}
+	}
+
+
+	public synchronized void restart() {
+		try {
+			TrustManager.getInstance().removeAllTlsModeCallback();
+			TrustManager.getInstance().removeAllCertCallback();
+			TrustManager.getInstance().removeAllRulesCallback();
+			xdsDataSource.close();
+			application.setEnvironment(context.getEnvironment());
+			ApplicationContext applicationContex = context;
+
+			while (applicationContex instanceof Closeable) {
+				try {
+					((Closeable) context).close();
+				}
+				catch (IOException e) {
+					log.error("Cannot close context: " + context.getId(), e);
+				}
+				applicationContex = applicationContex.getParent();
+			}
+
+			ClassUtils.overrideThreadContextClassLoader(application.getClass().getClassLoader());
+			context = application.run(this.args);
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+
+	public ConfigurableApplicationContext getContext() {
+		return context;
+	}
+
+	public SpringApplication getApplication() {
+		return application;
+	}
+
+	public String[] getArgs() {
+		return args;
+	}
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-starter-security/src/main/java/com/alibaba/cloud/security/trust/TrustSslStoreProvider.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-starter-security/src/main/java/com/alibaba/cloud/security/trust/TrustSslStoreProvider.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.security.trust;
+
+import java.security.KeyStore;
+
+import com.alibaba.csp.sentinel.trust.TrustManager;
+import com.alibaba.csp.sentinel.trust.cert.CertPair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.boot.web.server.SslStoreProvider;
+
+
+public class TrustSslStoreProvider implements SslStoreProvider {
+
+	private static final Logger log = LoggerFactory.getLogger(TrustSslStoreProvider.class);
+
+	/**
+	 *  key store alias key.
+	 */
+	public static final String MTLS_DEFAULT_KEY_STORE_ALIAS = "mtls-default-key-store";
+
+	/**
+	 * trust store alias key.
+	 */
+	public static final String MTLS_DEFAULT_TRUST_STORE_ALIAS = "mtls-default-trust-store";
+
+
+	private TrustManager trustManager = TrustManager.getInstance();
+
+	public TrustSslStoreProvider() {
+	}
+
+
+	@Override
+	public KeyStore getKeyStore() {
+		CertPair certPair = trustManager.getCertPair();
+
+		try {
+			KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+			keyStore.load(null, null);
+			keyStore.setKeyEntry(MTLS_DEFAULT_KEY_STORE_ALIAS,
+					certPair.getPrivateKey(), "".toCharArray(),
+					certPair.getCertificateChain());
+			return keyStore;
+		}
+		catch (Exception e) {
+			log.error("Error in getting key store", e);
+			return null;
+		}
+	}
+
+	@Override
+	public KeyStore getTrustStore() {
+
+		CertPair certPair = trustManager.getCertPair();
+
+		try {
+			KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+			keyStore.load(null, null);
+			keyStore.setCertificateEntry(MTLS_DEFAULT_TRUST_STORE_ALIAS,
+					certPair.getRootCA());
+			return keyStore;
+		}
+		catch (Exception e) {
+			log.error("Error in getting trust store", e);
+			return null;
+		}
+	}
+}
+

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-starter-security/src/main/java/com/alibaba/cloud/security/trust/auth/SentinelTrustInterceptor.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-starter-security/src/main/java/com/alibaba/cloud/security/trust/auth/SentinelTrustInterceptor.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.security.trust.auth;
+
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.alibaba.csp.sentinel.log.RecordLog;
+import com.alibaba.csp.sentinel.trust.TrustManager;
+import com.alibaba.csp.sentinel.trust.tls.TlsMode;
+import com.alibaba.csp.sentinel.trust.validator.AuthValidator;
+import com.alibaba.csp.sentinel.trust.validator.UnifiedHttpRequest;
+import com.alibaba.csp.sentinel.util.StringUtil;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+
+
+
+
+
+
+public class SentinelTrustInterceptor implements HandlerInterceptor {
+
+	private static final String UNKNOWN_IP = "unknown";
+	private TrustManager trustManager = TrustManager.getInstance();
+
+	public static String getPrincipal(X509Certificate x509Certificate) {
+		try {
+			Collection<List<?>> san = x509Certificate.getSubjectAlternativeNames();
+			return (String) san.iterator().next().get(1);
+		}
+		catch (Exception e) {
+			RecordLog.error("Failed to get istio SAN from X509Certificate", e);
+		}
+		return null;
+	}
+
+	public static String getRemoteIpAddress(HttpServletRequest request) {
+		String ip = request.getHeader("X-Forwarded-For");
+		//Only select the first one
+		if (StringUtil.isNotEmpty(ip) && !UNKNOWN_IP.equalsIgnoreCase(ip)) {
+			if (ip.contains(",")) {
+				ip = ip.split(",")[0];
+				return ip;
+			}
+		}
+		if (null != request.getRemoteAddr()) {
+			return request.getRemoteAddr();
+		}
+		return null;
+	}
+
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+		if (null == trustManager.getTlsMode()) {
+			return true;
+		}
+		//Don't authenticate in DISABLE mode
+		int port = request.getLocalPort();
+		TlsMode tlsMode = trustManager.getTlsMode();
+		TlsMode.TlsType currentTlsType = tlsMode.getPortTls(port);
+		if (TlsMode.TlsType.DISABLE == currentTlsType) {
+			return true;
+		}
+
+		X509Certificate[] certs = (X509Certificate[]) request.getAttribute("javax.servlet.request.X509Certificate");
+		boolean notHaveCert = (null == certs || 0 == certs.length);
+		//When no cert,don't authenticate in PERMISSIVE mode
+		if (notHaveCert) {
+			if (TlsMode.TlsType.STRICT == currentTlsType) {
+				return false;
+			}
+
+			if (TlsMode.TlsType.PERMISSIVE == currentTlsType) {
+				return true;
+			}
+		}
+
+		if (null == trustManager.getRules()) {
+			return true;
+		}
+
+		String principal = getPrincipal(certs[0]);
+		String sourceIp = request.getRemoteAddr();
+		String destIp = request.getLocalAddr();
+		String remoteIp = getRemoteIpAddress(request);
+		String host = request.getHeader(HttpHeaders.HOST);
+		String method = request.getMethod();
+		String path = request.getRequestURI();
+		Map<String, List<String>> headers = getHeaders(request);
+		Map<String, List<String>> params = getParams(request);
+		String sni = request.getServerName();
+
+		UnifiedHttpRequest.UnifiedHttpRequestBuilder builder = new UnifiedHttpRequest.UnifiedHttpRequestBuilder();
+		UnifiedHttpRequest unifiedHttpRequest = builder
+				.setDestIp(destIp)
+				.setRemoteIp(remoteIp)
+				.setSourceIp(sourceIp)
+				.setHost(host)
+				.setPort(port)
+				.setMethod(method)
+				.setPath(path)
+				.setHeaders(headers)
+				.setParams(params)
+				.setPrincipal(principal)
+				.setSni(sni)
+				.build();
+
+		return AuthValidator.validate(unifiedHttpRequest, trustManager.getRules());
+	}
+
+	private Map<String, List<String>> getHeaders(HttpServletRequest request) {
+		Map<String, List<String>> headers = new HashMap<>();
+		Enumeration<String> headerNames = request.getHeaderNames();
+		while (headerNames.hasMoreElements()) {
+			String key = headerNames.nextElement();
+			Enumeration<String> headerValues = request.getHeaders(key);
+			List<String> values = new ArrayList<>();
+			while (headerValues.hasMoreElements()) {
+				values.add(headerValues.nextElement());
+			}
+			headers.put(key, values);
+
+		}
+		return headers;
+	}
+
+	private Map<String, List<String>> getParams(HttpServletRequest request) {
+		Map<String, List<String>> params = new HashMap<>();
+		Enumeration<String> paramNames = request.getParameterNames();
+		while (paramNames.hasMoreElements()) {
+			String key = paramNames.nextElement();
+			List<String> values = Arrays.asList(request.getParameterValues(key));
+			params.put(key, values);
+		}
+		return params;
+	}
+
+
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-starter-security/src/main/java/com/alibaba/cloud/security/trust/auth/TrustWebMvcConfigurer.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-starter-security/src/main/java/com/alibaba/cloud/security/trust/auth/TrustWebMvcConfigurer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.security.trust.auth;
+
+
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+
+public class TrustWebMvcConfigurer implements WebMvcConfigurer {
+
+	private SentinelTrustInterceptor sentinelTrustInterceptor;
+
+	public TrustWebMvcConfigurer(SentinelTrustInterceptor sentinelTrustInterceptor) {
+		this.sentinelTrustInterceptor = sentinelTrustInterceptor;
+	}
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+
+		registry.addInterceptor(sentinelTrustInterceptor);
+	}
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-starter-security/src/main/java/com/alibaba/cloud/security/trust/rest/ClientRequestFactoryProvider.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-starter-security/src/main/java/com/alibaba/cloud/security/trust/rest/ClientRequestFactoryProvider.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.security.trust.rest;
+
+import javax.net.ssl.SSLContext;
+
+import com.alibaba.cloud.security.trust.TrustSslStoreProvider;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+
+
+
+public class ClientRequestFactoryProvider {
+
+	private static final Logger log = LoggerFactory
+			.getLogger(ClientRequestFactoryProvider.class);
+
+	private final TrustSslStoreProvider trustSslStoreProvider;
+
+	public ClientRequestFactoryProvider(TrustSslStoreProvider trustSslStoreProvider) {
+		this.trustSslStoreProvider = trustSslStoreProvider;
+	}
+
+
+	public ClientHttpRequestFactory getFactoryByTemplate(RestTemplate restTemplate) {
+		try {
+			SSLContext sslContext = new SSLContextBuilder()
+					.loadKeyMaterial(trustSslStoreProvider.getKeyStore(), "".toCharArray())
+					.loadTrustMaterial(trustSslStoreProvider.getTrustStore(), null)
+					.build();
+			return getFactoryByTemplate(restTemplate, sslContext);
+		}
+		catch (Exception e) {
+			log.error("Can not get factory by template, class name is {}",
+					restTemplate.getRequestFactory().getClass().getName(), e);
+		}
+		return null;
+	}
+
+	private ClientHttpRequestFactory getFactoryByTemplate(RestTemplate restTemplate, SSLContext sslContext) {
+		return new TrustSimpleClientHttpRequestFactory(sslContext);
+	}
+
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-starter-security/src/main/java/com/alibaba/cloud/security/trust/rest/TrustRestBeanPostProcessor.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-starter-security/src/main/java/com/alibaba/cloud/security/trust/rest/TrustRestBeanPostProcessor.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.security.trust.rest;
+
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.web.client.RestTemplate;
+
+public class TrustRestBeanPostProcessor implements BeanPostProcessor {
+
+	private final ClientRequestFactoryProvider clientRequestFactoryProvider;
+
+	public TrustRestBeanPostProcessor(
+			ClientRequestFactoryProvider clientRequestFactoryProvider) {
+		this.clientRequestFactoryProvider = clientRequestFactoryProvider;
+	}
+
+
+	@Override
+	public Object postProcessBeforeInitialization(Object bean, String beanName) {
+		if (bean instanceof RestTemplate) {
+			RestTemplate restTemplate = (RestTemplate) bean;
+			try {
+				restTemplate.setRequestFactory(
+						clientRequestFactoryProvider.getFactoryByTemplate(restTemplate));
+			}
+			catch (Exception e) {
+				throw new RuntimeException("Error in enhancing restTemplate", e);
+			}
+		}
+		return bean;
+	}
+
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-starter-security/src/main/java/com/alibaba/cloud/security/trust/rest/TrustRestTemplateCallback.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-starter-security/src/main/java/com/alibaba/cloud/security/trust/rest/TrustRestTemplateCallback.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.security.trust.rest;
+
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.web.client.RestTemplate;
+
+
+
+public class TrustRestTemplateCallback implements ApplicationContextAware {
+
+	private static final Logger log = LoggerFactory.getLogger(TrustRestTemplateCallback.class);
+
+	private ApplicationContext applicationContext;
+
+	private final ClientRequestFactoryProvider clientRequestFactoryProvider;
+
+	public TrustRestTemplateCallback(
+			ClientRequestFactoryProvider clientRequestFactoryProvider) {
+		this.clientRequestFactoryProvider = clientRequestFactoryProvider;
+	}
+
+	public void onUpdateCert() {
+		// When the certificate is expired, we refresh the client certificate.
+		try {
+			if (!validateContext()) {
+				return;
+			}
+			Map<String, RestTemplate> restTemplates = applicationContext
+					.getBeansOfType(RestTemplate.class);
+			for (RestTemplate restTemplate : restTemplates.values()) {
+				restTemplate.setRequestFactory(clientRequestFactoryProvider
+						.getFactoryByTemplate(restTemplate));
+			}
+		}
+		catch (BeanCreationException e1) {
+			log.warn(
+					"Spring is creating the RestTemplate bean, please try to refresh the client certificate later");
+		}
+		catch (Exception e2) {
+			log.error("Failed to refresh RestTemplate", e2);
+		}
+	}
+
+	@Override
+	public void setApplicationContext(ApplicationContext applicationContext)
+			throws BeansException {
+		this.applicationContext = applicationContext;
+	}
+
+	private boolean validateContext() {
+		if (applicationContext instanceof ConfigurableApplicationContext) {
+			ConfigurableApplicationContext context = (ConfigurableApplicationContext) applicationContext;
+			return context.isActive();
+		}
+		return true;
+	}
+
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-starter-security/src/main/java/com/alibaba/cloud/security/trust/rest/TrustSimpleClientHttpRequestFactory.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-starter-security/src/main/java/com/alibaba/cloud/security/trust/rest/TrustSimpleClientHttpRequestFactory.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.security.trust.rest;
+
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.Proxy;
+import java.net.URI;
+import java.net.URL;
+
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+
+
+import com.alibaba.csp.sentinel.trust.TrustManager;
+import com.alibaba.csp.sentinel.trust.tls.TlsMode;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+
+
+public class TrustSimpleClientHttpRequestFactory extends org.springframework.http.client.SimpleClientHttpRequestFactory {
+
+	private final SSLContext sslContext;
+
+	public TrustSimpleClientHttpRequestFactory(SSLContext sslContext) {
+		this.sslContext = sslContext;
+	}
+
+
+	@Override
+	protected HttpURLConnection openConnection(URL url, Proxy proxy) throws IOException {
+		url = tlsBefore(url);
+		return super.openConnection(url, proxy);
+	}
+
+	private URL tlsBefore(URL url) {
+		if (TrustManager.getInstance().getTlsMode().getGlobalTls() != TlsMode.TlsType.STRICT) {
+			return url;
+		}
+		try {
+			URI uri = url.toURI();
+			if ("http".equals(uri.getScheme())) {
+				String uriSt = uri.toString();
+				String uriStNew = uriSt.replaceFirst("http", "https");
+				URI newUri = new URI(uriStNew);
+				return newUri.toURL();
+			}
+			else {
+				return url;
+			}
+		}
+		catch (Exception e) {
+			return url;
+		}
+	}
+
+
+	@Override
+	protected void prepareConnection(HttpURLConnection connection, String httpMethod)
+			throws IOException {
+		if (TrustManager.getInstance().getTlsMode().getGlobalTls() != TlsMode.TlsType.STRICT) {
+			return;
+		}
+		if (connection instanceof HttpsURLConnection) {
+			HttpsURLConnection httpsURLConnection = (HttpsURLConnection) connection;
+			httpsURLConnection.setHostnameVerifier(new NoopHostnameVerifier());
+			httpsURLConnection.setSSLSocketFactory(sslContext.getSocketFactory());
+		}
+		super.prepareConnection(connection, httpMethod);
+	}
+
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-starter-security/src/main/java/com/alibaba/cloud/security/trust/tomcat/SslStoreProviderUrlStreamHandlerFactory.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-starter-security/src/main/java/com/alibaba/cloud/security/trust/tomcat/SslStoreProviderUrlStreamHandlerFactory.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.security.trust.tomcat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import java.net.URLStreamHandlerFactory;
+import java.security.KeyStore;
+
+import org.springframework.boot.web.server.SslStoreProvider;
+
+
+public class SslStoreProviderUrlStreamHandlerFactory implements URLStreamHandlerFactory {
+
+	private static final String PROTOCOL = "springbootssl";
+
+	private static final String KEY_STORE_PATH = "keyStore";
+
+	static final String KEY_STORE_URL = PROTOCOL + ":" + KEY_STORE_PATH;
+
+	private static final String TRUST_STORE_PATH = "trustStore";
+
+	static final String TRUST_STORE_URL = PROTOCOL + ":" + TRUST_STORE_PATH;
+
+	// Must be a static variable, or we can not reload sslStoreProvider when we restart
+	// the spring context.
+	private static SslStoreProvider sslStoreProvider;
+
+	SslStoreProviderUrlStreamHandlerFactory(SslStoreProvider sslStoreProvider) {
+		SslStoreProviderUrlStreamHandlerFactory.sslStoreProvider = sslStoreProvider;
+	}
+
+	@Override
+	public URLStreamHandler createURLStreamHandler(String protocol) {
+		if (PROTOCOL.equals(protocol)) {
+			return new URLStreamHandler() {
+
+				@Override
+				protected URLConnection openConnection(URL url) throws IOException {
+					try {
+						if (KEY_STORE_PATH.equals(url.getPath())) {
+							return new KeyStoreUrlConnection(url,
+									SslStoreProviderUrlStreamHandlerFactory.sslStoreProvider
+											.getKeyStore());
+						}
+						if (TRUST_STORE_PATH.equals(url.getPath())) {
+							return new KeyStoreUrlConnection(url,
+									SslStoreProviderUrlStreamHandlerFactory.sslStoreProvider
+											.getTrustStore());
+						}
+					}
+					catch (Exception ex) {
+						throw new IOException(ex);
+					}
+					throw new IOException("Invalid path: " + url.getPath());
+				}
+			};
+		}
+		return null;
+	}
+
+	private static final class KeyStoreUrlConnection extends URLConnection {
+
+		private final KeyStore keyStore;
+
+		private KeyStoreUrlConnection(URL url, KeyStore keyStore) {
+			super(url);
+			this.keyStore = keyStore;
+		}
+
+		@Override
+		public void connect() throws IOException {
+
+		}
+
+		@Override
+		public InputStream getInputStream() throws IOException {
+
+			try {
+				ByteArrayOutputStream stream = new ByteArrayOutputStream();
+				this.keyStore.store(stream, new char[0]);
+				return new ByteArrayInputStream(stream.toByteArray());
+			}
+			catch (Exception ex) {
+				throw new IOException(ex);
+			}
+		}
+
+	}
+
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-starter-security/src/main/java/com/alibaba/cloud/security/trust/tomcat/TrustTomcatConnectCustomizer.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-starter-security/src/main/java/com/alibaba/cloud/security/trust/tomcat/TrustTomcatConnectCustomizer.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.security.trust.tomcat;
+
+
+import com.alibaba.cloud.security.trust.TrustSslStoreProvider;
+import com.alibaba.csp.sentinel.trust.TrustManager;
+import com.alibaba.csp.sentinel.trust.tls.TlsMode;
+import org.apache.catalina.connector.Connector;
+import org.apache.catalina.webresources.TomcatURLStreamHandlerFactory;
+import org.apache.coyote.AbstractProtocol;
+import org.apache.coyote.ProtocolHandler;
+import org.apache.coyote.http11.AbstractHttp11JsseProtocol;
+import org.apache.coyote.http11.AbstractHttp11Protocol;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.beans.BeansException;
+import org.springframework.boot.web.embedded.tomcat.TomcatConnectorCustomizer;
+import org.springframework.boot.web.server.Ssl;
+import org.springframework.boot.web.server.WebServerException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.ConfigurableApplicationContext;
+
+public class TrustTomcatConnectCustomizer
+		implements TomcatConnectorCustomizer, ApplicationContextAware {
+
+	private static final Logger log = LoggerFactory
+			.getLogger(TrustTomcatConnectCustomizer.class);
+
+	private final TrustManager trustManager = TrustManager.getInstance();
+
+	private final TrustSslStoreProvider sslStoreProvider;
+
+	private ApplicationContext applicationContext;
+
+
+	public TrustTomcatConnectCustomizer(TrustSslStoreProvider trustSslStoreProvider) {
+		this.sslStoreProvider = trustSslStoreProvider;
+	}
+
+	@Override
+	public void customize(Connector connector) {
+		if (!validateContext()) {
+			return;
+		}
+		TlsMode tlsMode = trustManager.getTlsMode();
+		if (tlsMode == null) {
+			return;
+		}
+		if (tlsMode.getPortTls(connector.getPort()) != TlsMode.TlsType.STRICT) {
+			return;
+		}
+
+
+		// When the certificate is expired, we refresh the server certificate.
+		trustManager.registerCertCallback(certPair -> {
+			try {
+				if (!validateContext()) {
+					return;
+				}
+				ProtocolHandler protocolHandler = connector.getProtocolHandler();
+				AbstractProtocol<?> abstractProtocol = (AbstractProtocol<?>) protocolHandler;
+				if (abstractProtocol instanceof AbstractHttp11Protocol<?>) {
+					AbstractHttp11Protocol<?> proto = ((AbstractHttp11Protocol<?>) abstractProtocol);
+					proto.reloadSslHostConfigs();
+				}
+			}
+			catch (Exception e) {
+				log.error("Failed to reload certificate of tomcat", e);
+			}
+		});
+
+		try {
+			ProtocolHandler handler = connector.getProtocolHandler();
+			AbstractHttp11JsseProtocol<?> protocol = (AbstractHttp11JsseProtocol<?>) handler;
+			Ssl ssl = new Ssl();
+			ssl.setClientAuth(Ssl.ClientAuth.WANT);
+			protocol.setSSLEnabled(true);
+			protocol.setSslProtocol(ssl.getProtocol());
+			configureSslClientAuth(protocol, ssl);
+			protocol.setKeyAlias(ssl.getKeyAlias());
+			TomcatURLStreamHandlerFactory tomcatURLStreamHandlerFactory = TomcatURLStreamHandlerFactory
+					.getInstance();
+			SslStoreProviderUrlStreamHandlerFactory sslStoreProviderUrlStreamHandlerFactory = new SslStoreProviderUrlStreamHandlerFactory(
+					sslStoreProvider);
+			TomcatURLStreamHandlerFactory.release(
+					sslStoreProviderUrlStreamHandlerFactory.getClass().getClassLoader());
+			tomcatURLStreamHandlerFactory
+					.addUserFactory(sslStoreProviderUrlStreamHandlerFactory);
+			try {
+				if (sslStoreProvider.getKeyStore() != null) {
+					protocol.setKeystorePass("");
+					protocol.setKeystoreFile(
+							SslStoreProviderUrlStreamHandlerFactory.KEY_STORE_URL);
+				}
+				if (sslStoreProvider.getTrustStore() != null) {
+					protocol.setTruststorePass("");
+					protocol.setTruststoreFile(
+							SslStoreProviderUrlStreamHandlerFactory.TRUST_STORE_URL);
+				}
+			}
+			catch (Exception ex) {
+				throw new WebServerException("Could not load store: " + ex.getMessage(),
+						ex);
+			}
+			connector.setScheme("https");
+			connector.setSecure(true);
+		}
+		catch (Exception e) {
+			log.error("Custom tomcat ssl failed!", e);
+		}
+	}
+
+	private boolean validateContext() {
+		if (applicationContext instanceof ConfigurableApplicationContext) {
+			ConfigurableApplicationContext context = (ConfigurableApplicationContext) applicationContext;
+			return context.isActive();
+		}
+		return true;
+	}
+
+	private void configureSslClientAuth(AbstractHttp11JsseProtocol<?> protocol, Ssl ssl) {
+		if (ssl.getClientAuth() == Ssl.ClientAuth.NEED) {
+			protocol.setClientAuth(Boolean.TRUE.toString());
+		}
+		else if (ssl.getClientAuth() == Ssl.ClientAuth.WANT) {
+			protocol.setClientAuth("want");
+		}
+	}
+
+	@Override
+	public void setApplicationContext(ApplicationContext applicationContext)
+			throws BeansException {
+		this.applicationContext = applicationContext;
+	}
+
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-starter-security/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-starter-security/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.context.ApplicationListener=\
+com.alibaba.cloud.security.trust.ApplicationPreparedEventListener

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-starter-security/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-starter-security/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,2 @@
+com.alibaba.cloud.security.SecurityAutoConfiguration
+com.alibaba.cloud.security.trust.ApplicationPreparedEventListener


### PR DESCRIPTION
### Describe what this PR does / why we need it

Zero trust construction in Kubernates system.
Added zero trust module.


### Does this pull request fix one issue?

 #3428

### Describe how you did it
We want to introduce a zero-trust module that uses the xds receiving and zero-trust core module in sentinel2.0. 
Under development in this issue，this module directly provides certificate and authentication-related functions for users.

### Describe how to verify it

You can directly access the dependency package of spring-cloud-alibaba-starter-security in the application，and  verify it.

----

### 描述这个PR是什么

希望引入零信任模块，该模块使用sentinel2.0中xds接收和零信任的core模块。
在本期开发中，该模块可以直接为用户提供证书和鉴权相关功能。

### Does this pull request fix one issue?

 #3428

### 描述你是如何做的

希望引入零信任模块，该模块使用sentinel2.0中xds接收和零信任的core模块。该模块可以直接为用户提供证书和鉴权相关功能。

### Describe how to verify it

在应用中直接引入 spring-cloud-alibaba-starter-security 模块，即可验证它.

