### PR TITLE
“Test cases cannot achieve project readme functionality”Problem Solvi…

### DIFF
--- a/spring-cloud-alibaba-examples/integrated-example/config-init/config/integrated-consumer.yaml
+++ b/spring-cloud-alibaba-examples/integrated-example/config-init/config/integrated-consumer.yaml
@@ -1,10 +1,10 @@
 spring:
-  datasource:
-    url: jdbc:mysql://integrated-mysql:3306/integrated_praise?useSSL=false&characterEncoding=utf8
   cloud:
     stream:
+      function:
+        definition: consumer;
       bindings:
-        praise-input:
+        consumer-in-0:
           destination: PRAISE-TOPIC-01
           content-type: application/json
           group: praise-consumer-group-PRAISE-TOPIC-01
@@ -12,7 +12,9 @@ spring:
         binder:
           name-server: rocketmq:9876
         bindings:
-          praise-input:
+          consumer-in-0:
             consumer:
               pullInterval: 4000
               pullBatchSize: 4
+  datasource:
+    url: jdbc:mysql://integrated-mysql:3306/integrated_praise?useSSL=false&characterEncoding=utf8


### PR DESCRIPTION
“Test cases cannot achieve project readme functionality”Problem Solving,Reason: When the file contents of the nacos file are being initialized, it has not been executed correctly and the configuration file is incorrect. Solution: It was discovered that only data source-related configurations exist in the file in nacos. Then I put other configuration content in the front position and re-executed the script. It was found that the content was successfully loaded. The consumer method name in the previously configured "bindings" was inconsistent with the actual code, and there was no configuration for"function.Fixes gh-3427