### PR TITLE
Fix 7 order-dependent tests by adding a precondition

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/test/java/com/alibaba/cloud/nacos/configdata/NacosConfigDataLocationResolverTest.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/test/java/com/alibaba/cloud/nacos/configdata/NacosConfigDataLocationResolverTest.java
@@ -63,6 +63,12 @@ public class NacosConfigDataLocationResolverTest {
 	@BeforeEach
 	void setup() {
 		this.environment = new MockEnvironment();
+		environment.setProperty("spring.cloud.nacos.username", "root");
+		environment.setProperty("spring.cloud.nacos.password", "root");
+		environment.setProperty("spring.cloud.nacos.config.password", "not_root");
+		environment.setProperty("spring.cloud.nacos.server-addr", "127.0.0.1:8888");
+		environment.setProperty("spring.cloud.nacos.config.server-addr",
+				"127.0.0.1:9999");
 		this.environmentBinder = Binder.get(this.environment);
 		this.resolver = new NacosConfigDataLocationResolver(new DeferredLogs());
 		when(bootstrapContext.isRegistered(eq(ConfigService.class))).thenReturn(true);
@@ -166,7 +172,10 @@ public class NacosConfigDataLocationResolverTest {
 	void testSetCommonPropertiesIsOK() {
 		environment.setProperty("spring.cloud.nacos.username", "root");
 		environment.setProperty("spring.cloud.nacos.password", "root");
+		environment.setProperty("spring.cloud.nacos.config.password", "root");
 		environment.setProperty("spring.cloud.nacos.server-addr", "127.0.0.1:8888");
+		environment.setProperty("spring.cloud.nacos.config.server-addr",
+			"127.0.0.1:8888");
 		String locationUri = "nacos:test.yml";
 		List<NacosConfigDataResource> resources = testUri(locationUri);
 


### PR DESCRIPTION
### Describe what this PR does / why we need it
This PR fix seven order-dependent tests by always adding a precondition.

Related test:
[com.alibaba.cloud.nacos.configdata.NacosConfigDataLocationResolverTest.testResolveProfileSpecific_givenNothing_thenReturnDefaultProfile](https://github.com/alibaba/spring-cloud-alibaba/blob/6843cb06da903c39527705e07c16a0e17a06e873/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/test/java/com/alibaba/cloud/nacos/configdata/NacosConfigDataLocationResolverTest.java#L98)
[com.alibaba.cloud.nacos.configdata.NacosConfigDataLocationResolverTest.testStartWithASlashIsOK](https://github.com/alibaba/spring-cloud-alibaba/blob/6843cb06da903c39527705e07c16a0e17a06e873/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/test/java/com/alibaba/cloud/nacos/configdata/NacosConfigDataLocationResolverTest.java#L104)
[com.alibaba.cloud.nacos.configdata.NacosConfigDataLocationResolverTest.testDataIdMustBeSpecified](https://github.com/lxb007981/spring-cloud-alibaba/blob/6843cb06da903c39527705e07c16a0e17a06e873/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/test/java/com/alibaba/cloud/nacos/configdata/NacosConfigDataLocationResolverTest.java#L117)
[com.alibaba.cloud.nacos.configdata.NacosConfigDataLocationResolverTest.testInvalidDataId](https://github.com/alibaba/spring-cloud-alibaba/blob/6843cb06da903c39527705e07c16a0e17a06e873/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/test/java/com/alibaba/cloud/nacos/configdata/NacosConfigDataLocationResolverTest.java#L124)
[com.alibaba.cloud.nacos.configdata.NacosConfigDataLocationResolverTest.whenCustomizeSuffix_thenOverrideDefault](https://github.com/lxb007981/spring-cloud-alibaba/blob/6843cb06da903c39527705e07c16a0e17a06e873/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/test/java/com/alibaba/cloud/nacos/configdata/NacosConfigDataLocationResolverTest.java#L130)
[com.alibaba.cloud.nacos.configdata.NacosConfigDataLocationResolverTest.testUrisInLocationShouldOverridesProperty](https://github.com/alibaba/spring-cloud-alibaba/blob/6843cb06da903c39527705e07c16a0e17a06e873/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/test/java/com/alibaba/cloud/nacos/configdata/NacosConfigDataLocationResolverTest.java#L152)
[com.alibaba.cloud.nacos.configdata.NacosConfigDataLocationResolverTest.whenNoneInBootstrapContext_thenCreateNewConfigClientProperties](https://github.com/lxb007981/spring-cloud-alibaba/blob/6843cb06da903c39527705e07c16a0e17a06e873/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/test/java/com/alibaba/cloud/nacos/configdata/NacosConfigDataLocationResolverTest.java#L207)

These seven tests are order-dependent flaky. they depend on the environment properties, but these properties are not properly set during the `setup()`. Some other tests set the properties individually (like `testCommonPropertiesHasLowerPriority`), which make the tests relying on these properties order-dependent.

### Does this pull request fix one issue?

https://github.com/alibaba/spring-cloud-alibaba/issues/3503

### Describe how you did it

Properties are now set in the `setup()` method, which is executed before each test.

### Describe how to verify it

Using a test order randomizer can trigger this order-dependent flakiness. Or one can directly run one of the flaky tests individually (instead of run the whole test class), and it will throw some error.

### Special notes for reviews
