### PR TITLE
Docs: Add example: nacos config setting Group

### DIFF
--- a/spring-cloud-alibaba-examples/nacos-example/nacos-config-example/readme-zh.md
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-config-example/readme-zh.md
@@ -29,7 +29,7 @@ spring:
       serverAddr: 127.0.0.1:8848
   config:
     import:
-      - nacos:nacos-config-example.properties?refresh=true
+      - nacos:nacos-config-example.properties?refresh=true&group=DEFAULT_GROUP
 ```
 		  
 3. 完成上述两步后，应用会从 Nacos Config 中获取相应的配置，并添加在 Spring Environment 的 PropertySources 中。假设我们通过 Nacos 配置中心保存 Nacos 的部分配置,有以下四种例子:

--- a/spring-cloud-alibaba-examples/nacos-example/nacos-config-example/readme.md
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-config-example/readme.md
@@ -31,7 +31,7 @@ spring:
       serverAddr: 127.0.0.1:8848
   config:
     import:
-      - nacos:nacos-config-example.properties?refresh=true
+      - nacos:nacos-config-example.properties?refresh=true&group=DEFAULT_GROUP
 ```
 
 3. After completing the above two steps, the application will obtain the corresponding configuration from Nacos Config and add it to the PropertySources of Spring Environment. Suppose we save part of the configuration of Nacos through the Nacos configuration center, there are the following four examples:


### PR DESCRIPTION
### Describe what this PR does / why we need it
The current nacos config example is missing the group setting. It's actually in the code, so it would be helpful to have a more complete example.

### Does this pull request fix one issue?
No

### Describe how you did it
I tracked down the logic for the nacos processing by reading the spring code for config.implant processing, which can be found in the following code.
/com/alibaba/cloud/nacos/configdata/NacosConfigDataLocationResolver:170   

Translated with DeepL.com (free version)