### PR TITLE
Fix configuration load error due to prefix

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/client/NacosPropertySourceLocator.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/client/NacosPropertySourceLocator.java
@@ -84,13 +84,8 @@ public class NacosPropertySourceLocator implements PropertySourceLocator {
 		long timeout = nacosConfigProperties.getTimeout();
 		nacosPropertySourceBuilder = new NacosPropertySourceBuilder(configService,
 				timeout);
-		String name = nacosConfigProperties.getName();
 
 		String dataIdPrefix = nacosConfigProperties.getPrefix();
-		if (StringUtils.isEmpty(dataIdPrefix)) {
-			dataIdPrefix = name;
-		}
-
 		if (StringUtils.isEmpty(dataIdPrefix)) {
 			dataIdPrefix = env.getProperty("spring.application.name");
 		}
@@ -138,7 +133,7 @@ public class NacosPropertySourceLocator implements PropertySourceLocator {
 		String fileExtension = properties.getFileExtension();
 		String nacosGroup = properties.getGroup();
 		// load directly once by default
-		loadNacosDataIfPresent(compositePropertySource, dataIdPrefix, nacosGroup,
+		loadNacosDataIfPresent(compositePropertySource, nacosConfigProperties.getName(), nacosGroup,
 				fileExtension, true);
 		// load with suffix, which have a higher priority than the default
 		loadNacosDataIfPresent(compositePropertySource,

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/client/NacosPropertySourceLocator.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/client/NacosPropertySourceLocator.java
@@ -133,7 +133,7 @@ public class NacosPropertySourceLocator implements PropertySourceLocator {
 		String fileExtension = properties.getFileExtension();
 		String nacosGroup = properties.getGroup();
 		// load directly once by default
-		loadNacosDataIfPresent(compositePropertySource, nacosConfigProperties.getName(), nacosGroup,
+		loadNacosDataIfPresent(compositePropertySource, properties.getName(), nacosGroup,
 				fileExtension, true);
 		// load with suffix, which have a higher priority than the default
 		loadNacosDataIfPresent(compositePropertySource,


### PR DESCRIPTION
### Describe what this PR does / why we need it
Same here: 
#3563 (it's for 2022.x)
#3579  (it's for 2020.0.0)

### Does this pull request fix one issue?
#3561 

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
Delete the following code:
`com.alibaba.cloud.nacos.client.NacosPropertySourceLocator#locate`
<img width="863" alt="image" src="https://github.com/alibaba/spring-cloud-alibaba/assets/68590897/5c671241-3825-4112-bb7c-a73e380aad90">
And the name field should be used here:
<img width="991" alt="image" src="https://github.com/alibaba/spring-cloud-alibaba/assets/68590897/637aedb6-3afa-4c6a-b309-486771137d25">
Here, only the default configuration is loaded, which is `spring.cloud.nacos.configuration.name`, that is:
<img width="949" alt="image" src="https://github.com/alibaba/spring-cloud-alibaba/assets/68590897/29128351-e6b9-4a14-993c-34cc756bd02d">

Here you can splice the prefix.
<img width="895" alt="image" src="https://github.com/alibaba/spring-cloud-alibaba/assets/68590897/975403a5-5305-43f3-a26c-8964ae82d9f1">

### Describe how to verify it
Install to the local repository, using the repaired version:
<img width="1255" alt="image" src="https://github.com/alibaba/spring-cloud-alibaba/assets/68590897/79af49eb-834c-449f-8e12-b146dc3a9814">
