### PR TITLE
feat:move warning logs to a more suitable location(#3570)

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/NacosLoadBalancer.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/NacosLoadBalancer.java
@@ -144,10 +144,10 @@ public class NacosLoadBalancer implements ReactorServiceInstanceLoadBalancer {
 							return StringUtils.equals(cluster, clusterName);
 						}).collect(Collectors.toList());
 				if (CollectionUtils.isEmpty(sameClusterInstances)) {
-					instancesToChoose = sameClusterInstances;
-				} else {
 					log.warn("Not filtering to the specified cluster instance node，name = {}, clusterName = {}, instance = {}",
 							serviceId, clusterName, serviceInstances);
+				} else {
+					instancesToChoose = sameClusterInstances;
 				}
 			}
 			instancesToChoose = this.filterInstanceByIpType(instancesToChoose);

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/NacosLoadBalancer.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/NacosLoadBalancer.java
@@ -143,11 +143,12 @@ public class NacosLoadBalancer implements ReactorServiceInstanceLoadBalancer {
 									.get("nacos.cluster");
 							return StringUtils.equals(cluster, clusterName);
 						}).collect(Collectors.toList());
-				if (!CollectionUtils.isEmpty(sameClusterInstances)) {
+				if (CollectionUtils.isEmpty(sameClusterInstances)) {
 					instancesToChoose = sameClusterInstances;
+				} else {
+					log.warn("Not filtering to the specified cluster instance node，name = {}, clusterName = {}, instance = {}",
+							serviceId, clusterName, serviceInstances);
 				}
-				log.warn("A cross-cluster call occurs，name = {}, clusterName = {}, instance = {}",
-						serviceId, clusterName, serviceInstances);
 			}
 			instancesToChoose = this.filterInstanceByIpType(instancesToChoose);
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/NacosLoadBalancer.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/NacosLoadBalancer.java
@@ -148,6 +148,8 @@ public class NacosLoadBalancer implements ReactorServiceInstanceLoadBalancer {
 							serviceId, clusterName, serviceInstances);
 				} else {
 					instancesToChoose = sameClusterInstances;
+					log.info("Calling to filter cluster instance nodes, name = {}, clusterName = {}, instance = {}",
+							serviceId, clusterName, serviceInstances);
 				}
 			}
 			instancesToChoose = this.filterInstanceByIpType(instancesToChoose);

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/NacosLoadBalancer.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/NacosLoadBalancer.java
@@ -143,14 +143,12 @@ public class NacosLoadBalancer implements ReactorServiceInstanceLoadBalancer {
 									.get("nacos.cluster");
 							return StringUtils.equals(cluster, clusterName);
 						}).collect(Collectors.toList());
-				if (!CollectionUtils.isEmpty(sameClusterInstances)) {
+				if (CollectionUtils.isEmpty(sameClusterInstances)) {
 					instancesToChoose = sameClusterInstances;
+				} else {
+					log.warn("Not filtering to the specified cluster instance node，name = {}, clusterName = {}, instance = {}",
+							serviceId, clusterName, serviceInstances);
 				}
-			}
-			else {
-				log.warn(
-						"A cross-cluster call occurs，name = {}, clusterName = {}, instance = {}",
-						serviceId, clusterName, serviceInstances);
 			}
 			instancesToChoose = this.filterInstanceByIpType(instancesToChoose);
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/NacosLoadBalancer.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/NacosLoadBalancer.java
@@ -146,10 +146,7 @@ public class NacosLoadBalancer implements ReactorServiceInstanceLoadBalancer {
 				if (!CollectionUtils.isEmpty(sameClusterInstances)) {
 					instancesToChoose = sameClusterInstances;
 				}
-			}
-			else {
-				log.warn(
-						"A cross-cluster call occurs，name = {}, clusterName = {}, instance = {}",
+				log.warn("A cross-cluster call occurs，name = {}, clusterName = {}, instance = {}",
 						serviceId, clusterName, serviceInstances);
 			}
 			instancesToChoose = this.filterInstanceByIpType(instancesToChoose);


### PR DESCRIPTION
### Describe what this PR does / why we need it
When Nacos made cross cluster calls, it was found that there was no warning log like "A cross cluster call occurrences..." in previous versions

### Does this pull request fix one issue?
Feat##3570

### Describe how you did it
Move the error warning log to the appropriate location so that the warning prompt can be printed correctly and reasonably

### Describe how to verify it
NONE

### Special notes for reviews
NONE