### PR TITLE
修复 Nacos 集群模式下获取到旧配置问题 | Fixed: server pulling old config in Nacos cluster mode

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/client/NacosPropertySourceBuilder.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/client/NacosPropertySourceBuilder.java
@@ -83,8 +83,7 @@ public class NacosPropertySourceBuilder {
 			String fileExtension) {
 		String data = null;
 		try {
-			String configSnapshot = NacosSnapshotConfigManager.getConfigSnapshot(dataId,
-					group);
+			String configSnapshot = NacosSnapshotConfigManager.getAndRemoveConfigSnapshot(dataId, group);
 			if (StringUtils.isEmpty(configSnapshot)) {
 				log.debug("get config from nacos, dataId: {}, group: {}", dataId, group);
 				data = configService.getConfig(dataId, group, timeout);
@@ -92,7 +91,6 @@ public class NacosPropertySourceBuilder {
 			else {
 				log.debug("get config from memory snapshot, dataId: {}, group: {}",
 						dataId, group);
-				NacosSnapshotConfigManager.removeConfigSnapshot(dataId, group);
 				data = configSnapshot;
 			}
 			if (StringUtils.isEmpty(data)) {

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/client/NacosPropertySourceBuilder.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/client/NacosPropertySourceBuilder.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import com.alibaba.cloud.nacos.NacosPropertySourceRepository;
 import com.alibaba.cloud.nacos.parser.NacosDataParserHandler;
+import com.alibaba.cloud.nacos.refresh.NacosSnapshotConfigManager;
 import com.alibaba.nacos.api.config.ConfigService;
 import com.alibaba.nacos.api.exception.NacosException;
 import org.slf4j.Logger;
@@ -82,7 +83,16 @@ public class NacosPropertySourceBuilder {
 			String fileExtension) {
 		String data = null;
 		try {
-			data = configService.getConfig(dataId, group, timeout);
+			String configSnapshot = NacosSnapshotConfigManager.getConfigSnapshot(dataId, group);
+			if (StringUtils.isEmpty(configSnapshot)) {
+				log.debug("get config from nacos, dataId: {}, group: {}", dataId, group);
+				data = configService.getConfig(dataId, group, timeout);
+			}
+			else {
+				log.debug("get config from memory snapshot, dataId: {}, group: {}", dataId, group);
+				NacosSnapshotConfigManager.removeConfigSnapshot(dataId, group);
+				data = configSnapshot;
+			}
 			if (StringUtils.isEmpty(data)) {
 				log.warn(
 						"Ignore the empty nacos configuration and get it based on dataId[{}] & group[{}]",

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/client/NacosPropertySourceBuilder.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/client/NacosPropertySourceBuilder.java
@@ -83,13 +83,15 @@ public class NacosPropertySourceBuilder {
 			String fileExtension) {
 		String data = null;
 		try {
-			String configSnapshot = NacosSnapshotConfigManager.getConfigSnapshot(dataId, group);
+			String configSnapshot = NacosSnapshotConfigManager.getConfigSnapshot(dataId,
+					group);
 			if (StringUtils.isEmpty(configSnapshot)) {
 				log.debug("get config from nacos, dataId: {}, group: {}", dataId, group);
 				data = configService.getConfig(dataId, group, timeout);
 			}
 			else {
-				log.debug("get config from memory snapshot, dataId: {}, group: {}", dataId, group);
+				log.debug("get config from memory snapshot, dataId: {}, group: {}",
+						dataId, group);
 				NacosSnapshotConfigManager.removeConfigSnapshot(dataId, group);
 				data = configSnapshot;
 			}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/refresh/NacosContextRefresher.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/refresh/NacosContextRefresher.java
@@ -129,6 +129,7 @@ public class NacosContextRefresher
 							String configInfo) {
 						refreshCountIncrement();
 						nacosRefreshHistory.addRefreshRecord(dataId, group, configInfo);
+						NacosSnapshotConfigManager.putConfigSnapshot(dataId, group, configInfo);
 						applicationContext.publishEvent(
 								new RefreshEvent(this, null, "Refresh Nacos config"));
 						if (log.isDebugEnabled()) {

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/refresh/NacosContextRefresher.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/refresh/NacosContextRefresher.java
@@ -129,7 +129,8 @@ public class NacosContextRefresher
 							String configInfo) {
 						refreshCountIncrement();
 						nacosRefreshHistory.addRefreshRecord(dataId, group, configInfo);
-						NacosSnapshotConfigManager.putConfigSnapshot(dataId, group, configInfo);
+						NacosSnapshotConfigManager.putConfigSnapshot(dataId, group,
+								configInfo);
 						applicationContext.publishEvent(
 								new RefreshEvent(this, null, "Refresh Nacos config"));
 						if (log.isDebugEnabled()) {

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/refresh/NacosSnapshotConfigManager.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/refresh/NacosSnapshotConfigManager.java
@@ -1,7 +1,11 @@
 package com.alibaba.cloud.nacos.refresh;
 
+import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author: ruansheng
@@ -9,8 +13,10 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class NacosSnapshotConfigManager {
 
-	private static final Map<String, String> CONFIG_INFO_SNAPSHOT_MAP = new ConcurrentHashMap<>(8);
+	private static final Logger log = LoggerFactory.getLogger(NacosSnapshotConfigManager.class);
 
+	private static final Map<String, String> CONFIG_INFO_SNAPSHOT_MAP = new ConcurrentHashMap<>(8);
+	private static final int MAX_SNAPSHOT_COUNT = 100;
 
 	private static String formatConfigSnapshotKey(String dataId, String group) {
 		return dataId + "@" + group;
@@ -21,7 +27,19 @@ public class NacosSnapshotConfigManager {
 	}
 
 	public static void putConfigSnapshot(String dataId, String group, String configInfo) {
-		CONFIG_INFO_SNAPSHOT_MAP.put(formatConfigSnapshotKey(dataId, group), configInfo);
+		try {
+			// Theoretically, the capacity limit restriction will never be triggered.
+			// This portion of the code logic serves as an additional fault tolerance layer.
+			if (CONFIG_INFO_SNAPSHOT_MAP.size() > MAX_SNAPSHOT_COUNT) {
+				Iterator<Map.Entry<String, String>> iterator = CONFIG_INFO_SNAPSHOT_MAP.entrySet().iterator();
+				iterator.next();
+				iterator.remove();
+			}
+			CONFIG_INFO_SNAPSHOT_MAP.put(formatConfigSnapshotKey(dataId, group), configInfo);
+		}
+		catch (Exception e) {
+			log.warn("remove nacos config snapshot error", e);
+		}
 	}
 
 	public static void removeConfigSnapshot(String dataId, String group) {

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/refresh/NacosSnapshotConfigManager.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/refresh/NacosSnapshotConfigManager.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.alibaba.cloud.nacos.refresh;
 
 import java.util.Iterator;
@@ -11,11 +27,17 @@ import org.slf4j.LoggerFactory;
  * @author: ruansheng
  * @date: 2024-01-22
  */
-public class NacosSnapshotConfigManager {
+public final class NacosSnapshotConfigManager {
 
-	private static final Logger log = LoggerFactory.getLogger(NacosSnapshotConfigManager.class);
+	private NacosSnapshotConfigManager() {
+	}
 
-	private static final Map<String, String> CONFIG_INFO_SNAPSHOT_MAP = new ConcurrentHashMap<>(8);
+	private static final Logger log = LoggerFactory
+			.getLogger(NacosSnapshotConfigManager.class);
+
+	private static final Map<String, String> CONFIG_INFO_SNAPSHOT_MAP = new ConcurrentHashMap<>(
+			8);
+
 	private static final int MAX_SNAPSHOT_COUNT = 100;
 
 	private static String formatConfigSnapshotKey(String dataId, String group) {
@@ -29,13 +51,15 @@ public class NacosSnapshotConfigManager {
 	public static void putConfigSnapshot(String dataId, String group, String configInfo) {
 		try {
 			// Theoretically, the capacity limit restriction will never be triggered.
-			// This portion of the code logic serves as an additional fault tolerance layer.
+			// This portion of the code serves as an additional fault tolerance layer.
 			if (CONFIG_INFO_SNAPSHOT_MAP.size() > MAX_SNAPSHOT_COUNT) {
-				Iterator<Map.Entry<String, String>> iterator = CONFIG_INFO_SNAPSHOT_MAP.entrySet().iterator();
+				Iterator<Map.Entry<String, String>> iterator = CONFIG_INFO_SNAPSHOT_MAP
+						.entrySet().iterator();
 				iterator.next();
 				iterator.remove();
 			}
-			CONFIG_INFO_SNAPSHOT_MAP.put(formatConfigSnapshotKey(dataId, group), configInfo);
+			CONFIG_INFO_SNAPSHOT_MAP.put(formatConfigSnapshotKey(dataId, group),
+					configInfo);
 		}
 		catch (Exception e) {
 			log.warn("remove nacos config snapshot error", e);

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/refresh/NacosSnapshotConfigManager.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/refresh/NacosSnapshotConfigManager.java
@@ -1,0 +1,31 @@
+package com.alibaba.cloud.nacos.refresh;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author: ruansheng
+ * @date: 2024-01-22
+ */
+public class NacosSnapshotConfigManager {
+
+	private static final Map<String, String> CONFIG_INFO_SNAPSHOT_MAP = new ConcurrentHashMap<>(8);
+
+
+	private static String formatConfigSnapshotKey(String dataId, String group) {
+		return dataId + "@" + group;
+	}
+
+	public static String getConfigSnapshot(String dataId, String group) {
+		return CONFIG_INFO_SNAPSHOT_MAP.get(formatConfigSnapshotKey(dataId, group));
+	}
+
+	public static void putConfigSnapshot(String dataId, String group, String configInfo) {
+		CONFIG_INFO_SNAPSHOT_MAP.put(formatConfigSnapshotKey(dataId, group), configInfo);
+	}
+
+	public static void removeConfigSnapshot(String dataId, String group) {
+		CONFIG_INFO_SNAPSHOT_MAP.remove(formatConfigSnapshotKey(dataId, group));
+	}
+
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/refresh/NacosSnapshotConfigManager.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/refresh/NacosSnapshotConfigManager.java
@@ -44,8 +44,11 @@ public final class NacosSnapshotConfigManager {
 		return dataId + "@" + group;
 	}
 
-	public static String getConfigSnapshot(String dataId, String group) {
-		return CONFIG_INFO_SNAPSHOT_MAP.get(formatConfigSnapshotKey(dataId, group));
+	public static String getAndRemoveConfigSnapshot(String dataId, String group) {
+		String configInfo = CONFIG_INFO_SNAPSHOT_MAP
+				.get(formatConfigSnapshotKey(dataId, group));
+		removeConfigSnapshot(dataId, group);
+		return configInfo;
 	}
 
 	public static void putConfigSnapshot(String dataId, String group, String configInfo) {


### PR DESCRIPTION
### Describe what this PR does / why we need it
![image](https://github.com/alibaba/spring-cloud-alibaba/assets/24709538/06198271-8876-4bc9-88f6-6fabf7026a46)

### 改造逻辑：
1. 用户在 Nacos 更新配置，服务接受到更新后的配置内容，将收到的配置内容缓存到内存中
2. 向 Spring 容器发送一个 `RefreshEvent ` 刷新下上下文，`RefreshEvent` 监听器收到事件后开始触发上下文刷新逻辑
3. 根据 dataId + group 判断是否存在本地内存快照，如果存在本地快照则直接使用（快照取出后会直接被移除，避免占用内存），如果快照不存在则调用 Nacos Api 获取远程配置

### 其他说明
由于 Spring 在处理 RefreshEvent 的时候，并没有将 Event 原始数据传入后续的业务逻辑，所以这里单独声明了一个 Nacos 快照配置管理工具类管理 Nacos 临时配置
![image](https://github.com/alibaba/spring-cloud-alibaba/assets/24709538/9b536117-32d7-49d6-b15f-8a9f22b52c45)
