### PR TITLE
chore: update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,3 @@ sessionStore/
 # Maven ignore
 .flattened-pom.xml
 
-# AsciiDoc
-spring-cloud-alibaba-docs/**/*.html


### PR DESCRIPTION
`spring-cloud-alibaba-docs` module removed in https://github.com/alibaba/spring-cloud-alibaba/pull/3490.
