### PR TITLE
Upgrade the Spring Boot version to 3.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <spring.cloud.version>2023.0.1</spring.cloud.version>
 
         <!-- Spring Boot -->
-        <spring-boot.version>3.2.0</spring-boot.version>
+        <spring-boot.version>3.2.4</spring-boot.version>
 
         <curator.version>4.0.1</curator.version>
 


### PR DESCRIPTION


### Describe what this PR does / why we need it
Upgrade the Spring Boot version to 3.2.4, which is consistent with the Spring Boot version supported by Spring Cloud 2023.0.1

### Does this pull request fix one issue?


### Describe how you did it

Modify the spring boot. version  Version number in the pom.xml 

### Describe how to verify it


### Special notes for reviews
