### PR TITLE
docs: fix wrong dependency version in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ These artifacts are available from Maven Central and Spring Release repository v
         <dependency>
             <groupId>com.alibaba.cloud</groupId>
             <artifactId>spring-cloud-alibaba-dependencies</artifactId>
-            <version>2023.0.0.1-RC2</version>
+            <version>2023.0.1.0</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>


### PR DESCRIPTION
### Describe what this PR does / why we need it

The version `2023.0.0.1-RC2` of `spring-cloud-alibaba-dependencies` is not exists in maven central repository.

[mvnrepository](https://mvnrepository.com/artifact/com.alibaba.cloud/spring-cloud-alibaba-dependencies)

I changed it to the latest version.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

NONE

### Describe how you did it

See above

### Describe how to verify it

Just simple add it to my Java project with maven.

### Special notes for reviews

N/A