### PR TITLE
Fix: The dependency groupId of spring-ai-core in spring-cloud-starter-alibaba-ai module is not found.

### DIFF
--- a/spring-cloud-alibaba-dependencies/pom.xml
+++ b/spring-cloud-alibaba-dependencies/pom.xml
@@ -27,7 +27,7 @@
         <rocketmq.version>5.1.4</rocketmq.version>
 
         <!-- Spring AI -->
-        <spring.ai.version>0.8.1</spring.ai.version>
+        <spring.ai.version>1.0.0</spring.ai.version>
         <dashscope-sdk-java.version>2.14.0</dashscope-sdk-java.version>
 
         <!-- scheduling -->

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-ai/pom.xml
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-ai/pom.xml
@@ -34,7 +34,7 @@
 	<dependencies>
 
 		<dependency>
-			<groupId>org.springframework.ai</groupId>
+			<groupId>io.springboot.ai</groupId>
 			<artifactId>spring-ai-core</artifactId>
 		</dependency>
 


### PR DESCRIPTION
### Describe what this PR does / why we need it
Fixed an issue where spring.ai.core version update caused maven warehouse and Aliyun warehouse to not be found.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixed #3753

### Describe how you did it
 Modify the version information of spring.ai.version in spring-cloud-alibaba-dependencies/pom.xml to 1.0.0 or later.

### Describe how to verify it
You can implement Maven install locally, or you can remove the original spring-ai-core dependency and re-import a new spring-ai-core dependency.

### Special notes for reviews
The dependency can be replicated by importing spring-cloud-starter-alibaba-ai directly.