### PR TITLE
[2023.x] Fix nacos clusterName and extended properties

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigManager.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigManager.java
@@ -38,9 +38,6 @@ public class NacosConfigManager {
 
 	public NacosConfigManager(NacosConfigProperties nacosConfigProperties) {
 		this.nacosConfigProperties = nacosConfigProperties;
-		// Compatible with older code in NacosConfigProperties,It will be deleted in the
-		// future.
-		createConfigService(nacosConfigProperties);
 	}
 
 	/**

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigProperties.java
@@ -565,7 +565,7 @@ public class NacosConfigProperties {
 	 */
 	public Properties assembleConfigServiceProperties() {
 		Properties properties = new Properties();
-		properties.put(SERVER_ADDR, Objects.toString(this.serverAddr, DEFAULT_ADDRESS));
+		properties.put(SERVER_ADDR, Objects.toString(this.serverAddr, ""));
 		properties.put(USERNAME, Objects.toString(this.username, ""));
 		properties.put(PASSWORD, Objects.toString(this.password, ""));
 		properties.put(ENCODE, Objects.toString(this.encode, ""));
@@ -591,6 +591,12 @@ public class NacosConfigProperties {
 		}
 
 		enrichNacosConfigProperties(properties);
+
+		// set default value when serverAddr and endpoint is empty
+		if (StringUtils.isEmpty(this.serverAddr) && StringUtils.isEmpty(this.endpoint)) {
+			properties.put(SERVER_ADDR, DEFAULT_ADDRESS);
+		}
+
 		return properties;
 	}
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigProperties.java
@@ -101,6 +101,105 @@ public class NacosConfigProperties {
 	@Autowired
 	@JsonIgnore
 	private Environment environment;
+	/**
+	 * nacos config server address.
+	 */
+	private String serverAddr;
+	/**
+	 * the nacos authentication username.
+	 */
+	private String username;
+	/**
+	 * the nacos authentication password.
+	 */
+	private String password;
+	/**
+	 * encode for nacos config content.
+	 */
+	private String encode;
+	/**
+	 * nacos config group, group is config data meta info.
+	 */
+	private String group = "DEFAULT_GROUP";
+	/**
+	 * nacos config dataId prefix.
+	 */
+	private String prefix;
+	/**
+	 * the suffix of nacos config dataId, also the file extension of config content.
+	 */
+	private String fileExtension = "properties";
+	/**
+	 * timeout for get config from nacos.
+	 */
+	private int timeout = 3000;
+	/**
+	 * nacos maximum number of tolerable server reconnection errors.
+	 */
+	private String maxRetry;
+	/**
+	 * nacos get config long poll timeout.
+	 */
+	private String configLongPollTimeout;
+	/**
+	 * nacos get config failure retry time.
+	 */
+	private String configRetryTime;
+	/**
+	 * If you want to pull it yourself when the program starts to get the configuration
+	 * for the first time, and the registered Listener is used for future configuration
+	 * updates, you can keep the original code unchanged, just add the system parameter:
+	 * enableRemoteSyncConfig = "true" ( But there is network overhead); therefore we
+	 * recommend that you use {@link ConfigService#getConfigAndSignListener} directly.
+	 */
+	private boolean enableRemoteSyncConfig = false;
+	/**
+	 * endpoint for Nacos, the domain name of a service, through which the server address
+	 * can be dynamically obtained.
+	 */
+	private String endpoint;
+	/**
+	 * namespace, separation configuration of different environments.
+	 */
+	private String namespace;
+	/**
+	 * access key for namespace.
+	 */
+	private String accessKey;
+	/**
+	 * secret key for namespace.
+	 */
+	private String secretKey;
+	/**
+	 * role name for aliyun ram.
+	 */
+	private String ramRoleName;
+	/**
+	 * context path for nacos config server.
+	 */
+	private String contextPath;
+	/**
+	 * nacos config cluster name.
+	 */
+	private String clusterName;
+	/**
+	 * nacos config dataId name.
+	 */
+	private String name;
+	/**
+	 * a set of shared configurations .e.g:
+	 * spring.cloud.nacos.config.shared-configs[0]=xxx .
+	 */
+	private List<Config> sharedConfigs;
+	/**
+	 * a set of extensional configurations .e.g:
+	 * spring.cloud.nacos.config.extension-configs[0]=xxx .
+	 */
+	private List<Config> extensionConfigs;
+	/**
+	 * the master switch for refresh configuration, it default opened(true).
+	 */
+	private boolean refreshEnabled = true;
 
 	@PostConstruct
 	public void init() {
@@ -129,128 +228,6 @@ public class NacosConfigProperties {
 					environment.resolvePlaceholders("${spring.cloud.nacos.password:}"));
 		}
 	}
-
-	/**
-	 * nacos config server address.
-	 */
-	private String serverAddr;
-
-	/**
-	 * the nacos authentication username.
-	 */
-	private String username;
-
-	/**
-	 * the nacos authentication password.
-	 */
-	private String password;
-
-	/**
-	 * encode for nacos config content.
-	 */
-	private String encode;
-
-	/**
-	 * nacos config group, group is config data meta info.
-	 */
-	private String group = "DEFAULT_GROUP";
-
-	/**
-	 * nacos config dataId prefix.
-	 */
-	private String prefix;
-
-	/**
-	 * the suffix of nacos config dataId, also the file extension of config content.
-	 */
-	private String fileExtension = "properties";
-
-	/**
-	 * timeout for get config from nacos.
-	 */
-	private int timeout = 3000;
-
-	/**
-	 * nacos maximum number of tolerable server reconnection errors.
-	 */
-	private String maxRetry;
-
-	/**
-	 * nacos get config long poll timeout.
-	 */
-	private String configLongPollTimeout;
-
-	/**
-	 * nacos get config failure retry time.
-	 */
-	private String configRetryTime;
-
-	/**
-	 * If you want to pull it yourself when the program starts to get the configuration
-	 * for the first time, and the registered Listener is used for future configuration
-	 * updates, you can keep the original code unchanged, just add the system parameter:
-	 * enableRemoteSyncConfig = "true" ( But there is network overhead); therefore we
-	 * recommend that you use {@link ConfigService#getConfigAndSignListener} directly.
-	 */
-	private boolean enableRemoteSyncConfig = false;
-
-	/**
-	 * endpoint for Nacos, the domain name of a service, through which the server address
-	 * can be dynamically obtained.
-	 */
-	private String endpoint;
-
-	/**
-	 * namespace, separation configuration of different environments.
-	 */
-	private String namespace;
-
-	/**
-	 * access key for namespace.
-	 */
-	private String accessKey;
-
-	/**
-	 * secret key for namespace.
-	 */
-	private String secretKey;
-
-	/**
-	 * role name for aliyun ram.
-	 */
-	private String ramRoleName;
-
-	/**
-	 * context path for nacos config server.
-	 */
-	private String contextPath;
-
-	/**
-	 * nacos config cluster name.
-	 */
-	private String clusterName;
-
-	/**
-	 * nacos config dataId name.
-	 */
-	private String name;
-
-	/**
-	 * a set of shared configurations .e.g:
-	 * spring.cloud.nacos.config.shared-configs[0]=xxx .
-	 */
-	private List<Config> sharedConfigs;
-
-	/**
-	 * a set of extensional configurations .e.g:
-	 * spring.cloud.nacos.config.extension-configs[0]=xxx .
-	 */
-	private List<Config> extensionConfigs;
-
-	/**
-	 * the master switch for refresh configuration, it default opened(true).
-	 */
-	private boolean refreshEnabled = true;
 
 	// todo sts support
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/refresh/NacosContextRefresher.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/refresh/NacosContextRefresher.java
@@ -54,13 +54,9 @@ public class NacosContextRefresher
 			.getLogger(NacosContextRefresher.class);
 
 	private static final AtomicLong REFRESH_COUNT = new AtomicLong(0);
-
-	private NacosConfigProperties nacosConfigProperties;
-
 	private final boolean isRefreshEnabled;
-
 	private final NacosRefreshHistory nacosRefreshHistory;
-
+	private NacosConfigProperties nacosConfigProperties;
 	private ConfigService configService;
 
 	private NacosConfigManager configManager;
@@ -77,6 +73,14 @@ public class NacosContextRefresher
 		this.nacosConfigProperties = nacosConfigManager.getNacosConfigProperties();
 		this.nacosRefreshHistory = refreshHistory;
 		this.isRefreshEnabled = this.nacosConfigProperties.isRefreshEnabled();
+	}
+
+	public static long getRefreshCount() {
+		return REFRESH_COUNT.get();
+	}
+
+	public static void refreshCountIncrement() {
+		REFRESH_COUNT.incrementAndGet();
 	}
 
 	@Override
@@ -162,14 +166,6 @@ public class NacosContextRefresher
 			return false;
 		}
 		return isRefreshEnabled;
-	}
-
-	public static long getRefreshCount() {
-		return REFRESH_COUNT.get();
-	}
-
-	public static void refreshCountIncrement() {
-		REFRESH_COUNT.incrementAndGet();
 	}
 
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/refresh/NacosContextRefresher.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/refresh/NacosContextRefresher.java
@@ -61,7 +61,9 @@ public class NacosContextRefresher
 
 	private final NacosRefreshHistory nacosRefreshHistory;
 
-	private final ConfigService configService;
+	private ConfigService configService;
+
+	private NacosConfigManager configManager;
 
 	private ApplicationContext applicationContext;
 
@@ -71,9 +73,9 @@ public class NacosContextRefresher
 
 	public NacosContextRefresher(NacosConfigManager nacosConfigManager,
 			NacosRefreshHistory refreshHistory) {
+		this.configManager = nacosConfigManager;
 		this.nacosConfigProperties = nacosConfigManager.getNacosConfigProperties();
 		this.nacosRefreshHistory = refreshHistory;
-		this.configService = nacosConfigManager.getConfigService();
 		this.isRefreshEnabled = this.nacosConfigProperties.isRefreshEnabled();
 	}
 
@@ -127,6 +129,9 @@ public class NacosContextRefresher
 					}
 				});
 		try {
+			if (configService == null && configManager != null) {
+				configService = configManager.getConfigService();
+			}
 			configService.addListener(dataKey, groupKey, listener);
 			log.info("[Nacos Config] Listening config: dataId={}, group={}", dataKey,
 					groupKey);

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
@@ -134,7 +134,7 @@ public class NacosDiscoveryProperties {
 	/**
 	 * cluster name for nacos .
 	 */
-	private String clusterName = "DEFAULT";
+	private String clusterName;
 
 	/**
 	 * group name for nacos.
@@ -692,7 +692,8 @@ public class NacosDiscoveryProperties {
 
 		properties.put(ACCESS_KEY, accessKey);
 		properties.put(SECRET_KEY, secretKey);
-		properties.put(CLUSTER_NAME, clusterName);
+		// only used for instance.setClusterName()
+//		properties.put(CLUSTER_NAME, clusterName);
 		properties.put(NAMING_LOAD_CACHE_AT_START, namingLoadCacheAtStart);
 
 		enrichNacosDiscoveryProperties(properties);

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
@@ -28,7 +28,6 @@ import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-
 import com.alibaba.cloud.commons.lang.StringUtils;
 import com.alibaba.cloud.nacos.event.NacosDiscoveryInfoChangedEvent;
 import com.alibaba.cloud.nacos.util.InetIPv6Utils;
@@ -49,7 +48,6 @@ import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
 
 import static com.alibaba.nacos.api.PropertyKeyConst.ACCESS_KEY;
-import static com.alibaba.nacos.api.PropertyKeyConst.CLUSTER_NAME;
 import static com.alibaba.nacos.api.PropertyKeyConst.ENDPOINT;
 import static com.alibaba.nacos.api.PropertyKeyConst.ENDPOINT_PORT;
 import static com.alibaba.nacos.api.PropertyKeyConst.NAMESPACE;
@@ -70,14 +68,12 @@ import static com.alibaba.nacos.api.PropertyKeyConst.USERNAME;
 @ConfigurationProperties("spring.cloud.nacos.discovery")
 public class NacosDiscoveryProperties {
 
-	private static final Logger log = LoggerFactory
-			.getLogger(NacosDiscoveryProperties.class);
-
 	/**
 	 * Prefix of {@link NacosDiscoveryProperties}.
 	 */
 	public static final String PREFIX = "spring.cloud.nacos.discovery";
-
+	private static final Logger log = LoggerFactory
+			.getLogger(NacosDiscoveryProperties.class);
 	private static final Pattern PATTERN = Pattern.compile("-(\\w)");
 
 	private static final String IPV4 = "IPv4";


### PR DESCRIPTION
1. DiscoveryProperties
 * NamingService
    [X] 去掉默认值
    [X] 去掉设置
  * Instance
    [X] clusterName 继续保留

2. Endpoint 与 server address
  [X] 修改逻辑：如果 server addr和endpoint都为空，才给server adder设置默认值

4. 修复 enrich 扩展参数无法读取问题