### PR TITLE
fallback Method throw exception but seata does not rollback

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/feign/SentinelInvocationHandler.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/feign/SentinelInvocationHandler.java
@@ -124,7 +124,7 @@ public class SentinelInvocationHandler implements InvocationHandler {
 							throw new AssertionError(e);
 						}
 						catch (InvocationTargetException e) {
-							throw new AssertionError(e.getCause());
+							throw e.getCause();
 						}
 					}
 					else {


### PR DESCRIPTION
### Describe what this PR does / why we need it
i use seata to perform global transaction, use openfeign to invoke other microservice, and use sentinel to do fallbacks. in my fallback method if i throw an customerized Exception, this exception will be wrapped into `AssertionError`, then seata will not rollback correctly, beacuse seate only rollback for Exception defined in @GlobalTransactional(rollbackFor=Exception.class).

### Does this pull request fix one issue?
yes
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
when i throw the original excetion, seata rollbacks correctly 

### Describe how to verify it
throw new RuntimeException('wharever') in fallback method, seata rollbacks correctly

### Special notes for reviews
-