### PR TITLE
docs: fix wrong dependency version in README-zh.md

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -77,7 +77,7 @@ Spring Cloud 使用 Maven 来构建，最快的使用方式是将本项目 clone
         <dependency>
             <groupId>com.alibaba.cloud</groupId>
             <artifactId>spring-cloud-alibaba-dependencies</artifactId>
-            <version>2023.0.0.1-RC2</version>
+            <version>2023.0.1.0</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>


### PR DESCRIPTION
The version 2023.0.0.1-RC2 of spring-cloud-alibaba-dependencies is not exists in maven central repository.
Keep the Maven version consistent with the version in the README.md.