### PR TITLE
feature 2023.x: Expand NacosLoadBalancer to conveniently support custom service list filtering and load balancing algorithms

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/DefaultLoadBalancerAlgorithm.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/DefaultLoadBalancerAlgorithm.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.nacos.loadbalancer;
+
+import java.util.List;
+
+import com.alibaba.cloud.nacos.balancer.NacosBalancer;
+
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.loadbalancer.Request;
+import org.springframework.core.Ordered;
+
+/**
+ * This is a default implementation of load balancing algorithm.
+ * use {@link com.alibaba.cloud.nacos.balancer.NacosBalancer}
+ *
+ * @author <a href="mailto:zhangbin1010@qq.com">zhangbinhub</a>
+ */
+public class DefaultLoadBalancerAlgorithm implements LoadBalancerAlgorithm {
+	@Override
+	public String getServiceId() {
+		return LoadBalancerAlgorithm.DEFAULT_SERVICE_ID;
+	}
+
+	@Override
+	public ServiceInstance getInstance(Request<?> request, List<ServiceInstance> serviceInstances) {
+		return NacosBalancer.getHostByRandomWeight3(serviceInstances);
+	}
+
+	@Override
+	public int getOrder() {
+		return Ordered.LOWEST_PRECEDENCE;
+	}
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/DefaultLoadBalancerAlgorithm.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/DefaultLoadBalancerAlgorithm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 the original author or authors.
+ * Copyright 2023-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/LoadBalancerAlgorithm.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/LoadBalancerAlgorithm.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.nacos.loadbalancer;
+
+import java.util.List;
+
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.loadbalancer.Request;
+import org.springframework.core.Ordered;
+
+/**
+ * Load Balancer algorithm interface.
+ * When expanding the load balancing algorithm, implement this interface and register it as a bean.
+ *
+ * @author <a href="mailto:zhangbin1010@qq.com">zhangbinhub</a>
+ */
+public interface LoadBalancerAlgorithm extends Ordered {
+	/**
+	 * default service id.
+	 */
+	String DEFAULT_SERVICE_ID = "defaultServiceId";
+
+	String getServiceId();
+
+	ServiceInstance getInstance(Request<?> request, List<ServiceInstance> serviceInstances);
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/LoadBalancerAlgorithm.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/LoadBalancerAlgorithm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 the original author or authors.
+ * Copyright 2023-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/LoadBalancerNacosAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/LoadBalancerNacosAutoConfiguration.java
@@ -20,6 +20,7 @@ import com.alibaba.cloud.nacos.ConditionalOnNacosDiscoveryEnabled;
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.loadbalancer.annotation.LoadBalancerClients;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
@@ -32,5 +33,8 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnNacosDiscoveryEnabled
 @LoadBalancerClients(defaultConfiguration = NacosLoadBalancerClientConfiguration.class)
 public class LoadBalancerNacosAutoConfiguration {
-
+	@Bean
+	public LoadBalancerAlgorithm defaultLoadBalancerAlgorithm() {
+		return new DefaultLoadBalancerAlgorithm();
+	}
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/ServiceInstanceFilter.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/ServiceInstanceFilter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.nacos.loadbalancer;
+
+import java.util.List;
+
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.loadbalancer.Request;
+import org.springframework.core.Ordered;
+
+/**
+ * Service Instance Filter interface.
+ * When custom service instance list filter, implement this interface and register it as a bean.
+ *
+ * @author <a href="mailto:zhangbin1010@qq.com">zhangbinhub</a>
+ */
+public interface ServiceInstanceFilter extends Ordered {
+	List<ServiceInstance> filterInstance(Request<?> request, List<ServiceInstance> serviceInstances);
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/ServiceInstanceFilter.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/ServiceInstanceFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 the original author or authors.
+ * Copyright 2023-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryLoadBalancerConfigurationTest.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryLoadBalancerConfigurationTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.nacos.discovery;
+
+import com.alibaba.cloud.nacos.NacosServiceAutoConfiguration;
+import com.alibaba.cloud.nacos.loadbalancer.LoadBalancerAlgorithm;
+import com.alibaba.cloud.nacos.loadbalancer.LoadBalancerNacosAutoConfiguration;
+import com.alibaba.cloud.nacos.loadbalancer.NacosLoadBalancerClientConfiguration;
+import com.alibaba.cloud.nacos.registry.NacosServiceRegistryAutoConfiguration;
+import com.alibaba.cloud.nacos.util.UtilIPv6AutoConfiguration;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationConfiguration;
+import org.springframework.cloud.commons.util.UtilAutoConfiguration;
+import org.springframework.cloud.loadbalancer.config.LoadBalancerAutoConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author <a href="mailto:zhangbin1010@qq.com">zhangbinhub</a>
+ **/
+public class NacosDiscoveryLoadBalancerConfigurationTest {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(
+					AutoServiceRegistrationConfiguration.class,
+					NacosServiceRegistryAutoConfiguration.class,
+					UtilAutoConfiguration.class,
+					UtilIPv6AutoConfiguration.class,
+					NacosServiceAutoConfiguration.class,
+					NacosDiscoveryAutoConfiguration.class,
+					NacosDiscoveryClientConfiguration.class,
+					LoadBalancerAutoConfiguration.class, this.getClass()));
+
+	@Test
+	public void testNacosLoadBalancerEnabled() {
+		contextRunner.withPropertyValues("spring.cloud.loadbalancer.nacos.enabled=true")
+				.withConfiguration(AutoConfigurations.of(
+						LoadBalancerNacosAutoConfiguration.class,
+						NacosLoadBalancerClientConfiguration.class))
+				.run(context -> {
+					assertThat(context).hasSingleBean(LoadBalancerAlgorithm.class);
+					assertThat(context).hasBean("nacosLoadBalancer");
+				});
+	}
+
+	@Test
+	public void testNacosLoadBalancerDisabled() {
+		contextRunner.withPropertyValues("spring.cloud.loadbalancer.nacos.enabled=false")
+				.withConfiguration(AutoConfigurations.of(
+						LoadBalancerNacosAutoConfiguration.class,
+						NacosLoadBalancerClientConfiguration.class))
+				.run(context -> {
+					assertThat(context).doesNotHaveBean(LoadBalancerAlgorithm.class);
+					assertThat(context).doesNotHaveBean("nacosLoadBalancer");
+				});
+	}
+
+}


### PR DESCRIPTION
Expand NacosLoadBalancer to conveniently support custom service list filtering and load balancing algorithms

### Describe what this PR does / why we need it

At present, neither the official loadbalancer provided by Spring Cloud nor the existing NacosLoadBalancer can meet personalized load balancing requirements.
- The official offers RandomLoadBalancer and RoundRobinLoadBalancer
- SCA provides a NacosLoadBalancer based on Nacos weights

In order to conveniently and quickly meet various personalized load balancing needs, NacosLoadBalancer has been extended to support custom service list filters and custom load balancing algorithms.

### Does this pull request fix one issue?

NONE

### Describe how you did it

1. Add interface `com.alibaba.cloud.nacos.loadbalancer.ServiceInstanceFilter` to expand the service list filter.
2. Add interface `com.alibaba.cloud.nacos.loadbalancer.LoadBalancerAlgorithm` to expand the load balancing algorithm.
3. Add class `com.alibaba.cloud.nacos.loadbalancer.DefaultLoadBalancerAlgorithm` implementation of default load balancing algorithm, and register as a Bean in LoadBalancerNacosAutoConfiguration.
4. Adjust the construction method and creation process of `NacosLoadBalancer`, and add relevant logic for custom service list filtering and custom load balancing algorithm in the getInstanceResponse method.

### Describe how to verify it

1. Set the environment variable `spring.cloud.loadbalance.nacos.enabled` to `true` to enable NacosLoadBalancer.
2. When custom service instance list filter, implement the interface `ServiceInstanceFilter` and register it as a bean.
3. When expanding the load balancing algorithm, implement the interface `LoadBalancerAlgorithm` and register it as a bean.

### Special notes for reviews

NONE