### PR TITLE
[2023.x] upgrade spring cloud to 2023.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
 
     <properties>
         <!-- Project revision -->
-        <revision>2023.0.3.0</revision>
+        <revision>2023.0.1.2</revision>
 
         <!-- Spring Cloud -->
         <spring.cloud.version>2023.0.3</spring.cloud.version>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-build</artifactId>
-        <version>4.1.0</version>
+        <version>4.1.3</version>
         <relativePath/>
     </parent>
 
@@ -80,17 +80,13 @@
 
     <properties>
         <!-- Project revision -->
-        <revision>2023.0.1.2</revision>
+        <revision>2023.0.3.0</revision>
 
         <!-- Spring Cloud -->
-        <spring.cloud.version>2023.0.1</spring.cloud.version>
+        <spring.cloud.version>2023.0.3</spring.cloud.version>
 
         <!-- Spring Boot -->
-        <spring-boot.version>3.2.4</spring-boot.version>
-
-        <curator.version>4.0.1</curator.version>
-
-
+        <spring-boot.version>3.2.7</spring-boot.version>
 
         <!-- Maven Plugin Versions -->
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
@@ -103,7 +99,7 @@
         <flatten-maven-plugin.version>1.2.7</flatten-maven-plugin.version>
         <gmavenplus-plugin.version>1.6</gmavenplus-plugin.version>
         <jacoco.version>0.8.8</jacoco.version>
-        <native-maven-plugin.version>0.9.19</native-maven-plugin.version>
+        <native-maven-plugin.version>0.10.2</native-maven-plugin.version>
     </properties>
 
     <modules>

--- a/spring-cloud-alibaba-dependencies/pom.xml
+++ b/spring-cloud-alibaba-dependencies/pom.xml
@@ -18,7 +18,7 @@
     <description>Spring Cloud Alibaba Dependencies</description>
 
     <properties>
-        <revision>2023.0.3.0</revision>
+        <revision>2023.0.1.2</revision>
         <sentinel.version>1.8.8</sentinel.version>
         <nacos.client.version>2.3.2</nacos.client.version>
         <seata.version>2.0.0</seata.version>

--- a/spring-cloud-alibaba-dependencies/pom.xml
+++ b/spring-cloud-alibaba-dependencies/pom.xml
@@ -18,7 +18,7 @@
     <description>Spring Cloud Alibaba Dependencies</description>
 
     <properties>
-        <revision>2023.0.1.2</revision>
+        <revision>2023.0.3.0</revision>
         <sentinel.version>1.8.8</sentinel.version>
         <nacos.client.version>2.3.2</nacos.client.version>
         <seata.version>2.0.0</seata.version>

--- a/spring-cloud-alibaba-tests/nacos-tests/pom.xml
+++ b/spring-cloud-alibaba-tests/nacos-tests/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-bootstrap</artifactId>
-            <version>3.1.1</version>
+            <version>4.1.4</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/spring-cloud-alibaba-tests/spring-cloud-alibaba-test-support/pom.xml
+++ b/spring-cloud-alibaba-tests/spring-cloud-alibaba-test-support/pom.xml
@@ -17,14 +17,14 @@
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <junit.version>5.7.2</junit.version>
+        <junit.version>5.10.2</junit.version>
         <selenium.version>3.141.59</selenium.version>
         <lombok.version>1.18.30</lombok.version>
         <assertj-core.version>3.20.2</assertj-core.version>
         <awaitility.version>4.1.0</awaitility.version>
-        <kotlin.version>1.5.30</kotlin.version>
-        <slf4j-api.version>1.7.32</slf4j-api.version>
-        <log4j-slf4j-impl.version>2.14.1</log4j-slf4j-impl.version>
+        <kotlin.version>1.9.24</kotlin.version>
+        <slf4j-api.version>2.0.13</slf4j-api.version>
+        <log4j-slf4j-impl.version>2.23.1</log4j-slf4j-impl.version>
         <guava.version>31.1-jre</guava.version>
         <hamcrest.version>1.3</hamcrest.version>
     </properties>


### PR DESCRIPTION
### Describe what this PR does / why we need it

Upgrade spring cloud to 2023.0.3, keep as consistent as possible with the Spring Cloud version.

### Does this pull request fix one issue?

NONE

### Describe how you did it

- remove curator.version properties in pom.xml
- upgrade dependency version
  - spring cloud to 2023.0.3
  - spring cloud build to 4.1.3
  - spring boot to 3.2.7
  - native-maven-plugin version to 0.10.2
- upgrade test support dependency
  - junit to 5.10.2
  - kotlin to 1.9.24
  - slf4j to 2.0.13
  - log4j-slf4j-impl to 2.23.1
  - spring cloud starter bootstrap to 4.1.4

### Describe how to verify it

NONE

### Special notes for reviews

NONE
