### PR TITLE
fix: Hide nacos password when nacos-registration fails

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosRegistration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosRegistration.java
@@ -24,6 +24,7 @@ import com.alibaba.cloud.nacos.NacosDiscoveryProperties;
 import com.alibaba.nacos.api.naming.PreservedMetadataKeys;
 import jakarta.annotation.PostConstruct;
 
+import org.springframework.beans.BeanUtils;
 import org.springframework.cloud.client.DefaultServiceInstance;
 import org.springframework.cloud.client.discovery.ManagementServerPortUtils;
 import org.springframework.cloud.client.serviceregistry.Registration;
@@ -172,8 +173,12 @@ public class NacosRegistration implements Registration {
 
 	@Override
 	public String toString() {
+		NacosDiscoveryProperties safeProp = new NacosDiscoveryProperties();
+		BeanUtils.copyProperties(safeProp, nacosDiscoveryProperties);
+		safeProp.setUsername("******");
+		safeProp.setPassword("******");
 		return "NacosRegistration{" + "nacosDiscoveryProperties="
-				+ nacosDiscoveryProperties + '}';
+				+ safeProp + '}';
 	}
 
 }


### PR DESCRIPTION
### Describe what this PR does / why we need it

控制台日志可能被各类组件抽取到不同的地方，因此在控制台日志中隐藏 Nacos 帐号密码等敏感信息。
See #3837
