### PR TITLE
Updated Nacos Config

### DIFF
--- a/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/nacos-discovery-spring-cloud-config-client-example/src/main/resources/application.yml
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/nacos-discovery-spring-cloud-config-client-example/src/main/resources/application.yml
@@ -1,1 +1,8 @@
 config: config-from-yml
+logging:
+  level:
+    com:
+      alibaba:
+        cloud:
+          nacos:
+            client=DEBUG:

--- a/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/nacos-discovery-spring-cloud-config-client-example/src/main/resources/bootstrap.yml
+++ b/spring-cloud-alibaba-examples/nacos-example/nacos-discovery-example/nacos-discovery-spring-cloud-config-client-example/src/main/resources/bootstrap.yml
@@ -1,14 +1,19 @@
 spring:
   application:
-    name: client
+    name: apu-gateway
+  profiles:
+    active: prod
   cloud:
     nacos:
       username: nacos
       password: nacos
       discovery:
         server-addr: 127.0.0.1:8848
+      config:
+        server-addr: 127.0.0.1:8848
+        namespace: b3404bc0-d7dc-4855-b519-570ed34cdaa7  # Example namespace ID
+        group: PROD
+        file-extension: yaml
     config:
       discovery:
         enabled: true
-  profiles:
-    active: dev


### PR DESCRIPTION
Addressing issue #3855, 

Fixed and Set up configuration of Nacos Config.

1. Added `spring.cloud.nacos.config.server-addr` to specify the Nacos config server address.
2. Added `spring.cloud.nacos.config.file-extension: yaml` to indicate that you're using YAML config files.
3. Added `spring.cloud.nacos.config.group: PROD` to match the group mentioned in your error message.
4. Consider adding a `namespace` if you're using one in Nacos.
5. The `spring.profiles.active` is set to dev, which means it will look for a config file named client-dev.yml in Nacos.
6.Added config `logging.level.com.alibaba.cloud.nacos.client=DEBUG` in _application.yml_ 