### PR TITLE
fix bug: deserialization of chinese encoding characters in xml is incorrect

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigAutoConfiguration.java
@@ -16,12 +16,18 @@
 
 package com.alibaba.cloud.nacos;
 
+import com.alibaba.cloud.nacos.parser.NacosDataParserHandler;
 import com.alibaba.cloud.nacos.refresh.NacosContextRefresher;
 import com.alibaba.cloud.nacos.refresh.NacosRefreshHistory;
 import com.alibaba.cloud.nacos.refresh.SmartConfigurationPropertiesRebinder;
 import com.alibaba.cloud.nacos.refresh.condition.ConditionalOnNonDefaultBehavior;
+import com.alibaba.nacos.api.common.Constants;
+import com.alibaba.nacos.common.utils.StringUtils;
 
+import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactoryUtils;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.SearchStrategy;
@@ -44,11 +50,30 @@ public class NacosConfigAutoConfiguration {
 	public NacosConfigProperties nacosConfigProperties(ApplicationContext context) {
 		if (context.getParent() != null
 				&& BeanFactoryUtils.beanNamesForTypeIncludingAncestors(
-						context.getParent(), NacosConfigProperties.class).length > 0) {
+				context.getParent(), NacosConfigProperties.class).length > 0) {
 			return BeanFactoryUtils.beanOfTypeIncludingAncestors(context.getParent(),
 					NacosConfigProperties.class);
 		}
 		return new NacosConfigProperties();
+	}
+
+	@Bean
+	@ConditionalOnBean(NacosConfigProperties.class)
+	public BeanPostProcessor nacosConfigBeanPostProcessor() {
+		return new BeanPostProcessor() {
+
+			@Override
+			public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+				if (bean instanceof NacosConfigProperties nacosConfigProperties) {
+					String encode = nacosConfigProperties.getEncode();
+					if (StringUtils.isBlank(encode)) {
+						encode = Constants.ENCODE;
+					}
+					NacosDataParserHandler.getInstance().setEncode(encode);
+				}
+				return BeanPostProcessor.super.postProcessAfterInitialization(bean, beanName);
+			}
+		};
 	}
 
 	@Bean

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigAutoConfiguration.java
@@ -50,7 +50,7 @@ public class NacosConfigAutoConfiguration {
 	public NacosConfigProperties nacosConfigProperties(ApplicationContext context) {
 		if (context.getParent() != null
 				&& BeanFactoryUtils.beanNamesForTypeIncludingAncestors(
-				context.getParent(), NacosConfigProperties.class).length > 0) {
+						context.getParent(), NacosConfigProperties.class).length > 0) {
 			return BeanFactoryUtils.beanOfTypeIncludingAncestors(context.getParent(),
 					NacosConfigProperties.class);
 		}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/parser/NacosDataParserHandler.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/parser/NacosDataParserHandler.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import com.alibaba.cloud.nacos.utils.NacosConfigUtils;
+import com.alibaba.nacos.api.common.Constants;
 
 import org.springframework.boot.env.OriginTrackedMapPropertySource;
 import org.springframework.boot.env.PropertiesPropertySourceLoader;
@@ -49,6 +50,8 @@ public final class NacosDataParserHandler {
 	private static final String DEFAULT_EXTENSION = "properties";
 
 	private static List<PropertySourceLoader> propertySourceLoaders;
+
+	private String encode = Constants.ENCODE;
 
 	private NacosDataParserHandler() {
 		propertySourceLoaders = SpringFactoriesLoader
@@ -85,7 +88,7 @@ public final class NacosDataParserHandler {
 			}
 			else {
 				nacosByteArrayResource = new NacosByteArrayResource(
-						configValue.getBytes(), configName);
+						configValue.getBytes(encode), configName);
 			}
 			nacosByteArrayResource.setFilename(getFileName(configName, extension));
 			List<PropertySource<?>> propertySourceList = propertySourceLoader
@@ -155,6 +158,10 @@ public final class NacosDataParserHandler {
 			}
 		}
 		return name + DOT + extension;
+	}
+
+	public void setEncode(String encode) {
+		this.encode = encode;
 	}
 
 	public static NacosDataParserHandler getInstance() {


### PR DESCRIPTION
### Describe what this PR does / why we need it
1. nacos config center 中配置xml，包含中文字符。
2. app启动参数配置了-Dfile.encoding=gb18030时，启动报错。
3. 当-Dfile.encoding=utf-8时，启动正常。

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
NONE
### Describe how you did it
在 NacosDataParserHandler 中引入 encode 字段

### Describe how to verify it
#### 复现
1. 在配置中心新建一个config.xml，内容为
```xml
<a>中文</a>
```
2. 项目启动参数配置：-Dfile.encoding=gb18030
3. 增加配置项：spring.cloud.nacos.config.encode=gb18030
注意：这里配置utf-8也会报错

### Special notes for reviews
目前我没想到有更好的方法修复它，你们可以自己探索其它的方法。这个问题值得关注一下。