### PR TITLE
fix bug: deserialization of chinese encoding characters in xml/yml would be incorrect

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/parser/NacosDataParserHandler.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/parser/NacosDataParserHandler.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import com.alibaba.cloud.nacos.utils.NacosConfigUtils;
+import com.alibaba.nacos.api.common.Constants;
 
 import org.springframework.boot.env.OriginTrackedMapPropertySource;
 import org.springframework.boot.env.PropertiesPropertySourceLoader;
@@ -85,7 +86,7 @@ public final class NacosDataParserHandler {
 			}
 			else {
 				nacosByteArrayResource = new NacosByteArrayResource(
-						configValue.getBytes(), configName);
+						configValue.getBytes(Constants.ENCODE), configName);
 			}
 			nacosByteArrayResource.setFilename(getFileName(configName, extension));
 			List<PropertySource<?>> propertySourceList = propertySourceLoader


### PR DESCRIPTION
### Describe what this PR does / why we need it
nacos config center 中配置xml/yml，包含中文字符。
app启动参数配置了-Dfile.encoding=gb18030时，启动报错。
当-Dfile.encoding=utf-8时，启动正常。

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
NONE
### Describe how you did it
在 NacosDataParserHandler getBytes时，指定UTF-8编码

### Describe how to verify it
#### 复现
1. 在配置中心新建一个config.xml，内容为
```xml
<a>中文</a>
```
2.项目启动参数配置：-Dfile.encoding=gb18030

### Special notes for reviews
目前我没想到有更好的方法修复它，你们可以自己探索其它的方法。这个问题值得关注一下。
hope this PR will be help.