### PR TITLE
feat: Springboot supports graceful shutdown of Nacos

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -24,14 +24,14 @@ jobs:
     name: Integration Testing
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'adopt'
       - name: Dependies Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
@@ -229,6 +229,13 @@ public class NacosDiscoveryProperties {
 	 */
 	private boolean failFast = true;
 
+	/**
+	 * graceful shutdown wait time. Time unit: millisecond.
+	 * default is 10s
+	 * When the Springboot shutdown hook is executed, remove the Nacos service, wait for 10 seconds, and then Tomcat rejects the request
+	 */
+	private Integer gracefulShutdownWaitTime = 10*1000;
+
 	@Autowired
 	private InetIPv6Utils inetIPv6Utils;
 
@@ -556,6 +563,14 @@ public class NacosDiscoveryProperties {
 
 	public void setFailFast(boolean failFast) {
 		this.failFast = failFast;
+	}
+
+	public Integer getGracefulShutdownWaitTime() {
+		return gracefulShutdownWaitTime;
+	}
+
+	public void setGracefulShutdownWaitTime(Integer gracefulShutdownWaitTime) {
+		this.gracefulShutdownWaitTime = gracefulShutdownWaitTime;
 	}
 
 	@Override

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
@@ -234,7 +234,7 @@ public class NacosDiscoveryProperties {
 	 * default is 10s
 	 * When the Springboot shutdown hook is executed, remove the Nacos service, wait for 10 seconds, and then Tomcat rejects the request
 	 */
-	private Integer gracefulShutdownWaitTime = 10*1000;
+	private Integer gracefulShutdownWaitTime = 10 * 1000;
 
 	@Autowired
 	private InetIPv6Utils inetIPv6Utils;

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosAutoServiceRegistration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosAutoServiceRegistration.java
@@ -17,7 +17,9 @@
 package com.alibaba.cloud.nacos.registry;
 
 import com.alibaba.cloud.commons.lang.StringUtils;
+import com.alibaba.cloud.nacos.NacosDiscoveryProperties;
 import com.alibaba.cloud.nacos.event.NacosDiscoveryInfoChangedEvent;
+import com.alibaba.nacos.common.utils.ThreadUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,6 +27,7 @@ import org.springframework.cloud.client.serviceregistry.AbstractAutoServiceRegis
 import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationProperties;
 import org.springframework.cloud.client.serviceregistry.Registration;
 import org.springframework.cloud.client.serviceregistry.ServiceRegistry;
+import org.springframework.context.event.ContextClosedEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.util.Assert;
 
@@ -112,6 +115,14 @@ public class NacosAutoServiceRegistration
 	private void restart() {
 		this.stop();
 		this.start();
+	}
+
+	@EventListener(ContextClosedEvent.class)
+	public void onContextClosedEvent(ContextClosedEvent event) {
+		NacosDiscoveryProperties configuration = (NacosDiscoveryProperties) getConfiguration();
+		Integer gracefulShutdownWaitTime = configuration.getGracefulShutdownWaitTime();
+		ThreadUtils.sleep(gracefulShutdownWaitTime);
+        stop();
 	}
 
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosAutoServiceRegistration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosAutoServiceRegistration.java
@@ -119,10 +119,10 @@ public class NacosAutoServiceRegistration
 
 	@EventListener(ContextClosedEvent.class)
 	public void onContextClosedEvent(ContextClosedEvent event) {
+		stop();
 		NacosDiscoveryProperties configuration = (NacosDiscoveryProperties) getConfiguration();
 		Integer gracefulShutdownWaitTime = configuration.getGracefulShutdownWaitTime();
 		ThreadUtils.sleep(gracefulShutdownWaitTime);
-        stop();
 	}
 
 }


### PR DESCRIPTION

# 遇到的问题
发版期间，springboot 是先拒绝请求，再下线nacos注册的实例，导致gateway有部分流量打到服务，服务会拒绝请求

`	@PreDestroy
	public void destroy() {
		stop();
	}`

这是目前的关机逻辑，这个钩子会在springweb拒绝请求后再执行

# 解决办法
	springboot 下有SpringApplicationShutdownHook，会比PreDestroy回调更早，并且回调hook事件期间springweb 依然可以正常处理请求，我们可以在下线nacos后，休眠10s时间吞吐掉网关转发来的请求（拿到上一个已下线节点的请求），

目前生产环境测试发版不会抖动