### PR TITLE
bugfix: NacosConfigAutoConfiguration is not eligible for getting proc…

### DIFF
--- a/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigAutoConfiguration.java
@@ -62,7 +62,7 @@ public class NacosConfigAutoConfiguration {
 	}
 
 	@Bean
-	public NacosAnnotationProcessor nacosAnnotationProcessor() {
+	public static NacosAnnotationProcessor nacosAnnotationProcessor() {
 		return new NacosAnnotationProcessor();
 	}
 


### PR DESCRIPTION
### Describe what this PR does / why we need it

refer to issue #3954

When using Nacos for configuration management in a Spring Cloud Alibaba (2023.x) application, a warning message appears indicating that the Bean 'com.alibaba.cloud.nacos.NacosConfigAutoConfiguration' of type NacosConfigAutoConfiguration is not eligible for processing by all BeanPostProcessors, such as auto-proxying. This warning is caused by the nacosAnnotationProcessor BeanPostProcessor being declared through a non-static factory method. It is recommended to declare this BeanPostProcessor as static to resolve the issue.

### Does this pull request fix one issue?

Fixes #3954

### Describe how you did it

Added `static` modifier to the nacosAnnotationProcessor method to fix the warning indicating that the Bean 'com.alibaba.cloud.nacos.NacosConfigAutoConfiguration' is not eligible for processing by all BeanPostProcessors.

### Describe how to verify it

1. `git clone https://github.com/alibaba/spring-cloud-alibaba -b 2023.x`
2. run a nacos-server@2.4.2,add config below, dataId:`nacos-config-example.properties`, group: `DEFAULT_GROUP` 

```properties
spring.cloud.nacos.config.serveraddr=127.0.0.1:8848
spring.cloud.nacos.config.prefix=PREFIX
spring.cloud.nacos.config.group=GROUP
spring.cloud.nacos.config.namespace=NAMESPACE
```
3. open `spring-cloud-alibaba-examples/nacos-example/nacos-config-example` and change `server-addr`,`username`,`password` in  `application.yaml`
4. find the main class `NacosConfigApplication` and execute the main method to start the application. The warning has disappeared, and then visit `http://127.0.0.1:18084/nacos/bean` retrieves the expected information, indicating that the program is running normally and has successfully obtained the configuration information.
![image](https://github.com/user-attachments/assets/049f3cc3-6ddc-4b87-afc2-7fbd3cbf9764)


### Special notes for reviews
