### PR TITLE
fix #3995 Configuring logging.level in bootstrap. yml file does not work

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigSpringCloudAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigSpringCloudAutoConfiguration.java
@@ -19,6 +19,7 @@ package com.alibaba.cloud.nacos;
 import com.alibaba.cloud.nacos.configdata.NacosConfigRefreshEventListener;
 import com.alibaba.cloud.nacos.refresh.SmartConfigurationPropertiesRebinder;
 import com.alibaba.cloud.nacos.refresh.condition.ConditionalOnNonDefaultBehavior;
+
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.SearchStrategy;
 import org.springframework.cloud.context.properties.ConfigurationPropertiesBeans;

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigSpringCloudAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigSpringCloudAutoConfiguration.java
@@ -16,11 +16,9 @@
 
 package com.alibaba.cloud.nacos;
 
-import com.alibaba.cloud.nacos.client.NacosPropertySourceLocator;
 import com.alibaba.cloud.nacos.configdata.NacosConfigRefreshEventListener;
 import com.alibaba.cloud.nacos.refresh.SmartConfigurationPropertiesRebinder;
 import com.alibaba.cloud.nacos.refresh.condition.ConditionalOnNonDefaultBehavior;
-
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.SearchStrategy;
 import org.springframework.cloud.context.properties.ConfigurationPropertiesBeans;
@@ -44,12 +42,6 @@ public class NacosConfigSpringCloudAutoConfiguration {
 		// If using default behavior, not use SmartConfigurationPropertiesRebinder.
 		// Minimize te possibility of making mistakes.
 		return new SmartConfigurationPropertiesRebinder(beans);
-	}
-
-	@Bean
-	public NacosPropertySourceLocator nacosPropertySourceLocator(
-			NacosConfigManager nacosConfigManager) {
-		return new NacosPropertySourceLocator(nacosConfigManager);
 	}
 
 	@Bean(name = "nacosConfigSpringCloudRefreshEventListener")

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigSpringCloudBootstrapConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigSpringCloudBootstrapConfiguration.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.cloud.nacos;
 
+import com.alibaba.cloud.nacos.client.NacosPropertySourceLocator;
 import com.alibaba.cloud.nacos.refresh.SmartConfigurationPropertiesRebinder;
 import com.alibaba.cloud.nacos.refresh.condition.ConditionalOnNonDefaultBehavior;
 
@@ -34,6 +35,13 @@ import org.springframework.context.annotation.Configuration;
 @Configuration(proxyBeanMethods = false)
 @Conditional(NacosConfigEnabledCondition.class)
 public class NacosConfigSpringCloudBootstrapConfiguration {
+
+	// fix #3995
+	@Bean
+	public NacosPropertySourceLocator nacosPropertySourceLocator(
+			NacosConfigManager nacosConfigManager) {
+		return new NacosPropertySourceLocator(nacosConfigManager);
+	}
 
 	/**
 	 * Compatible with bootstrap way to start.

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,2 @@
 com.alibaba.cloud.nacos.NacosConfigSpringCloudAutoConfiguration
+com.alibaba.cloud.nacos.NacosConfigSpringCloudBootstrapConfiguration


### PR DESCRIPTION
### Describe what this PR does / why we need it

在 Bootstrap 环境下，没有找到任何 `PropertySourceLocator`。Spring Cloud 就不会加载 Bootstrap.xml 中的相关配置了，特别是 logging.level。源代码如下：

```java
private void doInitialize(ConfigurableApplicationContext applicationContext) {
	List<PropertySource<?>> composite = new ArrayList<>();
	AnnotationAwareOrderComparator.sort(this.propertySourceLocators);
	boolean empty = true;
	ConfigurableEnvironment environment = applicationContext.getEnvironment();
        // PropertySourceLocator 注入时机滞后，这里 propertySourceLocators 的数量为 0
	for (PropertySourceLocator locator : this.propertySourceLocators) {
		Collection<PropertySource<?>> source = locator.locateCollection(environment);
		if (source == null || source.size() == 0) {
			continue;
		}
		List<PropertySource<?>> sourceList = new ArrayList<>();
		for (PropertySource<?> p : source) {
			if (p instanceof EnumerablePropertySource<?> enumerable) {
				sourceList.add(new BootstrapPropertySource<>(enumerable));
			}
			else {
				sourceList.add(new SimpleBootstrapPropertySource(p));
			}
		}
		logger.info("Located property source: " + sourceList);
		composite.addAll(sourceList);
		empty = false;
	}
        // 因为 propertySourceLocators  是空的，所以下面的操作都不会进行
       //  所以就不会 setLogLevels，导致日志不生效。
	if (!empty) {
		MutablePropertySources propertySources = environment.getPropertySources();
		String logConfig = environment.resolvePlaceholders("${logging.config:}");
		LogFile logFile = LogFile.get(environment);
		for (PropertySource<?> p : environment.getPropertySources()) {
			if (p.getName().startsWith(BOOTSTRAP_PROPERTY_SOURCE_NAME)) {
				propertySources.remove(p.getName());
			}
		}
		insertPropertySources(propertySources, composite);
		reinitializeLoggingSystem(environment);
		setLogLevels(applicationContext, environment);
		handleProfiles(environment);
	}
}
```

因此，只要保证在 Bootstrap 阶段，让 `com.alibaba.cloud.nacos.client.NacosPropertySourceLocator`  注入即可。这与 2023.0.1.2 版本，即没有提取 spring-alibaba-nacos-config 模块前的版本逻辑一致。

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

Fixes #3395

### Describe how you did it

主要做了两项变更

1. 把 `NacosPropertySourceLocator` Bean 的配置，从 `NacosConfigSpringCloudAutoConfiguration` 迁移至 `NacosConfigSpringCloudBootstrapConfiguration` 配置中。因为 spring.factories 中已经配置了 `NacosConfigSpringCloudBootstrapConfiguration` 在 Bootstrap 阶段配置

2. 在 org.springframework.boot.autoconfigure.AutoConfiguration.imports 中添加了 `NacosConfigSpringCloudBootstrapConfiguration`  配置，以保证其正确注入。

### Describe how to verify it

在配置文件层面验证方法：

在 boostrap.yml 添加以下 Spring Boot 标准配置，可以控制日志的显示

```yaml
logging:
  file:
    name: logs/${spring.application.name}.log
  level:
    root: info
    cn.herodotus: debug
    org.springframework.security: info
    org.springframework.web: debug
    com.alicp.jetcache: debug
    org.springframework.cloud.bus: info
    org.apache.kafka: off
```

在调试代码方面：

Debug 代码，在 `org.springframework.cloud.bootstrap.config.PropertySourceBootstrapConfiguration`  类中设置断点，查看启动时该类 中的 `propertySourceLocators` list 中是否已经注入了 `NacosPropertySourceLocator`

### Special notes for reviews
 