### PR TITLE
fix:#4020 The log was incorrectly printed: "A cross-cluster call occurs"

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/NacosLoadBalancer.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/NacosLoadBalancer.java
@@ -16,22 +16,12 @@
 
 package com.alibaba.cloud.nacos.loadbalancer;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
-import javax.annotation.PostConstruct;
-
 import com.alibaba.cloud.commons.lang.StringUtils;
 import com.alibaba.cloud.nacos.NacosDiscoveryProperties;
 import com.alibaba.cloud.nacos.util.InetIPv6Utils;
 import com.alibaba.nacos.client.naming.utils.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import reactor.core.publisher.Mono;
-
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.loadbalancer.DefaultResponse;
@@ -41,6 +31,14 @@ import org.springframework.cloud.client.loadbalancer.Response;
 import org.springframework.cloud.loadbalancer.core.NoopServiceInstanceListSupplier;
 import org.springframework.cloud.loadbalancer.core.ReactorServiceInstanceLoadBalancer;
 import org.springframework.cloud.loadbalancer.core.ServiceInstanceListSupplier;
+import reactor.core.publisher.Mono;
+
+import javax.annotation.PostConstruct;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * see original.
@@ -152,13 +150,12 @@ public class NacosLoadBalancer implements ReactorServiceInstanceLoadBalancer {
 						}).collect(Collectors.toList());
 				if (!CollectionUtils.isEmpty(sameClusterInstances)) {
 					instancesToChoose = sameClusterInstances;
+				} else {
+					log.warn("A cross-cluster call occurs，name = {}, clusterName = {}, instance = {}",
+							serviceId, clusterName, serviceInstances);
 				}
 			}
-			else {
-				log.warn(
-						"A cross-cluster call occurs，name = {}, clusterName = {}, instance = {}",
-						serviceId, clusterName, serviceInstances);
-			}
+
 			instancesToChoose = this.filterInstanceByIpType(instancesToChoose);
 
 			// Filter the service list sequentially based on the order number


### PR DESCRIPTION
### Describe what this PR does / why we need it
Due to this pull request（https://github.com/alibaba/spring-cloud-alibaba/pull/3771）, the default value for com.alibaba.cloud.nacos.NacosDiscoveryProperties#clusterName was removed. When the user does not explicitly specify a clusterName, the method com.alibaba.cloud.nacos.loadbalancer.NacosLoadBalancer#getInstanceResponse will directly enter the else block, causing the message "A cross-cluster call occurs" to be logged incorrectly.

### Does this pull request fix one issue?
Fixes #4020 
### Describe how you did it


### Describe how to verify it


### Special notes for reviews
