### PR TITLE
fix: NacosDataParserHandler yaml配置解析默认编码错误

### DIFF
--- a/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/parser/NacosDataParserHandler.java
+++ b/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/parser/NacosDataParserHandler.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.cloud.nacos.parser;
 
+import java.nio.charset.StandardCharsets;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -30,6 +31,7 @@ import com.alibaba.cloud.nacos.utils.NacosConfigUtils;
 import org.springframework.boot.env.OriginTrackedMapPropertySource;
 import org.springframework.boot.env.PropertiesPropertySourceLoader;
 import org.springframework.boot.env.PropertySourceLoader;
+import org.springframework.boot.env.YamlPropertySourceLoader;
 import org.springframework.core.env.EnumerablePropertySource;
 import org.springframework.core.env.PropertySource;
 import org.springframework.core.io.support.SpringFactoriesLoader;
@@ -82,6 +84,12 @@ public final class NacosDataParserHandler {
 				nacosByteArrayResource = new NacosByteArrayResource(
 						NacosConfigUtils.selectiveConvertUnicode(configValue).getBytes(),
 						configName);
+			}
+			else if (propertySourceLoader instanceof YamlPropertySourceLoader) {
+				// YamlPropertySourceLoader internal only support use unicode,
+				// The default encoding for Chinese windows system is GBK, need to transform
+				nacosByteArrayResource = new NacosByteArrayResource(
+						configValue.getBytes(StandardCharsets.UTF_8), configName);
 			}
 			else {
 				nacosByteArrayResource = new NacosByteArrayResource(


### PR DESCRIPTION
### Describe what this PR does / why we need it
中文的操作系统默认编码是GBK，Yaml解析只支持Unicode编码，默认编码不一致导致使用了配置中心的服务无法正常启动

### Does this pull request fix one issue?
NONE

### Describe how you did it

针对yaml配置获取bytes时指定UTF-8编码

### Describe how to verify it
配置中心新增yaml配置，本地获取配置内容，要求本地默认编码非Unicode，且启动时未通过`-Dfile.encoding`指定VM默认编码

### Special notes for reviews
NONE
