### PR TITLE
更新scheduling的依赖版本，并屏蔽不需要推送的文件

### DIFF
--- a/spring-cloud-alibaba-dependencies/pom.xml
+++ b/spring-cloud-alibaba-dependencies/pom.xml
@@ -26,8 +26,8 @@
         <rocketmq.version>5.3.1</rocketmq.version>
 
         <!-- scheduling -->
-        <shedlock.version>4.23.0</shedlock.version>
-        <schedulerx.worker.version>1.11.4</schedulerx.worker.version>
+        <shedlock.version>5.10.0</shedlock.version>
+        <schedulerx.worker.version>1.13.1</schedulerx.worker.version>
 
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/spring-cloud-alibaba-examples/spring-cloud-scheduling-example/src/main/resources/application-schedulerx.yaml
+++ b/spring-cloud-alibaba-examples/spring-cloud-scheduling-example/src/main/resources/application-schedulerx.yaml
@@ -15,3 +15,6 @@ spring:
 #        aliyun-access-key: XXXXXXXXXXXX
 #        aliyun-secret-key: XXXXXXXXXXXX
 #        task-model-default: standalone
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-schedulerx/src/main/java/com/alibaba/cloud/scheduling/schedulerx/SchedulerxConfigurations.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-schedulerx/src/main/java/com/alibaba/cloud/scheduling/schedulerx/SchedulerxConfigurations.java
@@ -160,11 +160,11 @@ public class SchedulerxConfigurations {
 
 		@Bean
 		public SchedulerxSchedulingConfigurer schedulerxSchedulingConfigurer() {
-			return new SchedulerxSchedulingConfigurer();
+			return new SchedulerxSchedulingConfigurer(noOpScheduler(), true);
 		}
 
 		@Bean
-		public SchedulerxAnnotationBeanPostProcessor schedulerxAnnotationBeanPostProcessor() {
+		public static SchedulerxAnnotationBeanPostProcessor schedulerxAnnotationBeanPostProcessor() {
 			return new SchedulerxAnnotationBeanPostProcessor();
 		}
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-schedulerx/src/main/java/com/alibaba/cloud/scheduling/schedulerx/SchedulerxProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-schedulerx/src/main/java/com/alibaba/cloud/scheduling/schedulerx/SchedulerxProperties.java
@@ -181,7 +181,7 @@ public class SchedulerxProperties implements InitializingBean {
 	 */
 	private String label;
 
-	private String labelPath = "/etc/podinfo/annotations";
+	private String labelPath = "/etc/podinfo/labels";
 
 	/**
 	 * enableCgroupMetrics.

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-schedulerx/src/main/java/com/alibaba/cloud/scheduling/schedulerx/service/ScheduledJobSyncConfigurer.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-schedulerx/src/main/java/com/alibaba/cloud/scheduling/schedulerx/service/ScheduledJobSyncConfigurer.java
@@ -33,7 +33,7 @@ import com.alibaba.schedulerx.scheduling.annotation.SchedulerX;
 import com.alibaba.schedulerx.worker.domain.SpringScheduleProfile;
 import com.alibaba.schedulerx.worker.log.LogFactory;
 import com.alibaba.schedulerx.worker.log.Logger;
-import com.alibaba.schedulerx.worker.processor.springscheduling.SchedulerxSchedulingConfigurer;
+import com.alibaba.schedulerx.worker.processor.springscheduling.SchedulerxJobRegister;
 
 import org.springframework.aop.framework.AopProxyUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -63,9 +63,6 @@ public class ScheduledJobSyncConfigurer implements SchedulingConfigurer {
 
 	@Autowired
 	private SchedulerxProperties properties;
-
-	@Autowired
-	private SchedulerxSchedulingConfigurer schedulerxSchedulingConfigurer;
 
 	@Value("${" + SchedulerxProperties.CONFIG_PREFIX + ".task-overwrite:false}")
 	private Boolean overwrite = false;
@@ -175,7 +172,7 @@ public class ScheduledJobSyncConfigurer implements SchedulingConfigurer {
 			}
 
 			// 获取仅SchedulerX注解任务
-			Collection<Pair<Object, Method>> schedulerXTasks = schedulerxSchedulingConfigurer.getSchedulerXTaskTargets();
+			Collection<Pair<Object, Method>> schedulerXTasks = SchedulerxJobRegister.getInstance().getSchedulerXTaskTargets();
 			if (schedulerXTasks != null && schedulerXTasks.size() > 0) {
 				for (Pair<Object, Method> task : schedulerXTasks) {
 					JobProperty jobProperty = convertToJobProperty(null, task.getFirst(), task.getSecond());


### PR DESCRIPTION
### Describe what this PR does / why we need it
本 PR 对 scheduling 模块中进行了版本升级，并同步完成了相关配置和初始化逻辑的适配工作。
该改动旨在确保系统兼容最新组件 API，同时为后续维护与升级提供基础。

### Does this pull request fix one issue?
NONE

### Describe how you did it
升级了 schedulerx2-worker 和 shedlock 的依赖版本；
更新了spring-cloud-starter-alibaba-schedulerx的相关内容使其适配新版本

### Describe how to verify it
配置相关参数后，启动 spring-cloud-scheduling-example 模块，验证调度任务是否能正常注册与触发；

### Special notes for reviews
NONE