### PR TITLE
Enable @ConditionalOnLoadBalancerNacos by default, as Ribbon has been…

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/ConditionalOnLoadBalancerNacos.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/loadbalancer/ConditionalOnLoadBalancerNacos.java
@@ -25,7 +25,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD})
-@ConditionalOnProperty(value = "spring.cloud.loadbalancer.nacos.enabled", havingValue = "true")
+@ConditionalOnProperty(value = "spring.cloud.loadbalancer.nacos.enabled", havingValue = "true", matchIfMissing = true)
 public @interface ConditionalOnLoadBalancerNacos {
 
 }


### PR DESCRIPTION
### Describe what this PR does / why we need it

Avoid requiring users to manually configure `spring.cloud.loadbalancer.nacos.enabled=true` in app configuration files such as application.yml.
Instead, use Spring Boot auto-configuration to set up the load balancer.
Since the Spring Cloud Alibaba Nacos Discovery starter has removed Ribbon support, the only available load balancer is Spring Cloud LoadBalancer — it should be enabled by default.


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
