### PR TITLE
feat: disable HealthIndicator for Nacos by default

### DIFF
--- a/spring-cloud-alibaba-examples/nacos-example/readme-zh.md
+++ b/spring-cloud-alibaba-examples/nacos-example/readme-zh.md
@@ -325,6 +325,9 @@ SecretKey|spring.cloud.nacos.config.secret-key||
 接入点|spring.cloud.nacos.config.endpoint||地域的某个服务的入口域名，通过此域名可以动态地拿到服务端地址
 是否开启监听和自动刷新|spring.cloud.nacos.config.refresh-enabled|true|
 集群服务名|spring.cloud.nacos.config.cluster-name||
+是否开启 Nacos Config 的 Health Indicator|spring.nacos.config.health-indicator.enabled|false|
+是否开启 Nacos Discovery 的 Health Indicator|spring.cloud.nacos.discovery.health-indicator.enabled|false|
+
 
 ### Spring Cloud Alibaba Nacos Discovery
 

--- a/spring-cloud-alibaba-examples/nacos-example/readme.md
+++ b/spring-cloud-alibaba-examples/nacos-example/readme.md
@@ -321,6 +321,8 @@ Relative path | spring. Cloud. Nacos. Config. Context-path | | Relative path of 
 Access point | spring. Cloud. Nacos. Config. Endpoint | | The domain name of a service in a region. The server address can be obtained dynamically through this domain name
 Whether to enable listening and automatic refresh | spring. Cloud. Nacos. Config. Refresh -enabled | true |
 Cluster service name | spring. Cloud. Nacos. Config. Cluster -name | |
+Whether to enable nacos-config health indicator |spring.nacos.config.health-indicator.enabled|false|
+Whether to enable nacos-discovery health indicator |spring.cloud.nacos.discovery.health-indicator.enabled|false|
 
 ### Spring Cloud Alibaba Nacos Discovery
 

--- a/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/endpoint/NacosConfigEndpointAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/endpoint/NacosConfigEndpointAutoConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnable
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
@@ -54,6 +55,7 @@ public class NacosConfigEndpointAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
+	@ConditionalOnProperty(name = "spring.nacos.config.health-indicator.enabled", havingValue = "true", matchIfMissing = false)
 	@ConditionalOnEnabledHealthIndicator("nacos-config")
 	public NacosConfigHealthIndicator nacosConfigHealthIndicator() {
 		return new NacosConfigHealthIndicator(nacosConfigManager.getConfigService());

--- a/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -100,6 +100,12 @@
       "type": "com.alibaba.cloud.nacos.configdata.ConfigPreference",
       "defaultValue": "local",
       "description": "Config preference."
+    },
+    {
+      "name": "spring.nacos.config.health-indicator.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "whether to enable nacos-config health indicator."
     }
   ]
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/endpoint/NacosDiscoveryEndpointAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/endpoint/NacosDiscoveryEndpointAutoConfiguration.java
@@ -27,6 +27,7 @@ import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -51,6 +52,7 @@ public class NacosDiscoveryEndpointAutoConfiguration {
 	}
 
 	@Bean
+	@ConditionalOnProperty(name = "spring.cloud.nacos.discovery.health-indicator.enabled", havingValue = "true", matchIfMissing = false)
 	@ConditionalOnEnabledHealthIndicator("nacos-discovery")
 	public HealthIndicator nacosDiscoveryHealthIndicator(NacosServiceManager nacosServiceManager) {
 		return new NacosDiscoveryHealthIndicator(nacosServiceManager);

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -80,5 +80,11 @@
       "type": "java.lang.Boolean",
       "defaultValue": false,
       "description": "Integrate LoadBalancer or not."
+    },
+    {
+      "name": "spring.cloud.nacos.discovery.health-indicator.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "whether to enable nacos-discovery health indicator."
     }
 ]}


### PR DESCRIPTION
### Describe what this PR does / why we need it

For users unfamiliar with Nacos HealthIndicator, enabling it by default could lead to health check failures on the /actuator/health/ endpoint, impacting production applications. Therefore, it's now disabled by default. Users familiar with this mechanism may opt to enable it explicitly if needed.

### Does this pull request fix one issue?

Fixes #3535

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

Add @ConditionalOnProperty

### Describe how to verify it

To validate this configuration, simply add the following dependency:

```xml
<dependency>
    <groupId>org.springframework.boot</groupId>
    <artifactId>spring-boot-starter-actuator</artifactId>
</dependency>
```

Then access the Actuator health check endpoint at /actuator/health to verify the implementation.

### Special notes for reviews
