### PR TITLE
fix: avoid exceptions and repeated waits during Nacos client graceful…

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosAutoServiceRegistration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosAutoServiceRegistration.java
@@ -17,9 +17,7 @@
 package com.alibaba.cloud.nacos.registry;
 
 import com.alibaba.cloud.commons.lang.StringUtils;
-import com.alibaba.cloud.nacos.NacosDiscoveryProperties;
 import com.alibaba.cloud.nacos.event.NacosDiscoveryInfoChangedEvent;
-import com.alibaba.nacos.common.utils.ThreadUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,7 +25,6 @@ import org.springframework.cloud.client.serviceregistry.AbstractAutoServiceRegis
 import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationProperties;
 import org.springframework.cloud.client.serviceregistry.Registration;
 import org.springframework.cloud.client.serviceregistry.ServiceRegistry;
-import org.springframework.context.event.ContextClosedEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.util.Assert;
 
@@ -116,13 +113,4 @@ public class NacosAutoServiceRegistration
 		this.stop();
 		this.start();
 	}
-
-	@EventListener(ContextClosedEvent.class)
-	public void onContextClosedEvent(ContextClosedEvent event) {
-		stop();
-		NacosDiscoveryProperties configuration = (NacosDiscoveryProperties) getConfiguration();
-		Integer gracefulShutdownWaitTime = configuration.getGracefulShutdownWaitTime();
-		ThreadUtils.sleep(gracefulShutdownWaitTime);
-	}
-
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosGracefulShutdownDelegate.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosGracefulShutdownDelegate.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.nacos.registry;
+
+import com.alibaba.cloud.nacos.NacosDiscoveryProperties;
+import com.alibaba.nacos.common.utils.ThreadUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.lang.NonNull;
+
+/**
+ * @author <a href="mailto:uuuyuqi@gmail.com">uuuyuqi</a>
+ */
+public class NacosGracefulShutdownDelegate implements ApplicationListener<ContextClosedEvent>, ApplicationContextAware {
+
+	private static final Logger log = LoggerFactory.getLogger(NacosGracefulShutdownDelegate.class);
+
+	private final NacosAutoServiceRegistration autoServiceRegistration;
+
+	private final NacosDiscoveryProperties nacosDiscoveryProperties;
+
+	private ApplicationContext applicationContext;
+
+	public NacosGracefulShutdownDelegate(NacosAutoServiceRegistration autoServiceRegistration,
+		NacosDiscoveryProperties nacosDiscoveryProperties) {
+		this.autoServiceRegistration = autoServiceRegistration;
+		this.nacosDiscoveryProperties = nacosDiscoveryProperties;
+	}
+
+	@Override
+	public void setApplicationContext(@NonNull ApplicationContext applicationContext) throws BeansException {
+		this.applicationContext = applicationContext;
+	}
+
+	@Override
+	public void onApplicationEvent(@NonNull ContextClosedEvent event) {
+		// should NOT be executed if ContextClosedEvent published by sub contexts
+		if (!applicationContext.equals(event.getApplicationContext())) {
+			log.debug("Nacos client graceful shutdown will NOT be executed "
+					+ "for Spring context source: {}", event.getApplicationContext());
+			return;
+		}
+
+		doGracefulShutdown();
+	}
+
+	protected void doGracefulShutdown() {
+		try {
+			autoServiceRegistration.stop();
+			Integer gracefulShutdownWaitTime = this.nacosDiscoveryProperties.getGracefulShutdownWaitTime();
+			if (gracefulShutdownWaitTime != null && gracefulShutdownWaitTime > 0) {
+				ThreadUtils.sleep(gracefulShutdownWaitTime);
+			}
+		}
+		catch (Throwable t) {
+			log.error("Error occurred while performing Nacos client graceful shutdown", t);
+		}
+	}
+
+	@Override
+	public boolean supportsAsyncExecution() {
+		// need wait for graceful shutdown
+		return false;
+	}
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosServiceRegistryAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosServiceRegistryAutoConfiguration.java
@@ -76,4 +76,11 @@ public class NacosServiceRegistryAutoConfiguration {
 				autoServiceRegistrationProperties, registration);
 	}
 
+	@Bean
+	@ConditionalOnBean(NacosAutoServiceRegistration.class)
+	public NacosGracefulShutdownDelegate nacosGracefulShutdownDelegate(
+			NacosAutoServiceRegistration nacosAutoServiceRegistration,
+			NacosDiscoveryProperties nacosDiscoveryProperties) {
+		return new NacosGracefulShutdownDelegate(nacosAutoServiceRegistration, nacosDiscoveryProperties);
+	}
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/registry/NacosGracefulShutdownDelegateTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/registry/NacosGracefulShutdownDelegateTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.nacos.registry;
+
+import com.alibaba.cloud.nacos.NacosDiscoveryProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.event.ContextClosedEvent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author <a href="mailto:uuuyuqi@gmail.com">uuuyuqi</a>
+ */
+@ExtendWith(MockitoExtension.class)
+public class NacosGracefulShutdownDelegateTests {
+
+	@Mock
+	private NacosAutoServiceRegistration autoServiceRegistration;
+
+	@Mock
+	private NacosDiscoveryProperties nacosDiscoveryProperties;
+
+	@Mock
+	private ApplicationContext applicationContext;
+
+	@InjectMocks
+	private NacosGracefulShutdownDelegate delegate;
+
+	@BeforeEach
+	void setUp() {
+		delegate.setApplicationContext(applicationContext);
+	}
+
+	@Test
+	public void sameContextShouldTriggerStop() {
+		when(nacosDiscoveryProperties.getGracefulShutdownWaitTime()).thenReturn(0);
+
+		delegate.onApplicationEvent(new ContextClosedEvent(applicationContext));
+
+		verify(autoServiceRegistration).stop();
+	}
+
+	@Test
+	public void differentContextShouldNotTriggerStop() {
+		delegate.onApplicationEvent(new ContextClosedEvent(Mockito.mock(ApplicationContext.class)));
+
+		verify(autoServiceRegistration, never()).stop();
+	}
+
+	@Test
+	public void stopExceptionShouldBeSwallowed() {
+		doThrow(new RuntimeException("boom")).when(autoServiceRegistration).stop();
+
+		delegate.onApplicationEvent(new ContextClosedEvent(applicationContext));
+
+		verify(autoServiceRegistration).stop();
+	}
+
+	@Test
+	public void supportsAsyncExecutionShouldBeFalse() {
+		assertThat(delegate.supportsAsyncExecution()).isFalse();
+	}
+}
+
+


### PR DESCRIPTION
fix: avoid exceptions and repeated waits during Nacos client graceful shutdown

Change-Id: I0beac29df87beb4629299db63fbb9277961c1664


### Describe what this PR does / why we need it
refer to: https://github.com/alibaba/spring-cloud-alibaba/issues/4064

### Does this pull request fix one issue?
Fixes #4064

### Describe how you did it
Refactored the Nacos client’s graceful-shutdown logic by extracting a dedicated event listener to handle it.

### Describe how to verify it
Added unit tests and performed local verification.
