### PR TITLE
seata 模块增加 WebFlux 相关适配，修复在非Servlet环境下的bug

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+root = true
+
+[*.java]
+indent_style = tab
+indent_size = 4
+continuation_indent_size = 8
+
+[*.groovy]
+indent_style = tab
+indent_size = 4
+continuation_indent_size = 8
+
+[*.xml]
+indent_style = tab
+indent_size = 4
+continuation_indent_size = 8
+
+[*.yml]
+indent_style = space
+indent_size = 2
+
+[*.yaml]
+indent_style = space
+indent_size = 2

--- a/spring-cloud-alibaba-examples/integrated-example/integrated-account/src/main/java/com/alibaba/cloud/integration/account/service/impl/AccountServiceImpl.java
+++ b/spring-cloud-alibaba-examples/integrated-example/integrated-account/src/main/java/com/alibaba/cloud/integration/account/service/impl/AccountServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 the original author or authors.
+ * Copyright 2013-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import com.alibaba.cloud.integration.account.mapper.AccountMapper;
 import com.alibaba.cloud.integration.account.service.AccountService;
 import com.alibaba.cloud.integration.common.BusinessException;
 import com.alibaba.cloud.integration.common.Result;
-import io.seata.core.context.RootContext;
+import org.apache.seata.core.context.RootContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/spring-cloud-alibaba-examples/integrated-example/integrated-order/src/main/java/com/alibaba/cloud/integration/order/service/impl/OrderServiceImpl.java
+++ b/spring-cloud-alibaba-examples/integrated-example/integrated-order/src/main/java/com/alibaba/cloud/integration/order/service/impl/OrderServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 the original author or authors.
+ * Copyright 2013-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,8 +27,8 @@ import com.alibaba.cloud.integration.order.feign.dto.AccountDTO;
 import com.alibaba.cloud.integration.order.feign.dto.StorageDTO;
 import com.alibaba.cloud.integration.order.mapper.OrderMapper;
 import com.alibaba.cloud.integration.order.service.OrderService;
-import io.seata.core.context.RootContext;
-import io.seata.spring.annotation.GlobalTransactional;
+import org.apache.seata.core.context.RootContext;
+import org.apache.seata.spring.annotation.GlobalTransactional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/spring-cloud-alibaba-examples/integrated-example/integrated-storage/src/main/java/com/alibaba/cloud/integration/storage/service/impl/StorageServiceImpl.java
+++ b/spring-cloud-alibaba-examples/integrated-example/integrated-storage/src/main/java/com/alibaba/cloud/integration/storage/service/impl/StorageServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 the original author or authors.
+ * Copyright 2013-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import com.alibaba.cloud.integration.common.BusinessException;
 import com.alibaba.cloud.integration.common.Result;
 import com.alibaba.cloud.integration.storage.mapper.StorageMapper;
 import com.alibaba.cloud.integration.storage.service.StorageService;
-import io.seata.core.context.RootContext;
+import org.apache.seata.core.context.RootContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/spring-cloud-alibaba-examples/seata-example/account-service/src/main/java/com/alibaba/cloud/examples/AccountController.java
+++ b/spring-cloud-alibaba-examples/seata-example/account-service/src/main/java/com/alibaba/cloud/examples/AccountController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 the original author or authors.
+ * Copyright 2013-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package com.alibaba.cloud.examples;
 
 import java.util.Random;
 
-import io.seata.core.context.RootContext;
+import org.apache.seata.core.context.RootContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/spring-cloud-alibaba-examples/seata-example/business-service/src/main/java/com/alibaba/cloud/examples/HomeController.java
+++ b/spring-cloud-alibaba-examples/seata-example/business-service/src/main/java/com/alibaba/cloud/examples/HomeController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 the original author or authors.
+ * Copyright 2013-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package com.alibaba.cloud.examples;
 
 import com.alibaba.cloud.examples.BusinessApplication.OrderService;
 import com.alibaba.cloud.examples.BusinessApplication.StorageService;
-import io.seata.spring.annotation.GlobalTransactional;
+import org.apache.seata.spring.annotation.GlobalTransactional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/spring-cloud-alibaba-examples/seata-example/order-service/src/main/java/com/alibaba/cloud/examples/OrderController.java
+++ b/spring-cloud-alibaba-examples/seata-example/order-service/src/main/java/com/alibaba/cloud/examples/OrderController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 the original author or authors.
+ * Copyright 2013-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Random;
 
-import io.seata.core.context.RootContext;
+import org.apache.seata.core.context.RootContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/spring-cloud-alibaba-examples/seata-example/storage-service/src/main/java/com/alibaba/cloud/examples/controller/StorageController.java
+++ b/spring-cloud-alibaba-examples/seata-example/storage-service/src/main/java/com/alibaba/cloud/examples/controller/StorageController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 the original author or authors.
+ * Copyright 2013-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package com.alibaba.cloud.examples.controller;
 
-import io.seata.core.context.RootContext;
+import org.apache.seata.core.context.RootContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/pom.xml
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/pom.xml
@@ -40,6 +40,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.seata</groupId>
             <artifactId>seata-spring-boot-starter</artifactId>
         </dependency>

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/java/com/alibaba/cloud/seata/feign/SeataFeignRequestInterceptor.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/java/com/alibaba/cloud/seata/feign/SeataFeignRequestInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 the original author or authors.
+ * Copyright 2013-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package com.alibaba.cloud.seata.feign;
 
 import feign.RequestInterceptor;
 import feign.RequestTemplate;
-import io.seata.core.context.RootContext;
+import org.apache.seata.core.context.RootContext;
 
 import org.springframework.util.StringUtils;
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/java/com/alibaba/cloud/seata/rest/SeataRestTemplateInterceptor.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/java/com/alibaba/cloud/seata/rest/SeataRestTemplateInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 the original author or authors.
+ * Copyright 2013-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package com.alibaba.cloud.seata.rest;
 
 import java.io.IOException;
 
-import io.seata.core.context.RootContext;
+import org.apache.seata.core.context.RootContext;
 
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpRequestExecution;

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/java/com/alibaba/cloud/seata/web/SeataHandlerInterceptor.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/java/com/alibaba/cloud/seata/web/SeataHandlerInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 the original author or authors.
+ * Copyright 2013-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
 
 package com.alibaba.cloud.seata.web;
 
-import io.seata.common.util.StringUtils;
-import io.seata.core.context.RootContext;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.apache.seata.common.util.StringUtils;
+import org.apache.seata.core.context.RootContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,7 +29,7 @@ import org.springframework.web.servlet.HandlerInterceptor;
  * @author xiaojing
  *
  * Seata HandlerInterceptor, Convert Seata information into
- * @see io.seata.core.context.RootContext from http request's header in
+ * @see org.apache.seata.core.context.RootContext from http request's header in
  * {@link org.springframework.web.servlet.HandlerInterceptor#preHandle(HttpServletRequest, HttpServletResponse, Object)},
  * And clean up Seata information after servlet method invocation in
  * {@link org.springframework.web.servlet.HandlerInterceptor#afterCompletion(HttpServletRequest, HttpServletResponse, Object, Exception)}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/java/com/alibaba/cloud/seata/webclient/SeataWebClientAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/java/com/alibaba/cloud/seata/webclient/SeataWebClientAutoConfiguration.java
@@ -14,30 +14,29 @@
  * limitations under the License.
  */
 
-package com.alibaba.cloud.seata.rest;
+package com.alibaba.cloud.seata.webclient;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.web.reactive.function.client.WebClientCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.client.RestClient;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.web.reactive.function.client.WebClient;
 
 /**
- * @author xiaojing
  * @author ChangJin Wei (魏昌进)
  */
 @Configuration(proxyBeanMethods = false)
-@ConditionalOnClass({RestClient.class, RestTemplate.class})
-public class SeataRestTemplateAutoConfiguration {
+@ConditionalOnClass(WebClient.class)
+public class SeataWebClientAutoConfiguration {
 
 	@Bean
-	public SeataRestTemplateInterceptor seataRestTemplateInterceptor() {
-		return new SeataRestTemplateInterceptor();
+	public SeataWebClientFilter seataWebClientFilter() {
+		return new SeataWebClientFilter();
 	}
 
 	@Bean
-	public SeataRestTemplateInterceptorAfterPropertiesSet seataRestTemplateInterceptorConfiguration() {
-		return new SeataRestTemplateInterceptorAfterPropertiesSet();
+	public WebClientCustomizer seataWebClientCustomizer(SeataWebClientFilter filter) {
+		return new SeataWebClientBuilderCustomizer(filter);
 	}
 
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/java/com/alibaba/cloud/seata/webclient/SeataWebClientBuilderCustomizer.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/java/com/alibaba/cloud/seata/webclient/SeataWebClientBuilderCustomizer.java
@@ -14,22 +14,24 @@
  * limitations under the License.
  */
 
-package com.alibaba.cloud.seata.web;
+package com.alibaba.cloud.seata.webclient;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
-import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import org.springframework.boot.web.reactive.function.client.WebClientCustomizer;
+import org.springframework.web.reactive.function.client.WebClient;
 
 /**
- * @author xiaojing
  * @author ChangJin Wei (魏昌进)
  */
-@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
-public class SeataHandlerInterceptorConfiguration implements WebMvcConfigurer {
+public class SeataWebClientBuilderCustomizer implements WebClientCustomizer {
+	private final SeataWebClientFilter filter;
 
-	@Override
-	public void addInterceptors(InterceptorRegistry registry) {
-		registry.addInterceptor(new SeataHandlerInterceptor()).addPathPatterns("/**");
+	public SeataWebClientBuilderCustomizer(SeataWebClientFilter filter) {
+		this.filter = filter;
 	}
 
+	@Override
+	public void customize(WebClient.Builder builder) {
+		builder.filter(filter);
+	}
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/java/com/alibaba/cloud/seata/webclient/SeataWebClientFilter.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/java/com/alibaba/cloud/seata/webclient/SeataWebClientFilter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.seata.webclient;
+
+import io.seata.core.context.RootContext;
+import reactor.core.publisher.Mono;
+
+import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+
+/**
+ * @author ChangJin Wei (魏昌进)
+ */
+public class SeataWebClientFilter implements ExchangeFilterFunction {
+
+	@Override
+	public Mono<ClientResponse> filter(ClientRequest request, ExchangeFunction next) {
+		String xid = RootContext.getXID();
+		if (!StringUtils.hasLength(xid)) {
+			return next.exchange(request);
+		}
+		ClientRequest newReq = ClientRequest.from(request)
+				.headers(h -> h.add(RootContext.KEY_XID, xid))
+				.build();
+		return next.exchange(newReq);
+	}
+
+
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/java/com/alibaba/cloud/seata/webclient/SeataWebClientFilter.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/java/com/alibaba/cloud/seata/webclient/SeataWebClientFilter.java
@@ -16,7 +16,7 @@
 
 package com.alibaba.cloud.seata.webclient;
 
-import io.seata.core.context.RootContext;
+import org.apache.seata.core.context.RootContext;
 import reactor.core.publisher.Mono;
 
 import org.springframework.util.StringUtils;

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/java/com/alibaba/cloud/seata/webflux/SeataWebFilter.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/java/com/alibaba/cloud/seata/webflux/SeataWebFilter.java
@@ -16,8 +16,8 @@
 
 package com.alibaba.cloud.seata.webflux;
 
-import io.seata.common.util.StringUtils;
-import io.seata.core.context.RootContext;
+import org.apache.seata.common.util.StringUtils;
+import org.apache.seata.core.context.RootContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/java/com/alibaba/cloud/seata/webflux/SeataWebFilter.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/java/com/alibaba/cloud/seata/webflux/SeataWebFilter.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.seata.webflux;
+
+import io.seata.common.util.StringUtils;
+import io.seata.core.context.RootContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+
+/**
+ * @author ChangJin Wei (魏昌进)
+ */
+public class SeataWebFilter implements WebFilter {
+
+	private static final Logger log = LoggerFactory.getLogger(SeataWebFilter.class);
+
+	@Override
+	public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+		String xid = RootContext.getXID();
+		String rpcXid = exchange.getRequest().getHeaders().getFirst(RootContext.KEY_XID);
+		if (log.isDebugEnabled()) {
+			log.debug("xid in RootContext {} xid in RpcContext {}", xid, rpcXid);
+		}
+
+		if (StringUtils.isBlank(xid) && rpcXid != null) {
+			RootContext.bind(rpcXid);
+			if (log.isDebugEnabled()) {
+				log.debug("bind {} to RootContext", rpcXid);
+			}
+		}
+
+		return chain.filter(exchange)
+				.doFinally(sig -> {
+					if (StringUtils.isNotBlank(RootContext.getXID())) {
+						String headerXid = exchange.getRequest().getHeaders().getFirst(RootContext.KEY_XID);
+
+						if (StringUtils.isEmpty(headerXid)) {
+							return;
+						}
+
+						String unbindXid = RootContext.unbind();
+						if (log.isDebugEnabled()) {
+							log.debug("unbind {} from RootContext", unbindXid);
+						}
+						if (!headerXid.equalsIgnoreCase(unbindXid)) {
+							log.warn("xid in change during RPC from {} to {}", headerXid, unbindXid);
+							if (unbindXid != null) {
+								RootContext.bind(unbindXid);
+								log.warn("bind {} back to RootContext", unbindXid);
+							}
+						}
+					}
+				});
+	}
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/java/com/alibaba/cloud/seata/webflux/SeataWebfluxAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/java/com/alibaba/cloud/seata/webflux/SeataWebfluxAutoConfiguration.java
@@ -14,30 +14,23 @@
  * limitations under the License.
  */
 
-package com.alibaba.cloud.seata.rest;
+package com.alibaba.cloud.seata.webflux;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.web.client.RestClient;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.web.reactive.config.WebFluxConfigurer;
+import org.springframework.web.server.WebFilter;
 
 /**
- * @author xiaojing
  * @author ChangJin Wei (魏昌进)
  */
-@Configuration(proxyBeanMethods = false)
-@ConditionalOnClass({RestClient.class, RestTemplate.class})
-public class SeataRestTemplateAutoConfiguration {
+@ConditionalOnClass({WebFilter.class, WebFluxConfigurer.class})
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.REACTIVE)
+public class SeataWebfluxAutoConfiguration {
 
 	@Bean
-	public SeataRestTemplateInterceptor seataRestTemplateInterceptor() {
-		return new SeataRestTemplateInterceptor();
+	public WebFilter seataWebFilter() {
+		return new SeataWebFilter();
 	}
-
-	@Bean
-	public SeataRestTemplateInterceptorAfterPropertiesSet seataRestTemplateInterceptorConfiguration() {
-		return new SeataRestTemplateInterceptorAfterPropertiesSet();
-	}
-
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/resources/META-INF/native-image/proxy-config.json
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/resources/META-INF/native-image/proxy-config.json
@@ -1,18 +1,18 @@
 [
   {
     "condition": {
-      "typeReachable": "io.seata.config.ConfigurationCache"
+      "typeReachable": "org.apache.config.ConfigurationCache"
     },
     "interfaces": [
-      "io.seata.config.Configuration"
+      "org.apache.config.Configuration"
     ]
   },
   {
     "condition": {
-      "typeReachable": "io.seata.spring.boot.autoconfigure.provider.SpringBootConfigurationProvider"
+      "typeReachable": "org.apache.spring.boot.autoconfigure.provider.SpringBootConfigurationProvider"
     },
     "interfaces": [
-      "io.seata.config.Configuration"
+      "org.apache.config.Configuration"
     ]
   }
 ]

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/resources/META-INF/native-image/reflect-config.json
@@ -1,52 +1,52 @@
 [
   {
     "condition": {
-      "typeReachable": "io.seata.config.ConfigurationCache"
+      "typeReachable": "org.apache.config.ConfigurationCache"
     },
-    "name": "io.seata.config.Configuration"
+    "name": "org.apache.config.Configuration"
   },
   {
     "condition": {
-      "typeReachable": "io.seata.config.ConfigurationCache$$Lambda$494/0x00000008010e8000"
+      "typeReachable": "org.apache.config.ConfigurationCache$$Lambda$494/0x00000008010e8000"
     },
-    "name": "io.seata.config.Configuration"
+    "name": "org.apache.config.Configuration"
   },
   {
     "condition": {
-      "typeReachable": "io.seata.core.event.GuavaEventBus"
+      "typeReachable": "org.apache.core.event.GuavaEventBus"
     },
-    "name": "io.seata.config.ConfigurationChangeListener",
+    "name": "org.apache.config.ConfigurationChangeListener",
     "queryAllDeclaredMethods": true
   },
   {
     "condition": {
-      "typeReachable": "io.seata.config.ConfigurationFactory"
+      "typeReachable": "org.apache.config.ConfigurationFactory"
     },
-    "name": "io.seata.config.apollo.ApolloConfigurationProvider"
+    "name": "org.apache.config.apollo.ApolloConfigurationProvider"
   },
   {
     "condition": {
-      "typeReachable": "io.seata.config.ConfigurationFactory"
+      "typeReachable": "org.apache.config.ConfigurationFactory"
     },
-    "name": "io.seata.config.consul.ConsulConfigurationProvider"
+    "name": "org.apache.config.consul.ConsulConfigurationProvider"
   },
   {
     "condition": {
-      "typeReachable": "io.seata.config.ConfigurationFactory"
+      "typeReachable": "org.apache.config.ConfigurationFactory"
     },
-    "name": "io.seata.config.custom.CustomConfigurationProvider"
+    "name": "org.apache.config.custom.CustomConfigurationProvider"
   },
   {
     "condition": {
-      "typeReachable": "io.seata.config.ConfigurationFactory"
+      "typeReachable": "org.apache.config.ConfigurationFactory"
     },
-    "name": "io.seata.config.etcd3.EtcdConfigurationProvider"
+    "name": "org.apache.config.etcd3.EtcdConfigurationProvider"
   },
   {
     "condition": {
-      "typeReachable": "io.seata.common.loader.EnhancedServiceLoader$InnerEnhancedServiceLoader"
+      "typeReachable": "org.apache.common.loader.EnhancedServiceLoader$InnerEnhancedServiceLoader"
     },
-    "name": "io.seata.config.file.SimpleFileConfig",
+    "name": "org.apache.config.file.SimpleFileConfig",
     "methods": [
       {
         "name": "<init>",
@@ -56,15 +56,15 @@
   },
   {
     "condition": {
-      "typeReachable": "io.seata.common.loader.EnhancedServiceLoader$InnerEnhancedServiceLoader"
+      "typeReachable": "org.apache.common.loader.EnhancedServiceLoader$InnerEnhancedServiceLoader"
     },
-    "name": "io.seata.config.file.YamlFileConfig"
+    "name": "org.apache.config.file.YamlFileConfig"
   },
   {
     "condition": {
-      "typeReachable": "io.seata.config.ConfigurationFactory"
+      "typeReachable": "org.apache.config.ConfigurationFactory"
     },
-    "name": "io.seata.config.nacos.NacosConfigurationProvider",
+    "name": "org.apache.config.nacos.NacosConfigurationProvider",
     "methods": [
       {
         "name": "<init>",
@@ -74,9 +74,9 @@
   },
   {
     "condition": {
-      "typeReachable": "io.seata.config.processor.ConfigProcessor"
+      "typeReachable": "org.apache.config.processor.ConfigProcessor"
     },
-    "name": "io.seata.config.processor.ProcessorProperties",
+    "name": "org.apache.config.processor.ProcessorProperties",
     "methods": [
       {
         "name": "<init>",
@@ -86,27 +86,27 @@
   },
   {
     "condition": {
-      "typeReachable": "io.seata.config.processor.ConfigProcessor"
+      "typeReachable": "org.apache.config.processor.ConfigProcessor"
     },
-    "name": "io.seata.config.processor.ProcessorYaml"
+    "name": "org.apache.config.processor.ProcessorYaml"
   },
   {
     "condition": {
-      "typeReachable": "io.seata.config.ConfigurationFactory"
+      "typeReachable": "org.apache.config.ConfigurationFactory"
     },
-    "name": "io.seata.config.springcloud.SpringCloudConfigurationProvider"
+    "name": "org.apache.config.springcloud.SpringCloudConfigurationProvider"
   },
   {
     "condition": {
-      "typeReachable": "io.seata.config.ConfigurationFactory"
+      "typeReachable": "org.apache.config.ConfigurationFactory"
     },
-    "name": "io.seata.config.zk.ZookeeperConfigurationProvider"
+    "name": "org.apache.config.zk.ZookeeperConfigurationProvider"
   },
   {
     "condition": {
-      "typeReachable": "io.seata.core.rpc.netty.TmNettyRemotingClient"
+      "typeReachable": "org.apache.core.rpc.netty.TmNettyRemotingClient"
     },
-    "name": "io.seata.core.auth.DefaultAuthSigner",
+    "name": "org.apache.core.auth.DefaultAuthSigner",
     "methods": [
       {
         "name": "<init>",
@@ -116,9 +116,9 @@
   },
   {
     "condition": {
-      "typeReachable": "io.seata.core.context.ContextCoreLoader$ContextCoreHolder"
+      "typeReachable": "org.apache.core.context.ContextCoreLoader$ContextCoreHolder"
     },
-    "name": "io.seata.core.context.FastThreadLocalContextCore",
+    "name": "org.apache.core.context.FastThreadLocalContextCore",
     "methods": [
       {
         "name": "<init>",
@@ -128,15 +128,15 @@
   },
   {
     "condition": {
-      "typeReachable": "io.seata.core.context.ContextCoreLoader$ContextCoreHolder"
+      "typeReachable": "org.apache.core.context.ContextCoreLoader$ContextCoreHolder"
     },
-    "name": "io.seata.core.context.ThreadLocalContextCore"
+    "name": "org.apache.core.context.ThreadLocalContextCore"
   },
   {
     "condition": {
-      "typeReachable": "io.seata.core.rpc.netty.AbstractNettyRemoting"
+      "typeReachable": "org.apache.core.rpc.netty.AbstractNettyRemoting"
     },
-    "name": "io.seata.core.rpc.hook.StatusRpcHook",
+    "name": "org.apache.core.rpc.hook.StatusRpcHook",
     "methods": [
       {
         "name": "<init>",
@@ -146,9 +146,9 @@
   },
   {
     "condition": {
-      "typeReachable": "io.seata.core.rpc.netty.NettyClientBootstrap"
+      "typeReachable": "org.apache.core.rpc.netty.NettyClientBootstrap"
     },
-    "name": "io.seata.core.rpc.netty.AbstractNettyRemotingClient$ClientHandler",
+    "name": "org.apache.core.rpc.netty.AbstractNettyRemotingClient$ClientHandler",
     "methods": [
       {
         "name": "channelInactive",
@@ -194,57 +194,57 @@
   },
   {
     "condition": {
-      "typeReachable": "io.seata.core.rpc.netty.NettyClientBootstrap"
+      "typeReachable": "org.apache.core.rpc.netty.NettyClientBootstrap"
     },
-    "name": "io.seata.core.rpc.netty.NettyClientBootstrap$1"
+    "name": "org.apache.core.rpc.netty.NettyClientBootstrap$1"
   },
   {
     "condition": {
-      "typeReachable": "io.seata.core.rpc.netty.NettyClientBootstrap$1"
+      "typeReachable": "org.apache.core.rpc.netty.NettyClientBootstrap$1"
     },
-    "name": "io.seata.core.rpc.netty.v1.ProtocolV1Decoder"
+    "name": "org.apache.core.rpc.netty.v1.ProtocolV1Decoder"
   },
   {
     "condition": {
-      "typeReachable": "io.seata.core.rpc.netty.NettyClientBootstrap$1"
+      "typeReachable": "org.apache.core.rpc.netty.NettyClientBootstrap$1"
     },
-    "name": "io.seata.core.rpc.netty.v1.ProtocolV1Encoder"
+    "name": "org.apache.core.rpc.netty.v1.ProtocolV1Encoder"
   },
   {
     "condition": {
-      "typeReachable": "io.seata.discovery.registry.RegistryFactory"
+      "typeReachable": "org.apache.discovery.registry.RegistryFactory"
     },
-    "name": "io.seata.discovery.registry.FileRegistryProvider"
+    "name": "org.apache.discovery.registry.FileRegistryProvider"
   },
   {
     "condition": {
-      "typeReachable": "io.seata.discovery.registry.RegistryFactory"
+      "typeReachable": "org.apache.discovery.registry.RegistryFactory"
     },
-    "name": "io.seata.discovery.registry.consul.ConsulRegistryProvider"
+    "name": "org.apache.discovery.registry.consul.ConsulRegistryProvider"
   },
   {
     "condition": {
-      "typeReachable": "io.seata.discovery.registry.RegistryFactory"
+      "typeReachable": "org.apache.discovery.registry.RegistryFactory"
     },
-    "name": "io.seata.discovery.registry.custom.CustomRegistryProvider"
+    "name": "org.apache.discovery.registry.custom.CustomRegistryProvider"
   },
   {
     "condition": {
-      "typeReachable": "io.seata.discovery.registry.RegistryFactory"
+      "typeReachable": "org.apache.discovery.registry.RegistryFactory"
     },
-    "name": "io.seata.discovery.registry.etcd3.EtcdRegistryProvider"
+    "name": "org.apache.discovery.registry.etcd3.EtcdRegistryProvider"
   },
   {
     "condition": {
-      "typeReachable": "io.seata.discovery.registry.RegistryFactory"
+      "typeReachable": "org.apache.discovery.registry.RegistryFactory"
     },
-    "name": "io.seata.discovery.registry.eureka.EurekaRegistryProvider"
+    "name": "org.apache.discovery.registry.eureka.EurekaRegistryProvider"
   },
   {
     "condition": {
-      "typeReachable": "io.seata.discovery.registry.RegistryFactory"
+      "typeReachable": "org.apache.discovery.registry.RegistryFactory"
     },
-    "name": "io.seata.discovery.registry.nacos.NacosRegistryProvider",
+    "name": "org.apache.discovery.registry.nacos.NacosRegistryProvider",
     "methods": [
       {
         "name": "<init>",
@@ -254,34 +254,34 @@
   },
   {
     "condition": {
-      "typeReachable": "io.seata.discovery.registry.RegistryFactory"
+      "typeReachable": "org.apache.discovery.registry.RegistryFactory"
     },
-    "name": "io.seata.discovery.registry.redis.RedisRegistryProvider"
+    "name": "org.apache.discovery.registry.redis.RedisRegistryProvider"
   },
   {
     "condition": {
-      "typeReachable": "io.seata.discovery.registry.RegistryFactory"
+      "typeReachable": "org.apache.discovery.registry.RegistryFactory"
     },
-    "name": "io.seata.discovery.registry.sofa.SofaRegistryProvider"
+    "name": "org.apache.discovery.registry.sofa.SofaRegistryProvider"
   },
   {
     "condition": {
-      "typeReachable": "io.seata.discovery.registry.RegistryFactory"
+      "typeReachable": "org.apache.discovery.registry.RegistryFactory"
     },
-    "name": "io.seata.discovery.registry.zk.ZookeeperRegistryProvider"
+    "name": "org.apache.discovery.registry.zk.ZookeeperRegistryProvider"
   },
   {
     "condition": {
-      "typeReachable": "io.seata.spring.annotation.GlobalTransactionScanner"
+      "typeReachable": "org.apache.spring.annotation.GlobalTransactionScanner"
     },
-    "name": "io.seata.integration.http.JakartaSeataWebMvcConfigurer",
+    "name": "org.apache.integration.http.JakartaSeataWebMvcConfigurer",
     "queryAllPublicMethods": true
   },
   {
     "condition": {
-      "typeReachable": "io.seata.rm.DefaultRMHandler"
+      "typeReachable": "org.apache.rm.DefaultRMHandler"
     },
-    "name": "io.seata.rm.RMHandlerAT",
+    "name": "org.apache.rm.RMHandlerAT",
     "methods": [
       {
         "name": "<init>",
@@ -291,9 +291,9 @@
   },
   {
     "condition": {
-      "typeReachable": "io.seata.rm.DefaultRMHandler"
+      "typeReachable": "org.apache.rm.DefaultRMHandler"
     },
-    "name": "io.seata.rm.RMHandlerXA",
+    "name": "org.apache.rm.RMHandlerXA",
     "methods": [
       {
         "name": "<init>",
@@ -303,9 +303,9 @@
   },
   {
     "condition": {
-      "typeReachable": "io.seata.rm.DefaultResourceManager"
+      "typeReachable": "org.apache.rm.DefaultResourceManager"
     },
-    "name": "io.seata.rm.datasource.DataSourceManager",
+    "name": "org.apache.rm.datasource.DataSourceManager",
     "methods": [
       {
         "name": "<init>",
@@ -315,9 +315,9 @@
   },
   {
     "condition": {
-      "typeReachable": "io.seata.rm.DefaultResourceManager"
+      "typeReachable": "org.apache.rm.DefaultResourceManager"
     },
-    "name": "io.seata.rm.datasource.xa.ResourceManagerXA",
+    "name": "org.apache.rm.datasource.xa.ResourceManagerXA",
     "methods": [
       {
         "name": "<init>",
@@ -327,9 +327,9 @@
   },
   {
     "condition": {
-      "typeReachable": "io.seata.rm.DefaultRMHandler"
+      "typeReachable": "org.apache.rm.DefaultRMHandler"
     },
-    "name": "io.seata.rm.tcc.RMHandlerTCC",
+    "name": "org.apache.rm.tcc.RMHandlerTCC",
     "methods": [
       {
         "name": "<init>",
@@ -339,9 +339,9 @@
   },
   {
     "condition": {
-      "typeReachable": "io.seata.rm.DefaultResourceManager"
+      "typeReachable": "org.apache.rm.DefaultResourceManager"
     },
-    "name": "io.seata.rm.tcc.TCCResourceManager",
+    "name": "org.apache.rm.tcc.TCCResourceManager",
     "methods": [
       {
         "name": "<init>",
@@ -351,9 +351,9 @@
   },
   {
     "condition": {
-      "typeReachable": "io.seata.rm.tcc.remoting.parser.DefaultRemotingParser"
+      "typeReachable": "org.apache.rm.tcc.remoting.parser.DefaultRemotingParser"
     },
-    "name": "io.seata.rm.tcc.remoting.parser.DubboRemotingParser",
+    "name": "org.apache.rm.tcc.remoting.parser.DubboRemotingParser",
     "methods": [
       {
         "name": "<init>",
@@ -363,9 +363,9 @@
   },
   {
     "condition": {
-      "typeReachable": "io.seata.rm.tcc.remoting.parser.DefaultRemotingParser"
+      "typeReachable": "org.apache.rm.tcc.remoting.parser.DefaultRemotingParser"
     },
-    "name": "io.seata.rm.tcc.remoting.parser.HSFRemotingParser",
+    "name": "org.apache.rm.tcc.remoting.parser.HSFRemotingParser",
     "methods": [
       {
         "name": "<init>",
@@ -375,9 +375,9 @@
   },
   {
     "condition": {
-      "typeReachable": "io.seata.rm.tcc.remoting.parser.DefaultRemotingParser"
+      "typeReachable": "org.apache.rm.tcc.remoting.parser.DefaultRemotingParser"
     },
-    "name": "io.seata.rm.tcc.remoting.parser.LocalTCCRemotingParser",
+    "name": "org.apache.rm.tcc.remoting.parser.LocalTCCRemotingParser",
     "methods": [
       {
         "name": "<init>",
@@ -387,9 +387,9 @@
   },
   {
     "condition": {
-      "typeReachable": "io.seata.rm.tcc.remoting.parser.DefaultRemotingParser"
+      "typeReachable": "org.apache.rm.tcc.remoting.parser.DefaultRemotingParser"
     },
-    "name": "io.seata.rm.tcc.remoting.parser.SofaRpcRemotingParser",
+    "name": "org.apache.rm.tcc.remoting.parser.SofaRpcRemotingParser",
     "methods": [
       {
         "name": "<init>",
@@ -399,9 +399,9 @@
   },
   {
     "condition": {
-      "typeReachable": "io.seata.rm.DefaultRMHandler"
+      "typeReachable": "org.apache.rm.DefaultRMHandler"
     },
-    "name": "io.seata.saga.rm.RMHandlerSaga",
+    "name": "org.apache.saga.rm.RMHandlerSaga",
     "methods": [
       {
         "name": "<init>",
@@ -411,9 +411,9 @@
   },
   {
     "condition": {
-      "typeReachable": "io.seata.rm.DefaultResourceManager"
+      "typeReachable": "org.apache.rm.DefaultResourceManager"
     },
-    "name": "io.seata.saga.rm.SagaResourceManager",
+    "name": "org.apache.saga.rm.SagaResourceManager",
     "methods": [
       {
         "name": "<init>",
@@ -423,27 +423,27 @@
   },
   {
     "condition": {
-      "typeReachable": "io.seata.core.serializer.SerializerServiceLoader"
+      "typeReachable": "org.apache.core.serializer.SerializerServiceLoader"
     },
-    "name": "io.seata.serializer.fst.FstSerializer"
+    "name": "org.apache.serializer.fst.FstSerializer"
   },
   {
     "condition": {
-      "typeReachable": "io.seata.core.serializer.SerializerServiceLoader"
+      "typeReachable": "org.apache.core.serializer.SerializerServiceLoader"
     },
-    "name": "io.seata.serializer.hessian.HessianSerializer"
+    "name": "org.apache.serializer.hessian.HessianSerializer"
   },
   {
     "condition": {
-      "typeReachable": "io.seata.core.serializer.SerializerServiceLoader"
+      "typeReachable": "org.apache.core.serializer.SerializerServiceLoader"
     },
-    "name": "io.seata.serializer.kryo.KryoSerializer"
+    "name": "org.apache.serializer.kryo.KryoSerializer"
   },
   {
     "condition": {
-      "typeReachable": "io.seata.core.serializer.SerializerServiceLoader"
+      "typeReachable": "org.apache.core.serializer.SerializerServiceLoader"
     },
-    "name": "io.seata.serializer.seata.SeataSerializer",
+    "name": "org.apache.serializer.seata.SeataSerializer",
     "methods": [
       {
         "name": "<init>",
@@ -453,23 +453,23 @@
   },
   {
     "condition": {
-      "typeReachable": "io.seata.core.event.GuavaEventBus"
+      "typeReachable": "org.apache.core.event.GuavaEventBus"
     },
-    "name": "io.seata.spring.annotation.GlobalTransactionalInterceptor",
+    "name": "org.apache.spring.annotation.GlobalTransactionalInterceptor",
     "queryAllDeclaredMethods": true
   },
   {
     "condition": {
-      "typeReachable": "io.seata.core.event.GuavaEventBus"
+      "typeReachable": "org.apache.core.event.GuavaEventBus"
     },
-    "name": "io.seata.spring.annotation.SeataInterceptor",
+    "name": "org.apache.spring.annotation.SeataInterceptor",
     "queryAllDeclaredMethods": true
   },
   {
     "condition": {
-      "typeReachable": "io.seata.spring.boot.autoconfigure.SeataAutoConfiguration"
+      "typeReachable": "org.apache.spring.boot.autoconfigure.SeataAutoConfiguration"
     },
-    "name": "io.seata.spring.annotation.scannercheckers.ConfigBeansScannerChecker",
+    "name": "org.apache.spring.annotation.scannercheckers.ConfigBeansScannerChecker",
     "methods": [
       {
         "name": "<init>",
@@ -479,9 +479,9 @@
   },
   {
     "condition": {
-      "typeReachable": "io.seata.spring.boot.autoconfigure.SeataAutoConfiguration"
+      "typeReachable": "org.apache.spring.boot.autoconfigure.SeataAutoConfiguration"
     },
-    "name": "io.seata.spring.annotation.scannercheckers.PackageScannerChecker",
+    "name": "org.apache.spring.annotation.scannercheckers.PackageScannerChecker",
     "methods": [
       {
         "name": "<init>",
@@ -491,9 +491,9 @@
   },
   {
     "condition": {
-      "typeReachable": "io.seata.spring.boot.autoconfigure.SeataAutoConfiguration"
+      "typeReachable": "org.apache.spring.boot.autoconfigure.SeataAutoConfiguration"
     },
-    "name": "io.seata.spring.annotation.scannercheckers.ScopeBeansScannerChecker",
+    "name": "org.apache.spring.annotation.scannercheckers.ScopeBeansScannerChecker",
     "methods": [
       {
         "name": "<init>",
@@ -503,9 +503,9 @@
   },
   {
     "condition": {
-      "typeReachable": "io.seata.config.ConfigurationFactory"
+      "typeReachable": "org.apache.config.ConfigurationFactory"
     },
-    "name": "io.seata.spring.boot.autoconfigure.provider.SpringBootConfigurationProvider",
+    "name": "org.apache.spring.boot.autoconfigure.provider.SpringBootConfigurationProvider",
     "methods": [
       {
         "name": "<init>",
@@ -515,9 +515,9 @@
   },
   {
     "condition": {
-      "typeReachable": "io.seata.tm.TransactionManagerHolder$SingletonHolder"
+      "typeReachable": "org.apache.tm.TransactionManagerHolder$SingletonHolder"
     },
-    "name": "io.seata.tm.DefaultTransactionManager",
+    "name": "org.apache.tm.DefaultTransactionManager",
     "methods": [
       {
         "name": "<init>",

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/resources/META-INF/native-image/resource-config.json
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/resources/META-INF/native-image/resource-config.json
@@ -3,145 +3,145 @@
     "includes": [
       {
         "condition": {
-          "typeReachable": "io.seata.config.nacos.NacosConfiguration"
+          "typeReachable": "org.apache.config.nacos.NacosConfiguration"
         },
         "pattern": "\\QMETA-INF/services/com.alibaba.nacos.api.config.filter.IConfigFilter\\E"
       },
       {
         "condition": {
-          "typeReachable": "io.seata.config.nacos.NacosConfiguration"
+          "typeReachable": "org.apache.config.nacos.NacosConfiguration"
         },
         "pattern": "\\QMETA-INF/services/com.alibaba.nacos.api.remote.Payload\\E"
       },
       {
         "condition": {
-          "typeReachable": "io.seata.config.nacos.NacosConfiguration"
+          "typeReachable": "org.apache.config.nacos.NacosConfiguration"
         },
         "pattern": "\\QMETA-INF/services/com.alibaba.nacos.plugin.auth.spi.client.AbstractClientAuthService\\E"
       },
       {
         "condition": {
-          "typeReachable": "io.seata.config.nacos.NacosConfiguration"
+          "typeReachable": "org.apache.config.nacos.NacosConfiguration"
         },
         "pattern": "\\QMETA-INF/services/com.alibaba.nacos.shaded.io.grpc.LoadBalancerProvider\\E"
       },
       {
         "condition": {
-          "typeReachable": "io.seata.config.nacos.NacosConfiguration"
+          "typeReachable": "org.apache.config.nacos.NacosConfiguration"
         },
         "pattern": "\\QMETA-INF/services/com.alibaba.nacos.shaded.io.grpc.ManagedChannelProvider\\E"
       },
       {
         "condition": {
-          "typeReachable": "io.seata.config.nacos.NacosConfiguration"
+          "typeReachable": "org.apache.config.nacos.NacosConfiguration"
         },
         "pattern": "\\QMETA-INF/services/com.alibaba.nacos.shaded.io.grpc.NameResolverProvider\\E"
       },
       {
         "condition": {
-          "typeReachable": "io.seata.config.ConfigurationFactory"
+          "typeReachable": "org.apache.config.ConfigurationFactory"
         },
-        "pattern": "\\QMETA-INF/services/io.seata.config.ConfigurationProvider\\E"
+        "pattern": "\\QMETA-INF/services/org.apache.config.ConfigurationProvider\\E"
       },
       {
         "condition": {
-          "typeReachable": "io.seata.config.ConfigurationFactory"
+          "typeReachable": "org.apache.config.ConfigurationFactory"
         },
-        "pattern": "\\QMETA-INF/services/io.seata.config.ExtConfigurationProvider\\E"
+        "pattern": "\\QMETA-INF/services/org.apache.config.ExtConfigurationProvider\\E"
       },
       {
         "condition": {
-          "typeReachable": "io.seata.common.loader.EnhancedServiceLoader$InnerEnhancedServiceLoader"
+          "typeReachable": "org.apache.common.loader.EnhancedServiceLoader$InnerEnhancedServiceLoader"
         },
-        "pattern": "\\QMETA-INF/services/io.seata.config.file.FileConfig\\E"
+        "pattern": "\\QMETA-INF/services/org.apache.config.file.FileConfig\\E"
       },
       {
         "condition": {
-          "typeReachable": "io.seata.config.processor.ConfigProcessor"
+          "typeReachable": "org.apache.config.processor.ConfigProcessor"
         },
-        "pattern": "\\QMETA-INF/services/io.seata.config.processor.Processor\\E"
+        "pattern": "\\QMETA-INF/services/org.apache.config.processor.Processor\\E"
       },
       {
         "condition": {
-          "typeReachable": "io.seata.core.rpc.netty.TmNettyRemotingClient"
+          "typeReachable": "org.apache.core.rpc.netty.TmNettyRemotingClient"
         },
-        "pattern": "\\QMETA-INF/services/io.seata.core.auth.AuthSigner\\E"
+        "pattern": "\\QMETA-INF/services/org.apache.core.auth.AuthSigner\\E"
       },
       {
         "condition": {
-          "typeReachable": "io.seata.core.context.ContextCoreLoader$ContextCoreHolder"
+          "typeReachable": "org.apache.core.context.ContextCoreLoader$ContextCoreHolder"
         },
-        "pattern": "\\QMETA-INF/services/io.seata.core.context.ContextCore\\E"
+        "pattern": "\\QMETA-INF/services/org.apache.core.context.ContextCore\\E"
       },
       {
         "condition": {
-          "typeReachable": "io.seata.rm.DefaultResourceManager"
+          "typeReachable": "org.apache.rm.DefaultResourceManager"
         },
-        "pattern": "\\QMETA-INF/services/io.seata.core.model.ResourceManager\\E"
+        "pattern": "\\QMETA-INF/services/org.apache.core.model.ResourceManager\\E"
       },
       {
         "condition": {
-          "typeReachable": "io.seata.tm.TransactionManagerHolder$SingletonHolder"
+          "typeReachable": "org.apache.tm.TransactionManagerHolder$SingletonHolder"
         },
-        "pattern": "\\QMETA-INF/services/io.seata.core.model.TransactionManager\\E"
+        "pattern": "\\QMETA-INF/services/org.apache.core.model.TransactionManager\\E"
       },
       {
         "condition": {
-          "typeReachable": "io.seata.core.rpc.netty.AbstractNettyRemoting"
+          "typeReachable": "org.apache.core.rpc.netty.AbstractNettyRemoting"
         },
-        "pattern": "\\QMETA-INF/services/io.seata.core.rpc.hook.RpcHook\\E"
+        "pattern": "\\QMETA-INF/services/org.apache.core.rpc.hook.RpcHook\\E"
       },
       {
         "condition": {
-          "typeReachable": "io.seata.core.serializer.SerializerServiceLoader"
+          "typeReachable": "org.apache.core.serializer.SerializerServiceLoader"
         },
-        "pattern": "\\QMETA-INF/services/io.seata.core.serializer.Serializer\\E"
+        "pattern": "\\QMETA-INF/services/org.apache.core.serializer.Serializer\\E"
       },
       {
         "condition": {
-          "typeReachable": "io.seata.discovery.registry.RegistryFactory"
+          "typeReachable": "org.apache.discovery.registry.RegistryFactory"
         },
-        "pattern": "\\QMETA-INF/services/io.seata.discovery.registry.RegistryProvider\\E"
+        "pattern": "\\QMETA-INF/services/org.apache.discovery.registry.RegistryProvider\\E"
       },
       {
         "condition": {
-          "typeReachable": "io.seata.rm.DefaultRMHandler"
+          "typeReachable": "org.apache.rm.DefaultRMHandler"
         },
-        "pattern": "\\QMETA-INF/services/io.seata.rm.AbstractRMHandler\\E"
+        "pattern": "\\QMETA-INF/services/org.apache.rm.AbstractRMHandler\\E"
       },
       {
         "condition": {
-          "typeReachable": "io.seata.rm.tcc.remoting.parser.DefaultRemotingParser"
+          "typeReachable": "org.apache.rm.tcc.remoting.parser.DefaultRemotingParser"
         },
-        "pattern": "\\QMETA-INF/services/io.seata.rm.tcc.remoting.RemotingParser\\E"
+        "pattern": "\\QMETA-INF/services/org.apache.rm.tcc.remoting.RemotingParser\\E"
       },
       {
         "condition": {
-          "typeReachable": "io.seata.spring.boot.autoconfigure.SeataAutoConfiguration"
+          "typeReachable": "org.apache.spring.boot.autoconfigure.SeataAutoConfiguration"
         },
-        "pattern": "\\QMETA-INF/services/io.seata.spring.annotation.ScannerChecker\\E"
+        "pattern": "\\QMETA-INF/services/org.apache.spring.annotation.ScannerChecker\\E"
       },
       {
         "condition": {
-          "typeReachable": "io.seata.config.FileConfiguration"
+          "typeReachable": "org.apache.config.FileConfiguration"
         },
         "pattern": "\\Q\\E"
       },
       {
         "condition": {
-          "typeReachable": "io.seata.config.nacos.NacosConfiguration"
+          "typeReachable": "org.apache.config.nacos.NacosConfiguration"
         },
         "pattern": "\\Qnacos-version.txt\\E"
       },
       {
         "condition": {
-          "typeReachable": "io.seata.spring.annotation.GlobalTransactionalInterceptor$2"
+          "typeReachable": "org.apache.spring.annotation.GlobalTransactionalInterceptor$2"
         },
         "pattern": "\\Qorg/springframework/cloud/loadbalancer/annotation/LoadBalancerClientConfiguration$BlockingRetryConfiguration.class\\E"
       },
       {
         "condition": {
-          "typeReachable": "io.seata.spring.annotation.GlobalTransactionalInterceptor$2"
+          "typeReachable": "org.apache.spring.annotation.GlobalTransactionalInterceptor$2"
         },
         "pattern": "\\Qorg/springframework/cloud/loadbalancer/annotation/LoadBalancerClientConfiguration$BlockingSupportConfiguration.class\\E"
       }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-seata/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,3 +1,5 @@
 com.alibaba.cloud.seata.rest.SeataRestTemplateAutoConfiguration
 com.alibaba.cloud.seata.web.SeataHandlerInterceptorConfiguration
 com.alibaba.cloud.seata.feign.SeataFeignClientAutoConfiguration
+com.alibaba.cloud.seata.webclient.SeataWebClientAutoConfiguration
+com.alibaba.cloud.seata.webflux.SeataWebfluxAutoConfiguration


### PR DESCRIPTION


### Describe what this PR does / why we need it

1. 增加对 Spring WebFlux
2. 增加对 WebClient 支持
3. 修复 SeataHandlerInterceptorConfiguration 在非 SERVLET 环境下会自动装配
4. 修复 SeataRestTemplateAutoConfiguration在增加了一些条件装配
5. 根目录增加.editorconfig(Spring Cloud那边复制的)


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
