### PR TITLE
fix-4147: NacosConfigDataLocationResolver 在未使用 optional:nacos: 进行 import 时，注入  NacosConfigManager 对象后其中的属性都是默认值的问题

### DIFF
--- a/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigManager.java
+++ b/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigManager.java
@@ -160,6 +160,11 @@ public class NacosConfigManager implements InitializingBean, EnvironmentAware {
 	 */
 	private void recreateConfigService(NacosConfigProperties properties) {
 		if (service != null) {
+			try {
+				service.shutDown();
+			} catch (NacosException e) {
+				log.warn("Failed to shutdown old Nacos ConfigService", e);
+			}
 			service = null;
 		}
 		createConfigService(properties);

--- a/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigManager.java
+++ b/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigManager.java
@@ -18,6 +18,8 @@ package com.alibaba.cloud.nacos;
 
 import java.util.Objects;
 
+import com.alibaba.cloud.nacos.configdata.NacosConfigDataLoadProperties;
+import com.alibaba.cloud.nacos.configdata.NacosConfigDataLocationResolver;
 import com.alibaba.cloud.nacos.diagnostics.analyzer.NacosConnectionFailureException;
 import com.alibaba.nacos.api.NacosFactory;
 import com.alibaba.nacos.api.config.ConfigService;
@@ -25,18 +27,36 @@ import com.alibaba.nacos.api.exception.NacosException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.boot.context.properties.bind.BindHandler;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.core.env.Environment;
+import org.springframework.lang.NonNull;
+
 /**
  * @author zkzlx
  */
-public class NacosConfigManager {
+public class NacosConfigManager implements InitializingBean, EnvironmentAware {
 
 	private static final Logger log = LoggerFactory.getLogger(NacosConfigManager.class);
 
 	private static ConfigService service;
 
-	private static NacosConfigManager INSTANCE;
+	private static volatile NacosConfigManager INSTANCE;
 
 	private NacosConfigProperties nacosConfigProperties;
+
+	/**
+	 * The Spring environment used to bind properties.
+	 */
+	private Environment environment;
+
+	/*
+	 * Handler for binding configuration properties.
+	 */
+	private static BindHandler bindHandler;
 
 	public NacosConfigManager(NacosConfigProperties nacosConfigProperties) {
 		this.nacosConfigProperties = nacosConfigProperties;
@@ -87,6 +107,81 @@ public class NacosConfigManager {
 
 	public NacosConfigProperties getNacosConfigProperties() {
 		return nacosConfigProperties;
+	}
+
+	/**
+	 * Sets the Spring environment, used for property binding.
+	 *
+	 * @param environment the Spring environment
+	 */
+	@Override
+	public void setEnvironment(@NonNull Environment environment) {
+		this.environment = environment;
+	}
+
+	/**
+	 * Called after properties are set, re-binds configuration from the environment
+	 * and updates the internal configuration properties and ConfigService accordingly.
+	 */
+	@Override
+	public void afterPropertiesSet() {
+		// Rebinds environment properties to NacosConfigProperties
+		Binder binder = Binder.get(environment);
+		String nacosPrefix = NacosPropertiesPrefixer.getPrefix(binder);
+		String nacosConfigPrefix = nacosPrefix + ".config";
+		NacosConfigProperties newProperties = binder
+				.bind(nacosPrefix, Bindable.of(NacosConfigDataLoadProperties.class), bindHandler)
+				.map(properties -> binder
+						.bind(nacosConfigPrefix, Bindable.ofInstance(properties), bindHandler)
+						.orElse(properties))
+				.orElseGet(() -> binder
+						.bind(nacosConfigPrefix, Bindable.of(NacosConfigDataLoadProperties.class), bindHandler)
+						.orElse(null));
+		if (Objects.nonNull(newProperties)) {
+			// Update current instance's properties
+			this.nacosConfigProperties = newProperties;
+			// Safely update singleton instance
+			if (INSTANCE != null) {
+				synchronized (NacosConfigManager.class) {
+					if (INSTANCE != null) {
+						INSTANCE.nacosConfigProperties = newProperties;
+						// Recreate ConfigService if needed
+						recreateConfigService(newProperties);
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Recreates the ConfigService using new properties after shutting down the previous one.
+	 *
+	 * @param properties the new Nacos config properties
+	 */
+	private void recreateConfigService(NacosConfigProperties properties) {
+		if (service != null) {
+			service = null;
+		}
+		createConfigService(properties);
+	}
+
+	/**
+	 * Sets the bind handler for configuration properties binding.
+	 * <p>This method is typically called during early Spring startup phase,
+	 * such as in {@link NacosConfigDataLocationResolver} class.</p>
+	 *
+	 * @param handler the bind handler to set
+	 */
+	public static void setBindHandler(BindHandler handler) {
+		bindHandler = handler;
+	}
+
+	/**
+	 * Get BindHandler.
+	 *
+	 */
+	public static BindHandler getBindHandler() {
+		return bindHandler;
 	}
 
 }

--- a/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/configdata/NacosConfigDataLocationResolver.java
+++ b/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/configdata/NacosConfigDataLocationResolver.java
@@ -117,7 +117,10 @@ public class NacosConfigDataLocationResolver
 
 	@Override
 	public boolean isResolvable(ConfigDataLocationResolverContext context,
-			ConfigDataLocation location) {
+								ConfigDataLocation location) {
+		if (NacosConfigManager.getBindHandler() == null) {
+			NacosConfigManager.setBindHandler(this.getBindHandler(context));
+		}
 		if (!location.hasPrefix(getPrefix())) {
 			return false;
 		}
@@ -196,7 +199,7 @@ public class NacosConfigDataLocationResolver
 	}
 
 	private void registerConfigManager(NacosConfigProperties properties,
-			ConfigurableBootstrapContext bootstrapContext) {
+									   ConfigurableBootstrapContext bootstrapContext) {
 		if (!bootstrapContext.isRegistered(NacosConfigManager.class)) {
 			bootstrapContext.register(NacosConfigManager.class,
 					InstanceSupplier.of(NacosConfigManager.getInstance(properties)));

--- a/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/test/java/com.alibaba.cloud.nacos/endpoint/NacosConfigEndpointTests.java
+++ b/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/test/java/com.alibaba.cloud.nacos/endpoint/NacosConfigEndpointTests.java
@@ -23,6 +23,7 @@ import com.alibaba.cloud.nacos.NacosConfigBootstrapConfiguration;
 import com.alibaba.cloud.nacos.NacosConfigManager;
 import com.alibaba.cloud.nacos.NacosConfigProperties;
 import com.alibaba.cloud.nacos.refresh.NacosRefreshHistory;
+import com.alibaba.nacos.api.config.ConfigService;
 import com.alibaba.nacos.client.config.NacosConfigService;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -81,6 +82,11 @@ public class NacosConfigEndpointTests {
 		try {
 			Builder builder = new Builder();
 
+			ConfigService configService = properties.configServiceInstance();
+			// 因为 NacosConfigManager 的 afterPropertiesSet 中会重新创建 ConfigService，
+			// 导致当前测试用例类最开始 static 块中 Mockito 固定设置的 UP 失效，所以这里重新设置一下。
+			// 测试用例 static 块中固定设置的 UP，实际上为了跑测试用例，是假UP，这里重新设置没有逻辑影响。
+			Mockito.when(configService.getServerStatus()).thenReturn("UP");
 			NacosConfigHealthIndicator healthIndicator = new NacosConfigHealthIndicator(
 					properties.configServiceInstance());
 			healthIndicator.doHealthCheck(builder);


### PR DESCRIPTION
fix: NacosConfigDataLocationResolver 在未使用 optional:nacos: 进行 import 时，Spring 中 NacosConfigManager Bean 实例属性为默认值问题  (issue #4147)  https://github.com/alibaba/spring-cloud-alibaba/issues/4147

**应用场景：** 
需要使用 config 配置中心，但是不需要在配置文件中通过 import 的 nacos: 标识导入任何dataId，项目仅需要使用 NacosConfigManager 获取 ConfigService 来动态调用nacos配置。