### PR TITLE
fix: add MappingFastJsonMessageConverter to native-image reflect-config

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/resources/META-INF/native-image/reflect-config.json
@@ -232,6 +232,12 @@
     "allPublicMethods": true
   },
   {
+    "name": "com.alibaba.fastjson.support.spring.messaging.MappingFastJsonMessageConverter",
+    "allDeclaredConstructors": true,
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true
+  },
+  {
     "name": "org.springframework.integration.config.ConverterRegistrar$IntegrationConverterRegistration",
     "allDeclaredFields": true,
     "queryAllDeclaredMethods": true,


### PR DESCRIPTION
Fixes #4083.

## Problem

When running with GraalVM native-image, `RocketMQMessageConverter` uses reflective instantiation to load `MappingFastJsonMessageConverter`:

```java
// RocketMQMessageConverter.java line 73
messageConverters.add((MessageConverter) ClassUtils.forName(
    "com.alibaba.fastjson.support.spring.messaging.MappingFastJsonMessageConverter",
    ClassUtils.getDefaultClassLoader()).newInstance());
```

Without a `reflect-config.json` entry, this reflective access fails silently under native-image (caught by the existing try-catch), causing the converter to be **missing** from the converter list.

This leads to `StreamBridge.send()` returning `null` from `functionToInvoke.apply()`, resulting in a `NullPointerException` in `postProcessResult`.

## Fix

Added `MappingFastJsonMessageConverter` to `spring-cloud-starter-stream-rocketmq`'s `META-INF/native-image/reflect-config.json`:

```json
{
  "name": "com.alibaba.fastjson.support.spring.messaging.MappingFastJsonMessageConverter",
  "allDeclaredConstructors": true,
  "allDeclaredFields": true,
  "allDeclaredMethods": true
}
```

This ensures the reflective `newInstance()` call succeeds under native-image, and the FastJSON message converter is properly registered.
