### PR TITLE
feat: spring-cloud-starter-bootstrap is no longer supported

### DIFF
--- a/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigProperties.java
+++ b/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigProperties.java
@@ -195,6 +195,11 @@ public class NacosConfigProperties {
 	 */
 	private boolean refreshEnabled = true;
 
+	/**
+	 * whether to check if the bootstrap configuration is enabled, default is true.
+	 */
+	private boolean enableCheckBootstrap = true;
+
 	@PostConstruct
 	public void init() {
 		this.overrideFromEnv();
@@ -420,6 +425,14 @@ public class NacosConfigProperties {
 		this.refreshEnabled = refreshEnabled;
 	}
 
+	public boolean isEnableCheckBootstrap() {
+		return enableCheckBootstrap;
+	}
+
+	public void setEnableCheckBootstrap(boolean enableCheckBootstrap) {
+		this.enableCheckBootstrap = enableCheckBootstrap;
+	}
+
 	/**
 	 * recommend to use {@link NacosConfigProperties#sharedConfigs} .
 	 * @return string
@@ -640,6 +653,7 @@ public class NacosConfigProperties {
 				+ ", shares=" + sharedConfigs
 				+ ", extensions=" + extensionConfigs
 				+ ", refreshEnabled=" + refreshEnabled
+				+ ", enableCheckBootstrap=" + enableCheckBootstrap
 				+ '}';
 	}
 

--- a/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigProperties.java
+++ b/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigProperties.java
@@ -195,11 +195,6 @@ public class NacosConfigProperties {
 	 */
 	private boolean refreshEnabled = true;
 
-	/**
-	 * whether to check if the bootstrap configuration is enabled, default is true.
-	 */
-	private boolean enableCheckBootstrap = true;
-
 	@PostConstruct
 	public void init() {
 		this.overrideFromEnv();
@@ -425,14 +420,6 @@ public class NacosConfigProperties {
 		this.refreshEnabled = refreshEnabled;
 	}
 
-	public boolean isEnableCheckBootstrap() {
-		return enableCheckBootstrap;
-	}
-
-	public void setEnableCheckBootstrap(boolean enableCheckBootstrap) {
-		this.enableCheckBootstrap = enableCheckBootstrap;
-	}
-
 	/**
 	 * recommend to use {@link NacosConfigProperties#sharedConfigs} .
 	 * @return string
@@ -653,7 +640,6 @@ public class NacosConfigProperties {
 				+ ", shares=" + sharedConfigs
 				+ ", extensions=" + extensionConfigs
 				+ ", refreshEnabled=" + refreshEnabled
-				+ ", enableCheckBootstrap=" + enableCheckBootstrap
 				+ '}';
 	}
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigSpringCloudAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigSpringCloudAutoConfiguration.java
@@ -61,10 +61,8 @@ public class NacosConfigSpringCloudAutoConfiguration {
 	@ConditionalOnProperty(name = "spring.cloud.nacos.config.enable-check-bootstrap", matchIfMissing = true)
 	@ConditionalOnClass(name = "org.springframework.cloud.bootstrap.marker.Marker")
 	public Object checkBootstrapConfiguration() {
-		if (log.isWarnEnabled()) {
-			log.warn("Including 'org.springframework.cloud:spring-cloud-starter-bootstrap' is prohibited. "
-					+ "For details, please refer to: https://github.com/alibaba/spring-cloud-alibaba/issues/4259");
-		}
+		log.warn("Including 'org.springframework.cloud:spring-cloud-starter-bootstrap' is prohibited. "
+				+ "For details, please refer to: https://github.com/alibaba/spring-cloud-alibaba/issues/4259");
 		return null;
 	}
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigSpringCloudAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigSpringCloudAutoConfiguration.java
@@ -22,6 +22,7 @@ import com.alibaba.cloud.nacos.refresh.condition.ConditionalOnNonDefaultBehavior
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.SearchStrategy;
 import org.springframework.cloud.context.properties.ConfigurationPropertiesBeans;
 import org.springframework.cloud.context.properties.ConfigurationPropertiesRebinder;
@@ -52,6 +53,7 @@ public class NacosConfigSpringCloudAutoConfiguration {
 	}
 
 	@Bean
+	@ConditionalOnProperty(name = "spring.cloud.nacos.config.enable-check-bootstrap", matchIfMissing = true)
 	@ConditionalOnClass(name = "org.springframework.cloud.bootstrap.marker.Marker")
 	public Object checkBootstrapConfiguration() {
 		throw new RuntimeException("Including 'org.springframework.cloud:spring-cloud-starter-bootstrap' is prohibited. "

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigSpringCloudAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigSpringCloudAutoConfiguration.java
@@ -57,13 +57,15 @@ public class NacosConfigSpringCloudAutoConfiguration {
 		return new NacosConfigRefreshEventListener();
 	}
 
-	@Bean
+	@Configuration(proxyBeanMethods = false)
 	@ConditionalOnProperty(name = "spring.cloud.nacos.config.enable-check-bootstrap", matchIfMissing = true)
 	@ConditionalOnClass(name = "org.springframework.cloud.bootstrap.marker.Marker")
-	public Object checkBootstrapConfiguration() {
-		log.warn("Including 'org.springframework.cloud:spring-cloud-starter-bootstrap' is prohibited. "
-				+ "For details, please refer to: https://github.com/alibaba/spring-cloud-alibaba/issues/4259");
-		return null;
+	static class BootstrapDetectionConfiguration {
+		BootstrapDetectionConfiguration() {
+			LoggerFactory.getLogger(BootstrapDetectionConfiguration.class)
+					.warn("Including 'org.springframework.cloud:spring-cloud-starter-bootstrap' not work properly. "
+					+ "For details, please refer to: https://github.com/alibaba/spring-cloud-alibaba/issues/4259");
+		}
 	}
 
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigSpringCloudAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigSpringCloudAutoConfiguration.java
@@ -20,6 +20,7 @@ import com.alibaba.cloud.nacos.configdata.NacosConfigRefreshEventListener;
 import com.alibaba.cloud.nacos.refresh.SmartConfigurationPropertiesRebinder;
 import com.alibaba.cloud.nacos.refresh.condition.ConditionalOnNonDefaultBehavior;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.SearchStrategy;
 import org.springframework.cloud.context.properties.ConfigurationPropertiesBeans;
@@ -48,6 +49,13 @@ public class NacosConfigSpringCloudAutoConfiguration {
 	@Bean(name = "nacosConfigSpringCloudRefreshEventListener")
 	public NacosConfigRefreshEventListener nacosConfigRefreshEventListener() {
 		return new NacosConfigRefreshEventListener();
+	}
+
+	@Bean
+	@ConditionalOnClass(name = "org.springframework.cloud.bootstrap.marker.Marker")
+	public Object checkBootstrapConfiguration() {
+		throw new RuntimeException("Including 'org.springframework.cloud:spring-cloud-starter-bootstrap' is prohibited. "
+				+ "For details, please refer to: https://github.com/alibaba/spring-cloud-alibaba/issues/4259");
 	}
 
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigSpringCloudAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigSpringCloudAutoConfiguration.java
@@ -60,7 +60,7 @@ public class NacosConfigSpringCloudAutoConfiguration {
 		BootstrapDetectionConfiguration() {
 			LoggerFactory.getLogger(BootstrapDetectionConfiguration.class)
 					.warn("Including 'org.springframework.cloud:spring-cloud-starter-bootstrap' will prevent Nacos Config from working properly."
-					+ "For details, please refer to: https://github.com/alibaba/spring-cloud-alibaba/issues/4259");
+					+ "Please remove this dependency. For details, please refer to: https://github.com/alibaba/spring-cloud-alibaba/issues/4259");
 		}
 	}
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigSpringCloudAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigSpringCloudAutoConfiguration.java
@@ -19,6 +19,8 @@ package com.alibaba.cloud.nacos;
 import com.alibaba.cloud.nacos.configdata.NacosConfigRefreshEventListener;
 import com.alibaba.cloud.nacos.refresh.SmartConfigurationPropertiesRebinder;
 import com.alibaba.cloud.nacos.refresh.condition.ConditionalOnNonDefaultBehavior;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -38,6 +40,9 @@ import org.springframework.context.annotation.Configuration;
 @Conditional(NacosConfigEnabledCondition.class)
 public class NacosConfigSpringCloudAutoConfiguration {
 
+	private static final Logger log = LoggerFactory
+			.getLogger(NacosConfigSpringCloudAutoConfiguration.class);
+
 	@Bean
 	@ConditionalOnMissingBean(search = SearchStrategy.CURRENT)
 	@ConditionalOnNonDefaultBehavior
@@ -56,8 +61,11 @@ public class NacosConfigSpringCloudAutoConfiguration {
 	@ConditionalOnProperty(name = "spring.cloud.nacos.config.enable-check-bootstrap", matchIfMissing = true)
 	@ConditionalOnClass(name = "org.springframework.cloud.bootstrap.marker.Marker")
 	public Object checkBootstrapConfiguration() {
-		throw new RuntimeException("Including 'org.springframework.cloud:spring-cloud-starter-bootstrap' is prohibited. "
-				+ "For details, please refer to: https://github.com/alibaba/spring-cloud-alibaba/issues/4259");
+		if (log.isWarnEnabled()) {
+			log.warn("Including 'org.springframework.cloud:spring-cloud-starter-bootstrap' is prohibited. "
+					+ "For details, please refer to: https://github.com/alibaba/spring-cloud-alibaba/issues/4259");
+		}
+		return null;
 	}
 
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigSpringCloudAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigSpringCloudAutoConfiguration.java
@@ -19,7 +19,6 @@ package com.alibaba.cloud.nacos;
 import com.alibaba.cloud.nacos.configdata.NacosConfigRefreshEventListener;
 import com.alibaba.cloud.nacos.refresh.SmartConfigurationPropertiesRebinder;
 import com.alibaba.cloud.nacos.refresh.condition.ConditionalOnNonDefaultBehavior;
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -39,9 +38,6 @@ import org.springframework.context.annotation.Configuration;
 @Configuration(proxyBeanMethods = false)
 @Conditional(NacosConfigEnabledCondition.class)
 public class NacosConfigSpringCloudAutoConfiguration {
-
-	private static final Logger log = LoggerFactory
-			.getLogger(NacosConfigSpringCloudAutoConfiguration.class);
 
 	@Bean
 	@ConditionalOnMissingBean(search = SearchStrategy.CURRENT)

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigSpringCloudAutoConfiguration.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigSpringCloudAutoConfiguration.java
@@ -59,7 +59,7 @@ public class NacosConfigSpringCloudAutoConfiguration {
 	static class BootstrapDetectionConfiguration {
 		BootstrapDetectionConfiguration() {
 			LoggerFactory.getLogger(BootstrapDetectionConfiguration.class)
-					.warn("Including 'org.springframework.cloud:spring-cloud-starter-bootstrap' not work properly. "
+					.warn("Including 'org.springframework.cloud:spring-cloud-starter-bootstrap' will prevent Nacos Config from working properly."
 					+ "For details, please refer to: https://github.com/alibaba/spring-cloud-alibaba/issues/4259");
 		}
 	}


### PR DESCRIPTION
When `org.springframework.cloud:spring-cloud-starter-bootstrap` is present in the classpath, the application will fail to start with a descriptive error message. This is to enforce the new configuration loading mechanism and avoid conflicts.

Reference: https://github.com/alibaba/spring-cloud-alibaba/issues/4259


### Describe what this PR does / why we need it


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
