### PR TITLE
fix: Upgrade nacos client version to 3.1.1 to fix NPE on application shutdown

### DIFF
--- a/spring-cloud-alibaba-dependencies/pom.xml
+++ b/spring-cloud-alibaba-dependencies/pom.xml
@@ -20,7 +20,7 @@
     <properties>
         <revision>2025.0.0.1-SNAPSHOT</revision>
         <sentinel.version>1.8.9</sentinel.version>
-        <nacos.client.version>3.0.3</nacos.client.version>
+        <nacos.client.version>3.1.1</nacos.client.version>
         <seata.version>2.5.0</seata.version>
 
         <!-- Apache RocketMQ -->


### PR DESCRIPTION
### Describe what this PR does / why we need it

Upgrades the Nacos client from 3.0.3 to 3.1.1 in the 2025.0.x branch. When the application shuts down, the old client can throw a `NullPointerException` in `NotifyCenter.deregisterSubscriber()` because `NotifyCenter.INSTANCE` may already be null during shutdown. Nacos client 3.1.1 fixes this shutdown order issue.

### Does this pull request fix one issue?

Fixes gh-4247

### Describe how you did it

Bumped `nacos.client.version` in `spring-cloud-alibaba-dependencies/pom.xml` from `3.0.3` to `3.1.1`, consistent with the fix already applied in 2025.1.x (see PR #4204).

### Describe how to verify it

1. Build the project: `./mvnw install -DskipTests`
2. Run an application with Nacos Discovery and trigger graceful shutdown; the previous NPE in `NacosGracefulShutdownDelegate` should no longer occur.

### Special notes for reviews

Backport of the Nacos client version upgrade (3.1.1) to 2025.0.x for users who cannot move to 2025.1.x yet.
