### PR TITLE
fix: handle NPE when Nacos NotifyCenter.INSTANCE is null during graceful shutdown

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosGracefulShutdownDelegate.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosGracefulShutdownDelegate.java
@@ -66,7 +66,15 @@ public class NacosGracefulShutdownDelegate implements ApplicationListener<Contex
 
 	protected void doGracefulShutdown() {
 		try {
-			autoServiceRegistration.stop();
+			try {
+				autoServiceRegistration.stop();
+			}
+			catch (NullPointerException npe) {
+				// Nacos NotifyCenter.INSTANCE may already be null when deregisterSubscriber
+				// is called, if Nacos client shutdown hooks ran before this delegate.
+				// This is a known race condition in Nacos client graceful shutdown.
+				log.warn("Nacos client NotifyCenter already destroyed, skipping stop()", npe);
+			}
 			Integer gracefulShutdownWaitTime = this.nacosDiscoveryProperties.getGracefulShutdownWaitTime();
 			if (gracefulShutdownWaitTime != null && gracefulShutdownWaitTime > 0) {
 				ThreadUtils.sleep(gracefulShutdownWaitTime);


### PR DESCRIPTION
## What
When Spring context closes, `NacosGracefulShutdownDelegate` calls `autoServiceRegistration.stop()` which internally deregisters subscribers from Nacos `NotifyCenter`. However, if the Nacos client shutdown hooks have already destroyed `NotifyCenter.INSTANCE`, this results in:

```
java.lang.NullPointerException: Cannot read field "sharePublisher" because "com.alibaba.nacos.common.notify.NotifyCenter.INSTANCE" is null
  at com.alibaba.nacos.common.notify.NotifyCenter.deregisterSubscriber(NotifyCenter.java:242)
  at com.alibaba.nacos.client.naming.remote.gprc.NamingGrpcClientProxy.shutdown(NamingGrpcClientProxy.java:537)
  at com.alibaba.nacos.client.naming.remote.NamingClientProxyDelegate.shutdown(NamingClientProxyDelegate.java:212)
  at com.alibaba.nacos.client.naming.NacosNamingService.shutDown(NacosNamingService.java:637)
  at com.alibaba.cloud.nacos.NacosServiceManager.nacosServiceShutDown(NacosServiceManager.java:117)
  at com.alibaba.cloud.nacos.registry.NacosServiceRegistry.close(NacosServiceRegistry.java:120)
```

## Fix
Wrap the `stop()` call in an inner try-catch to gracefully handle this race condition by logging a warning instead of propagating the error.

## Testing
- Existing `NacosGracefulShutdownDelegateTests` continue to pass

## Related Issues
Fixes #4247
Fixes #4081