### PR TITLE
fix: handle NPE when NotifyCenter.INSTANCE is null during graceful shutdown

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosGracefulShutdownDelegate.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/registry/NacosGracefulShutdownDelegate.java
@@ -2,8 +2,8 @@
  * Copyright 2013-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *      https://www.apache.org/licenses/LICENSE-2.0
  *
@@ -74,6 +74,11 @@ public class NacosGracefulShutdownDelegate implements ApplicationListener<Contex
 
 			log.info("Nacos client graceful shutdown has been executed successfully. " +
 					"Graceful shutdown wait time is {}", gracefulShutdownWaitTime);
+		}
+		catch (NullPointerException e) {
+			// Ignore NPE during shutdown when NotifyCenter.INSTANCE has been destroyed
+			log.warn("Nacos client graceful shutdown encountered NPE (NotifyCenter may already be destroyed). " +
+					"This is safe to ignore during shutdown.", e);
 		}
 		catch (Throwable t) {
 			log.error("Error occurred while performing Nacos client graceful shutdown", t);


### PR DESCRIPTION
## What

When Spring context closes, `NacosGracefulShutdownDelegate.doGracefulShutdown()` calls `autoServiceRegistration.stop()` which internally deregisters subscribers from Nacos `NotifyCenter`. However, if the Nacos client shutdown hooks have already destroyed `NotifyCenter.INSTANCE`, this results in:

```
java.lang.NullPointerException: Cannot read field "sharePublisher" because "NotifyCenter.INSTANCE" is null
```

## Fix

Add explicit `NullPointerException` catch in `doGracefulShutdown()` and log a warning instead of propagating, since this NPE is safe to ignore during shutdown when the NotifyCenter has already been cleaned up.

## Testing

The existing test `sameContextShouldTriggerStop` and other tests in `NacosGracefulShutdownDelegateTests` continue to pass since they mock `autoServiceRegistration.stop()` to not throw NPE.

Fixes #4283
