### PR TITLE
fix: handle exceptions during Nacos service shutdown to prevent NPE propagation

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosServiceManager.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosServiceManager.java
@@ -114,11 +114,29 @@ public class NacosServiceManager {
 
 	public void nacosServiceShutDown() throws NacosException {
 		if (Objects.nonNull(this.namingService)) {
-			this.namingService.shutDown();
+			try {
+				this.namingService.shutDown();
+			}
+			catch (NacosException e) {
+				log.error("Nacos naming service shutDown failed", e);
+			}
+			catch (Exception e) {
+				log.warn("Nacos naming service shutDown failed, "
+						+ "possibly caused by shutdown order", e);
+			}
 			this.namingService = null;
 		}
 		if (Objects.nonNull(this.namingMaintainService)) {
-			this.namingMaintainService.shutDown();
+			try {
+				this.namingMaintainService.shutDown();
+			}
+			catch (NacosException e) {
+				log.error("Nacos naming maintain service shutDown failed", e);
+			}
+			catch (Exception e) {
+				log.warn("Nacos naming maintain service shutDown failed, "
+						+ "possibly caused by shutdown order", e);
+			}
 			this.namingMaintainService = null;
 		}
 	}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/NacosServiceManagerTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/NacosServiceManagerTests.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2013-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.nacos;
+
+import java.lang.reflect.Field;
+
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.naming.NamingMaintainService;
+import com.alibaba.nacos.api.naming.NamingService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@link NacosServiceManager}.
+ *
+ * @author daguimu
+ */
+@ExtendWith(MockitoExtension.class)
+public class NacosServiceManagerTests {
+
+	@Mock
+	private NamingService namingService;
+
+	@Mock
+	private NamingMaintainService namingMaintainService;
+
+	private NacosServiceManager nacosServiceManager;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		nacosServiceManager = new NacosServiceManager();
+		setField(nacosServiceManager, "namingService", namingService);
+		setField(nacosServiceManager, "namingMaintainService", namingMaintainService);
+	}
+
+	@Test
+	public void normalShutdownShouldSucceed() throws NacosException {
+		nacosServiceManager.nacosServiceShutDown();
+
+		verify(namingService).shutDown();
+		verify(namingMaintainService).shutDown();
+		assertThat(getField(nacosServiceManager, "namingService")).isNull();
+		assertThat(getField(nacosServiceManager, "namingMaintainService")).isNull();
+	}
+
+	@Test
+	public void namingServiceNpeShutdownShouldNotPropagate() throws NacosException {
+		doThrow(new NullPointerException(
+				"Cannot read field \"sharePublisher\" because \"com.alibaba.nacos.common.notify.NotifyCenter.INSTANCE\" is null"))
+				.when(namingService).shutDown();
+
+		nacosServiceManager.nacosServiceShutDown();
+
+		verify(namingService).shutDown();
+		verify(namingMaintainService).shutDown();
+		assertThat(getField(nacosServiceManager, "namingService")).isNull();
+		assertThat(getField(nacosServiceManager, "namingMaintainService")).isNull();
+	}
+
+	@Test
+	public void namingMaintainServiceNpeShutdownShouldNotPropagate() throws NacosException {
+		doThrow(new NullPointerException("NotifyCenter.INSTANCE is null"))
+				.when(namingMaintainService).shutDown();
+
+		nacosServiceManager.nacosServiceShutDown();
+
+		verify(namingService).shutDown();
+		verify(namingMaintainService).shutDown();
+		assertThat(getField(nacosServiceManager, "namingService")).isNull();
+		assertThat(getField(nacosServiceManager, "namingMaintainService")).isNull();
+	}
+
+	@Test
+	public void bothServicesFailShouldStillCleanUp() throws NacosException {
+		doThrow(new NullPointerException("INSTANCE is null"))
+				.when(namingService).shutDown();
+		doThrow(new NacosException(500, "shutdown error"))
+				.when(namingMaintainService).shutDown();
+
+		nacosServiceManager.nacosServiceShutDown();
+
+		verify(namingService).shutDown();
+		verify(namingMaintainService).shutDown();
+		assertThat(getField(nacosServiceManager, "namingService")).isNull();
+		assertThat(getField(nacosServiceManager, "namingMaintainService")).isNull();
+	}
+
+	@Test
+	public void nacosExceptionDuringShutdownShouldNotPropagate() throws NacosException {
+		doThrow(new NacosException(500, "server error"))
+				.when(namingService).shutDown();
+
+		nacosServiceManager.nacosServiceShutDown();
+
+		verify(namingService).shutDown();
+		verify(namingMaintainService).shutDown();
+		assertThat(getField(nacosServiceManager, "namingService")).isNull();
+	}
+
+	@Test
+	public void nullServicesShouldNotFail() throws NacosException {
+		setField(nacosServiceManager, "namingService", null);
+		setField(nacosServiceManager, "namingMaintainService", null);
+
+		nacosServiceManager.nacosServiceShutDown();
+
+		verify(namingService, never()).shutDown();
+		verify(namingMaintainService, never()).shutDown();
+	}
+
+	private static void setField(Object target, String fieldName, Object value) {
+		try {
+			Field field = target.getClass().getDeclaredField(fieldName);
+			field.setAccessible(true);
+			field.set(target, value);
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private static Object getField(Object target, String fieldName) {
+		try {
+			Field field = target.getClass().getDeclaredField(fieldName);
+			field.setAccessible(true);
+			return field.get(target);
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

During application shutdown, `NacosServiceManager.nacosServiceShutDown()` calls `namingService.shutDown()` which internally invokes `NotifyCenter.deregisterSubscriber()`. If the JVM shutdown hooks have already destroyed `NotifyCenter.INSTANCE`, this throws a `NullPointerException`:

```
java.lang.NullPointerException: Cannot read field "sharePublisher" because "com.alibaba.nacos.common.notify.NotifyCenter.INSTANCE" is null
  at com.alibaba.nacos.common.notify.NotifyCenter.deregisterSubscriber(NotifyCenter.java:242)
  at com.alibaba.nacos.client.naming.remote.gprc.NamingGrpcClientProxy.shutdown(...)
  at com.alibaba.cloud.nacos.NacosServiceManager.nacosServiceShutDown(...)
  at com.alibaba.cloud.nacos.registry.NacosServiceRegistry.close(...)
```

This NPE escapes `NacosServiceRegistry.close()` (which only catches `NacosException`) and propagates to `NacosGracefulShutdownDelegate`, causing an alarming ERROR log during every application shutdown.

Additionally, when `namingService.shutDown()` throws, `namingMaintainService.shutDown()` never gets a chance to execute.

### Does this pull request fix one issue?

Fixes #4081
Fixes #4247

### Describe how you did it

Wrapped each `shutDown()` call in `NacosServiceManager.nacosServiceShutDown()` with independent try-catch blocks:

- `NacosException` is caught and logged at ERROR level (real failures)
- Other exceptions (including the NPE race condition) are caught and logged at WARN level (expected during shutdown ordering)
- Service references are always nulled out after shutdown attempt
- Both `namingService` and `namingMaintainService` always get their shutdown attempts, even if one fails

### Describe how to verify it

1. Start a Spring Cloud Alibaba application with Nacos discovery
2. Stop the application
3. Verify no ERROR log from `NacosGracefulShutdownDelegate` during shutdown
4. Run `NacosServiceManagerTests` — all 6 tests pass

### Tests Added

| Change Point | Test |
|-------------|------|
| `namingService.shutDown()` NPE caught at WARN | `testNamingServiceNpeShutdownShouldNotPropagate()` |
| `namingMaintainService.shutDown()` NPE caught at WARN | `testNamingMaintainServiceNpeShutdownShouldNotPropagate()` |
| Both services get shutdown attempt when first fails | `testBothServicesFailShouldStillCleanUp()` |
| `NacosException` caught and logged at ERROR | `testNacosExceptionDuringShutdownShouldNotPropagate()` |
| Normal shutdown still works | `testNormalShutdownShouldSucceed()` |
| Null services handled safely | `testNullServicesShouldNotFail()` |

### Special notes for reviews

- The method signature `throws NacosException` is preserved for backward compatibility, though exceptions are now handled internally
- `NacosServiceRegistry.close()` catch block becomes dead code but is left unchanged to minimize diff
- The existing `NacosGracefulShutdownDelegateTests` (4 tests) continue to pass