### PR TITLE
docs: add Gradle dependency tutorial in README

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -136,6 +136,52 @@ Spring Cloud 使用 Maven 来构建，最快的使用方式是将本项目 clone
 </servers>
 ```
 
+### 如何引入 Gradle 依赖
+
+#### 正式版
+
+在 `build.gradle`（或 `build.gradle.kts`）中通过 `platform` 引入 BOM：
+
+```groovy
+dependencies {
+    implementation platform("com.alibaba.cloud:spring-cloud-alibaba-dependencies:2025.1.0.0")
+
+    // 按需选择 starter
+    implementation "com.alibaba.cloud:spring-cloud-starter-alibaba-nacos-config"
+}
+```
+
+#### 快照
+
+如果需要使用已发布的`快照版本`，使用快照 BOM 并添加 GitHub Packages 仓库：
+
+```groovy
+repositories {
+    mavenCentral()
+    maven {
+        url = uri("https://maven.pkg.github.com/alibaba/spring-cloud-alibaba")
+        credentials {
+            username = findProperty("gpr.user") ?: System.getenv("GITHUB_USERNAME")
+            password = findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
+        }
+    }
+}
+
+dependencies {
+    implementation platform("com.alibaba.cloud:spring-cloud-alibaba-dependencies:2025.1.0.0-SNAPSHOT")
+
+    // 按需选择 starter
+    implementation "com.alibaba.cloud:spring-cloud-starter-alibaba-nacos-config"
+}
+```
+
+你可以在 `~/.gradle/gradle.properties` 中配置凭据：
+
+```properties
+gpr.user=你的 GitHub 用户名
+gpr.key=你的 GitHub Token（需要 read:packages 权限）
+```
+
 ## 演示 Demo
 
 为了演示如何使用，Spring Cloud Alibaba 项目包含了一个子模块`spring-cloud-alibaba-examples`。此模块中提供了演示用的 example ，您可以阅读对应的 example 工程下的 readme 文档，根据里面的步骤来体验。

--- a/README.md
+++ b/README.md
@@ -132,6 +132,52 @@ Add the following configuration in `settings.xml`.
 </servers>
 ```
 
+### Add Gradle dependency
+
+#### Release Version
+
+Use Maven Central BOM in your `build.gradle` (or `build.gradle.kts`) via `platform`:
+
+```groovy
+dependencies {
+    implementation platform("com.alibaba.cloud:spring-cloud-alibaba-dependencies:2025.1.0.0")
+
+    // choose starter(s) as needed
+    implementation "com.alibaba.cloud:spring-cloud-starter-alibaba-nacos-config"
+}
+```
+
+#### Snapshot
+
+If you need the published `Snapshot Version`, use snapshot BOM and add GitHub Packages repository:
+
+```groovy
+repositories {
+    mavenCentral()
+    maven {
+        url = uri("https://maven.pkg.github.com/alibaba/spring-cloud-alibaba")
+        credentials {
+            username = findProperty("gpr.user") ?: System.getenv("GITHUB_USERNAME")
+            password = findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
+        }
+    }
+}
+
+dependencies {
+    implementation platform("com.alibaba.cloud:spring-cloud-alibaba-dependencies:2025.1.0.0-SNAPSHOT")
+
+    // choose starter(s) as needed
+    implementation "com.alibaba.cloud:spring-cloud-starter-alibaba-nacos-config"
+}
+```
+
+You can put credentials in `~/.gradle/gradle.properties`:
+
+```properties
+gpr.user=Your GitHub Username
+gpr.key=Your GitHub Token (requires read:packages permission)
+```
+
 ## Examples
 
 A `spring-cloud-alibaba-examples` module is included in our project for you to get started with Spring Cloud Alibaba quickly. It contains an example, and you can refer to the readme file in the example project for a quick walkthrough.


### PR DESCRIPTION
## Summary\nAdd Gradle dependency usage documentation to both English and Chinese README files, including release and snapshot configuration examples.\n\n## Changes\n- Add Gradle release BOM usage examples.\n- Add Gradle snapshot repository and credentials examples.\n- Update both \README.md\ and \README-zh.md\.\n\nCloses #217