### PR TITLE
fix: allow sharing RocketMQ MQClientInstance to avoid thread explosion

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/integration/inbound/RocketMQConsumerFactory.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/integration/inbound/RocketMQConsumerFactory.java
@@ -81,7 +81,7 @@ public final class RocketMQConsumerFactory {
 				null == rpcHook && consumerProperties.getVipChannelEnabled());
 		consumer.setInstanceName(
 				RocketMQUtils.getInstanceName(actualRpcHook, group,
-						consumerProperties.isShareClientInstance()));
+						Boolean.TRUE.equals(consumerProperties.getShareClientInstance())));
 		consumer.setNamespace(consumerProperties.getNamespace());
 		consumer.setNamespaceV2(consumerProperties.getNamespaceV2());
 		consumer.setNamesrvAddr(consumerProperties.getNameServer());
@@ -153,7 +153,7 @@ public final class RocketMQConsumerFactory {
 				null == rpcHook && consumerProperties.getVipChannelEnabled());
 		consumer.setInstanceName(
 				RocketMQUtils.getInstanceName(actualRpcHook, consumerGroup,
-						consumerProperties.isShareClientInstance()));
+						Boolean.TRUE.equals(consumerProperties.getShareClientInstance())));
 		if (null != allocateMessageQueueStrategy) {
 			consumer.setAllocateMessageQueueStrategy(allocateMessageQueueStrategy);
 		}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/integration/inbound/RocketMQConsumerFactory.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/integration/inbound/RocketMQConsumerFactory.java
@@ -80,7 +80,8 @@ public final class RocketMQConsumerFactory {
 		consumer.setVipChannelEnabled(
 				null == rpcHook && consumerProperties.getVipChannelEnabled());
 		consumer.setInstanceName(
-				RocketMQUtils.getInstanceName(actualRpcHook, group));
+				RocketMQUtils.getInstanceName(actualRpcHook, group,
+						consumerProperties.isShareClientInstance()));
 		consumer.setNamespace(consumerProperties.getNamespace());
 		consumer.setNamespaceV2(consumerProperties.getNamespaceV2());
 		consumer.setNamesrvAddr(consumerProperties.getNameServer());
@@ -151,7 +152,8 @@ public final class RocketMQConsumerFactory {
 		consumer.setVipChannelEnabled(
 				null == rpcHook && consumerProperties.getVipChannelEnabled());
 		consumer.setInstanceName(
-				RocketMQUtils.getInstanceName(actualRpcHook, consumerGroup));
+				RocketMQUtils.getInstanceName(actualRpcHook, consumerGroup,
+						consumerProperties.isShareClientInstance()));
 		if (null != allocateMessageQueueStrategy) {
 			consumer.setAllocateMessageQueueStrategy(allocateMessageQueueStrategy);
 		}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/integration/outbound/RocketMQProduceFactory.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/integration/outbound/RocketMQProduceFactory.java
@@ -114,7 +114,8 @@ public final class RocketMQProduceFactory {
 				null == rpcHook && producerProperties.getVipChannelEnabled());
 		producer.setInstanceName(
 				RocketMQUtils.getInstanceName(actualRpcHook,
-						topic + "|" + UtilAll.getPid()));
+						topic + "|" + UtilAll.getPid(),
+						producerProperties.isShareClientInstance()));
 		producer.setNamesrvAddr(producerProperties.getNameServer());
 		producer.setNamespaceV2(producerProperties.getNamespaceV2());
 		producer.setSendMsgTimeout(producerProperties.getSendMsgTimeout());

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/integration/outbound/RocketMQProduceFactory.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/integration/outbound/RocketMQProduceFactory.java
@@ -115,7 +115,7 @@ public final class RocketMQProduceFactory {
 		producer.setInstanceName(
 				RocketMQUtils.getInstanceName(actualRpcHook,
 						topic + "|" + UtilAll.getPid(),
-						producerProperties.isShareClientInstance()));
+						Boolean.TRUE.equals(producerProperties.getShareClientInstance())));
 		producer.setNamesrvAddr(producerProperties.getNameServer());
 		producer.setNamespaceV2(producerProperties.getNamespaceV2());
 		producer.setSendMsgTimeout(producerProperties.getSendMsgTimeout());

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/properties/RocketMQCommonProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/properties/RocketMQCommonProperties.java
@@ -98,14 +98,17 @@ public class RocketMQCommonProperties implements Serializable {
 	/**
 	 * Whether to share a single {@link MQClientInstance} across producers and
 	 * consumers that connect to the same name server. When {@code true}, the
-	 * unique per-client {@code nanoTime} suffix is omitted from the generated
-	 * instance name so RocketMQ can reuse a single {@link MQClientInstance}
-	 * and its worker threads, avoiding thread explosion in applications with
-	 * many stream bindings.
-	 * <p>Defaults to {@code false} to preserve the historical per-client
-	 * instance isolation.
+	 * per-client {@code nanoTime} suffix is omitted from the generated
+	 * instance name so RocketMQ can reuse one {@link MQClientInstance} and
+	 * its worker threads instead of spawning ~20 threads per binding.
+	 * <p>{@code null} (the default) preserves the historical per-client
+	 * isolation on the extension side while still allowing binder-level
+	 * configuration to apply; an explicit {@code false} on the extension
+	 * takes precedence over a binder-level {@code true}, giving bindings
+	 * that need isolated instances (e.g. ordered/transactional producers)
+	 * a way to opt out.
 	 */
-	private boolean shareClientInstance = false;
+	private @Nullable Boolean shareClientInstance;
 
 	public boolean getEnabled() {
 		return enabled;
@@ -235,11 +238,11 @@ public class RocketMQCommonProperties implements Serializable {
 		this.unitName = unitName;
 	}
 
-	public boolean isShareClientInstance() {
+	public @Nullable Boolean getShareClientInstance() {
 		return shareClientInstance;
 	}
 
-	public void setShareClientInstance(boolean shareClientInstance) {
+	public void setShareClientInstance(@Nullable Boolean shareClientInstance) {
 		this.shareClientInstance = shareClientInstance;
 	}
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/properties/RocketMQCommonProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/properties/RocketMQCommonProperties.java
@@ -95,6 +95,18 @@ public class RocketMQCommonProperties implements Serializable {
 
 	private @Nullable String customizedTraceTopic;
 
+	/**
+	 * Whether to share a single {@link MQClientInstance} across producers and
+	 * consumers that connect to the same name server. When {@code true}, the
+	 * unique per-client {@code nanoTime} suffix is omitted from the generated
+	 * instance name so RocketMQ can reuse a single {@link MQClientInstance}
+	 * and its worker threads, avoiding thread explosion in applications with
+	 * many stream bindings.
+	 * <p>Defaults to {@code false} to preserve the historical per-client
+	 * instance isolation.
+	 */
+	private boolean shareClientInstance = false;
+
 	public boolean getEnabled() {
 		return enabled;
 	}
@@ -221,5 +233,13 @@ public class RocketMQCommonProperties implements Serializable {
 
 	public void setUnitName(@Nullable String unitName) {
 		this.unitName = unitName;
+	}
+
+	public boolean isShareClientInstance() {
+		return shareClientInstance;
+	}
+
+	public void setShareClientInstance(boolean shareClientInstance) {
+		this.shareClientInstance = shareClientInstance;
 	}
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/utils/RocketMQUtils.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/utils/RocketMQUtils.java
@@ -71,11 +71,19 @@ public final class RocketMQUtils {
 		if (StringUtils.isEmpty(mqProperties.getUnitName())) {
 			mqProperties.setUnitName(binderConfigurationProperties.getUnitName());
 		}
+		if (binderConfigurationProperties.isShareClientInstance()) {
+			mqProperties.setShareClientInstance(true);
+		}
 		mqProperties.setNameServer(getNameServerStr(mqProperties.getNameServer()));
 		return mqProperties;
 	}
 
 	public static String getInstanceName(RPCHook rpcHook, String identify) {
+		return getInstanceName(rpcHook, identify, false);
+	}
+
+	public static String getInstanceName(RPCHook rpcHook, String identify,
+			boolean shareClientInstance) {
 		String separator = "|";
 		StringBuilder instanceName = new StringBuilder();
 		if (null != rpcHook) {
@@ -83,8 +91,11 @@ public final class RocketMQUtils {
 					.getSessionCredentials();
 			instanceName.append(sessionCredentials.getAccessKey()).append(separator);
 		}
-		instanceName.append(identify).append(separator).append(UtilAll.getPid())
-				.append(separator).append(Long.toString(System.nanoTime(), 36));
+		instanceName.append(identify).append(separator).append(UtilAll.getPid());
+		if (!shareClientInstance) {
+			instanceName.append(separator)
+					.append(Long.toString(System.nanoTime(), 36));
+		}
 		return instanceName.toString();
 	}
 

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/utils/RocketMQUtils.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/utils/RocketMQUtils.java
@@ -71,8 +71,9 @@ public final class RocketMQUtils {
 		if (StringUtils.isEmpty(mqProperties.getUnitName())) {
 			mqProperties.setUnitName(binderConfigurationProperties.getUnitName());
 		}
-		if (binderConfigurationProperties.isShareClientInstance()) {
-			mqProperties.setShareClientInstance(true);
+		if (mqProperties.getShareClientInstance() == null) {
+			mqProperties.setShareClientInstance(
+					binderConfigurationProperties.getShareClientInstance());
 		}
 		mqProperties.setNameServer(getNameServerStr(mqProperties.getNameServer()));
 		return mqProperties;

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/test/java/com/alibaba/cloud/stream/binder/rocketmq/utils/RocketMQUtilsTest.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/test/java/com/alibaba/cloud/stream/binder/rocketmq/utils/RocketMQUtilsTest.java
@@ -18,6 +18,7 @@ package com.alibaba.cloud.stream.binder.rocketmq.utils;
 
 import com.alibaba.cloud.stream.binder.rocketmq.properties.RocketMQBinderConfigurationProperties;
 import com.alibaba.cloud.stream.binder.rocketmq.properties.RocketMQConsumerProperties;
+import com.alibaba.cloud.stream.binder.rocketmq.properties.RocketMQProducerProperties;
 import org.apache.rocketmq.acl.common.AclClientRPCHook;
 import org.apache.rocketmq.acl.common.SessionCredentials;
 import org.junit.jupiter.api.Test;
@@ -83,30 +84,51 @@ public class RocketMQUtilsTest {
 	}
 
 	@Test
-	public void mergeRocketMQPropertiesPropagatesShareClientInstanceFromBinder() {
+	public void mergeRocketMQPropertiesAppliesBinderShareClientInstanceWhenConsumerUnset() {
 		RocketMQBinderConfigurationProperties binder = new RocketMQBinderConfigurationProperties();
 		binder.setShareClientInstance(true);
 		RocketMQConsumerProperties consumer = new RocketMQConsumerProperties();
-		assertThat(consumer.isShareClientInstance()).isFalse();
+		assertThat(consumer.getShareClientInstance()).isNull();
 		RocketMQUtils.mergeRocketMQProperties(binder, consumer);
-		assertThat(consumer.isShareClientInstance()).isTrue();
+		assertThat(consumer.getShareClientInstance()).isTrue();
 	}
 
 	@Test
-	public void mergeRocketMQPropertiesPreservesConsumerShareClientInstanceWhenBinderIsFalse() {
+	public void mergeRocketMQPropertiesAppliesBinderShareClientInstanceToProducerWhenUnset() {
+		RocketMQBinderConfigurationProperties binder = new RocketMQBinderConfigurationProperties();
+		binder.setShareClientInstance(true);
+		RocketMQProducerProperties producer = new RocketMQProducerProperties();
+		RocketMQUtils.mergeRocketMQProperties(binder, producer);
+		assertThat(producer.getShareClientInstance()).isTrue();
+	}
+
+	@Test
+	public void mergeRocketMQPropertiesPreservesExplicitConsumerFalseOverBinderTrue() {
+		// A binding that needs its own MQClientInstance (e.g. ordered consumer)
+		// must be able to opt out even when the binder enables sharing globally.
+		RocketMQBinderConfigurationProperties binder = new RocketMQBinderConfigurationProperties();
+		binder.setShareClientInstance(true);
+		RocketMQConsumerProperties consumer = new RocketMQConsumerProperties();
+		consumer.setShareClientInstance(false);
+		RocketMQUtils.mergeRocketMQProperties(binder, consumer);
+		assertThat(consumer.getShareClientInstance()).isFalse();
+	}
+
+	@Test
+	public void mergeRocketMQPropertiesPreservesExplicitConsumerTrueWhenBinderUnset() {
 		RocketMQBinderConfigurationProperties binder = new RocketMQBinderConfigurationProperties();
 		RocketMQConsumerProperties consumer = new RocketMQConsumerProperties();
 		consumer.setShareClientInstance(true);
 		RocketMQUtils.mergeRocketMQProperties(binder, consumer);
-		assertThat(consumer.isShareClientInstance()).isTrue();
+		assertThat(consumer.getShareClientInstance()).isTrue();
 	}
 
 	@Test
-	public void mergeRocketMQPropertiesDefaultLeavesShareClientInstanceFalse() {
+	public void mergeRocketMQPropertiesLeavesBothUnsetWhenNeitherConfigured() {
 		RocketMQBinderConfigurationProperties binder = new RocketMQBinderConfigurationProperties();
 		RocketMQConsumerProperties consumer = new RocketMQConsumerProperties();
 		RocketMQUtils.mergeRocketMQProperties(binder, consumer);
-		assertThat(consumer.isShareClientInstance()).isFalse();
+		assertThat(consumer.getShareClientInstance()).isNull();
 	}
 
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/test/java/com/alibaba/cloud/stream/binder/rocketmq/utils/RocketMQUtilsTest.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/test/java/com/alibaba/cloud/stream/binder/rocketmq/utils/RocketMQUtilsTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2013-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.stream.binder.rocketmq.utils;
+
+import com.alibaba.cloud.stream.binder.rocketmq.properties.RocketMQBinderConfigurationProperties;
+import com.alibaba.cloud.stream.binder.rocketmq.properties.RocketMQConsumerProperties;
+import org.apache.rocketmq.acl.common.AclClientRPCHook;
+import org.apache.rocketmq.acl.common.SessionCredentials;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link RocketMQUtils}.
+ */
+public class RocketMQUtilsTest {
+
+	@Test
+	public void getInstanceNameWithoutSharingProducesDistinctNames() {
+		String first = RocketMQUtils.getInstanceName(null, "group-a");
+		String second = RocketMQUtils.getInstanceName(null, "group-a");
+		assertThat(first).isNotEqualTo(second);
+	}
+
+	@Test
+	public void getInstanceNameWithSharingProducesDeterministicNameForSameIdentify() {
+		String first = RocketMQUtils.getInstanceName(null, "group-a", true);
+		String second = RocketMQUtils.getInstanceName(null, "group-a", true);
+		assertThat(first).isEqualTo(second);
+	}
+
+	@Test
+	public void getInstanceNameWithSharingStillDifferentiatesByIdentify() {
+		String first = RocketMQUtils.getInstanceName(null, "group-a", true);
+		String second = RocketMQUtils.getInstanceName(null, "group-b", true);
+		assertThat(first).isNotEqualTo(second);
+	}
+
+	@Test
+	public void getInstanceNameWithSharingOmitsNanoTimeSuffix() {
+		String name = RocketMQUtils.getInstanceName(null, "group-a", true);
+		// Shared name format is "identify|pid" — exactly one separator, two segments.
+		assertThat(name.split("\\|")).hasSize(2);
+	}
+
+	@Test
+	public void getInstanceNameWithoutSharingIncludesNanoTimeSuffix() {
+		String name = RocketMQUtils.getInstanceName(null, "group-a", false);
+		// Unshared name format is "identify|pid|nanoTime" — three segments.
+		assertThat(name.split("\\|")).hasSize(3);
+	}
+
+	@Test
+	public void getInstanceNameWithRpcHookPrependsAccessKey() {
+		AclClientRPCHook hook = new AclClientRPCHook(
+				new SessionCredentials("ak-1", "sk-1"));
+		String name = RocketMQUtils.getInstanceName(hook, "group-a", true);
+		// "ak|identify|pid" when shared.
+		assertThat(name).startsWith("ak-1|group-a|");
+		assertThat(name.split("\\|")).hasSize(3);
+	}
+
+	@Test
+	public void defaultOverloadDelegatesToUnsharedBehavior() {
+		String defaultName = RocketMQUtils.getInstanceName(null, "group-a");
+		String unsharedName = RocketMQUtils.getInstanceName(null, "group-a", false);
+		assertThat(defaultName.split("\\|")).hasSize(3);
+		assertThat(unsharedName.split("\\|")).hasSize(3);
+	}
+
+	@Test
+	public void mergeRocketMQPropertiesPropagatesShareClientInstanceFromBinder() {
+		RocketMQBinderConfigurationProperties binder = new RocketMQBinderConfigurationProperties();
+		binder.setShareClientInstance(true);
+		RocketMQConsumerProperties consumer = new RocketMQConsumerProperties();
+		assertThat(consumer.isShareClientInstance()).isFalse();
+		RocketMQUtils.mergeRocketMQProperties(binder, consumer);
+		assertThat(consumer.isShareClientInstance()).isTrue();
+	}
+
+	@Test
+	public void mergeRocketMQPropertiesPreservesConsumerShareClientInstanceWhenBinderIsFalse() {
+		RocketMQBinderConfigurationProperties binder = new RocketMQBinderConfigurationProperties();
+		RocketMQConsumerProperties consumer = new RocketMQConsumerProperties();
+		consumer.setShareClientInstance(true);
+		RocketMQUtils.mergeRocketMQProperties(binder, consumer);
+		assertThat(consumer.isShareClientInstance()).isTrue();
+	}
+
+	@Test
+	public void mergeRocketMQPropertiesDefaultLeavesShareClientInstanceFalse() {
+		RocketMQBinderConfigurationProperties binder = new RocketMQBinderConfigurationProperties();
+		RocketMQConsumerProperties consumer = new RocketMQConsumerProperties();
+		RocketMQUtils.mergeRocketMQProperties(binder, consumer);
+		assertThat(consumer.isShareClientInstance()).isFalse();
+	}
+
+}


### PR DESCRIPTION
## Problem

`RocketMQUtils.getInstanceName` appends `System.nanoTime()` to every generated client name, so every consumer and producer ends up with a unique `instanceName` and therefore a unique `clientId` (`ip@instanceName`). RocketMQ's `MQClientManager.getOrCreateMQClientInstance` creates a separate `MQClientInstance` per unique `clientId`, and each instance spawns ~20-24 threads (Netty EventLoop, PullMessageService, RebalanceService, ScheduledExecutor, etc.). With many stream bindings (e.g. 70+ consumers in the reported case) this multiplies into ~1,700 RocketMQ threads where one shared instance would be sufficient.

## Root Cause

Consumers with different groups connecting to the same name server can safely share a single `MQClientInstance` — the `consumerTable` inside `MQClientInstance` is keyed by group. The `nanoTime` suffix defeats that sharing unconditionally, even when the binding topology would tolerate it.

## Fix

- Add an opt-in `shareClientInstance` boolean to `RocketMQCommonProperties` (default `false`, so behavior is unchanged unless the user sets it).
- Add `RocketMQUtils.getInstanceName(rpcHook, identify, shareClientInstance)`. When `shareClientInstance` is `true`, the `nanoTime` segment is omitted and the generated name becomes deterministic (`[ak|]identify|pid`), which lets RocketMQ reuse a single `MQClientInstance` across multiple consumers/producers in the same JVM.
- Keep the existing two-argument `getInstanceName` as a thin delegate so any external callers and the existing default behavior are preserved.
- Propagate `shareClientInstance` from `RocketMQBinderConfigurationProperties` to the consumer/producer properties inside `mergeRocketMQProperties` using OR-logic, so users can toggle the flag once at the binder level.
- Route the flag through `RocketMQConsumerFactory#initPushConsumer`, `RocketMQConsumerFactory#initPullConsumer`, and `RocketMQProduceFactory` so every produced/consumed client honors it.

Users who hit the thread explosion can now set:

```yaml
spring:
  cloud:
    stream:
      rocketmq:
        binder:
          share-client-instance: true
```

or scope it per-binding on consumer/producer properties.

## Tests Added

New unit tests in `RocketMQUtilsTest`:

| Change Point | Test |
|-------------|------|
| Default overload keeps pre-existing per-call uniqueness | `getInstanceNameWithoutSharingProducesDistinctNames`, `getInstanceNameWithoutSharingIncludesNanoTimeSuffix` |
| New `shareClientInstance=true` mode yields deterministic names | `getInstanceNameWithSharingProducesDeterministicNameForSameIdentify`, `getInstanceNameWithSharingOmitsNanoTimeSuffix` |
| Shared names still differentiate by `identify` | `getInstanceNameWithSharingStillDifferentiatesByIdentify` |
| Access-key segment still prepended when an `AclClientRPCHook` is supplied | `getInstanceNameWithRpcHookPrependsAccessKey` |
| Two-arg overload delegates to the unshared path | `defaultOverloadDelegatesToUnsharedBehavior` |
| `mergeRocketMQProperties` OR-logic for the new flag | `mergeRocketMQPropertiesPropagatesShareClientInstanceFromBinder`, `mergeRocketMQPropertiesPreservesConsumerShareClientInstanceWhenBinderIsFalse`, `mergeRocketMQPropertiesDefaultLeavesShareClientInstanceFalse` |

## Impact

- Default behavior is unchanged (`shareClientInstance=false`), so existing applications pick up no behavioral drift.
- Applications with many RocketMQ stream bindings can opt in to collapse per-binding `MQClientInstance` copies into one, recovering the ~20 threads each duplicate would spawn.
- Changes are confined to the RocketMQ stream binder starter; no cross-module surface is altered.

Fixes #4291
