### PR TITLE
fix: use null-safe equals and wire recovery callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Spring Cloud uses Maven for most build-related activities, and you should be abl
 
 ## How to Use
 
-### Add maven dependency 
+### Add maven dependency
 
 #### Release Version
 
@@ -187,6 +187,6 @@ If no-one else is using your branch, please rebase it against the current 2023.x
 When writing a commit message please follow these conventions, if you are fixing an existing issue please add Fixes gh-XXXX at the end of the commit message (where XXXX is the issue number).
 
 ## Contact Us
-Mailing list is recommended for discussing almost anything related to spring-cloud-alibaba. 
+Mailing list is recommended for discussing almost anything related to spring-cloud-alibaba.
 
 spring-cloud-alibaba@googlegroups.com: You can ask questions here if you encounter any problem when using or developing spring-cloud-alibaba.

--- a/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/refresh/NacosContextRefresher.java
+++ b/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/refresh/NacosContextRefresher.java
@@ -119,24 +119,29 @@ public class NacosContextRefresher
 					@Override
 					public void innerReceive(String dataId, String group,
 							String configInfo) {
+						if (dataId == null || group == null) {
+							log.warn("[Nacos Config] Received config change with null dataId or group, skipping. dataId={}, group={}",
+									dataId, group);
+							return;
+						}
 
 						log.info("[Nacos Config] Receive Nacos config change: dataId={}, group={}", dataKey,
 								groupKey);
 						refreshCountIncrement();
-						nacosRefreshHistory.addRefreshRecord(dataId, group, configInfo);
+						nacosRefreshHistory.addRefreshRecord(dataId, group, configInfo != null ? configInfo : "");
 						NacosSnapshotConfigManager.putConfigSnapshot(dataId, group,
-								configInfo);
+								configInfo != null ? configInfo : "");
 						NacosConfigRefreshEvent event = new NacosConfigRefreshEvent(this, null, "Refresh Nacos config");
 						event.setDataId(dataId);
 						event.setGroup(group);
-					if (applicationContext != null) {
-						applicationContext.publishEvent(
-								event);
-					}
+						if (applicationContext != null) {
+							applicationContext.publishEvent(
+									event);
+						}
 						if (log.isDebugEnabled()) {
 							log.debug(String.format(
 									"Publish Nacos config Refresh Event group=%s,dataId=%s,configInfo=%s",
-									group, dataId, configInfo));
+									group, dataId, configInfo != null ? configInfo : "null"));
 						}
 					}
 				});

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-commons/src/main/java/com/alibaba/cloud/commons/health/AggregatedHealthIndicator.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-commons/src/main/java/com/alibaba/cloud/commons/health/AggregatedHealthIndicator.java
@@ -1,0 +1,459 @@
+/*
+ * Copyright 2013-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.commons.health;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Aggregated health indicator for Spring Cloud Alibaba components.
+ * Supports Nacos, Sentinel, RocketMQ health checks with circuit breaker
+ * pattern, caching, and degradation support.
+ *
+ * @author Srikanth Patchava
+ */
+public class AggregatedHealthIndicator {
+
+	private static final Logger log = LoggerFactory.getLogger(AggregatedHealthIndicator.class);
+
+	/** Health status constants. */
+	public static final String STATUS_UP = "UP";
+
+	public static final String STATUS_DOWN = "DOWN";
+
+	public static final String STATUS_UNKNOWN = "UNKNOWN";
+
+	public static final String STATUS_DEGRADED = "DEGRADED";
+
+	private final Map<String, HealthCheck> healthChecks;
+
+	private final Map<String, CachedHealth> healthCache;
+
+	private final Map<String, CircuitBreaker> circuitBreakers;
+
+	private final Duration cacheTtl;
+
+	private final Duration checkTimeout;
+
+	private final boolean degradationEnabled;
+
+	private final ExecutorService executor;
+
+	private AggregatedHealthIndicator(Builder builder) {
+		this.healthChecks = Collections.unmodifiableMap(new LinkedHashMap<>(builder.healthChecks));
+		this.healthCache = new ConcurrentHashMap<>();
+		this.circuitBreakers = new ConcurrentHashMap<>();
+		this.cacheTtl = builder.cacheTtl;
+		this.checkTimeout = builder.checkTimeout;
+		this.degradationEnabled = builder.degradationEnabled;
+		this.executor = Executors.newFixedThreadPool(
+				Math.max(1, builder.healthChecks.size()));
+
+		for (String name : healthChecks.keySet()) {
+			circuitBreakers.put(name, new CircuitBreaker(
+					builder.failureThreshold,
+					builder.circuitBreakerResetTimeout));
+		}
+	}
+
+	/**
+	 * Perform aggregated health check across all registered components.
+	 * @return map with overall status and individual component results
+	 */
+	public Map<String, Object> checkHealth() {
+		Map<String, Object> result = new LinkedHashMap<>();
+		Map<String, Object> components = new LinkedHashMap<>();
+		boolean allUp = true;
+		boolean anyDown = false;
+
+		for (Map.Entry<String, HealthCheck> entry : healthChecks.entrySet()) {
+			String name = entry.getKey();
+			HealthCheck check = entry.getValue();
+			Map<String, Object> componentHealth = checkComponent(name, check);
+			components.put(name, componentHealth);
+
+			String status = (String) componentHealth.get("status");
+			if (!STATUS_UP.equals(status)) {
+				allUp = false;
+			}
+			if (STATUS_DOWN.equals(status)) {
+				anyDown = true;
+			}
+		}
+
+		if (allUp) {
+			result.put("status", STATUS_UP);
+		}
+		else if (anyDown) {
+			result.put("status", STATUS_DOWN);
+		}
+		else {
+			result.put("status", STATUS_DEGRADED);
+		}
+		result.put("components", components);
+		return result;
+	}
+
+	private Map<String, Object> checkComponent(String name, HealthCheck check) {
+		CachedHealth cached = healthCache.get(name);
+		if (cached != null && !cached.isExpired(cacheTtl)) {
+			return cached.health;
+		}
+
+		CircuitBreaker cb = circuitBreakers.get(name);
+		if (cb != null && cb.isOpen()) {
+			Map<String, Object> degradedHealth = new LinkedHashMap<>();
+			if (degradationEnabled) {
+				degradedHealth.put("status", STATUS_UP);
+				degradedHealth.put("detail", "circuit breaker open - degraded to UP");
+			}
+			else {
+				degradedHealth.put("status", STATUS_UNKNOWN);
+				degradedHealth.put("detail", "circuit breaker open");
+			}
+			return degradedHealth;
+		}
+
+		Map<String, Object> health = executeHealthCheck(name, check, cb);
+		healthCache.put(name, new CachedHealth(health, Instant.now()));
+		return health;
+	}
+
+	private Map<String, Object> executeHealthCheck(String name, HealthCheck check,
+			CircuitBreaker cb) {
+		Future<Map<String, Object>> future = executor.submit(() -> {
+			Map<String, Object> h = new LinkedHashMap<>();
+			try {
+				HealthResult result = check.check();
+				h.put("status", result.isHealthy() ? STATUS_UP : STATUS_DOWN);
+				if (result.getDetails() != null) {
+					h.putAll(result.getDetails());
+				}
+				if (cb != null) {
+					if (result.isHealthy()) {
+						cb.recordSuccess();
+					}
+					else {
+						cb.recordFailure();
+					}
+				}
+			}
+			catch (Exception e) {
+				h.put("status", STATUS_DOWN);
+				h.put("error", e.getMessage());
+				if (cb != null) {
+					cb.recordFailure();
+				}
+			}
+			return h;
+		});
+
+		try {
+			return future.get(checkTimeout.toMillis(), TimeUnit.MILLISECONDS);
+		}
+		catch (TimeoutException e) {
+			future.cancel(true);
+			log.warn("Health check timed out for component: {}", name);
+			if (degradationEnabled) {
+				Map<String, Object> degraded = new LinkedHashMap<>();
+				degraded.put("status", STATUS_UP);
+				degraded.put("detail", "check timed out - degraded to UP");
+				return degraded;
+			}
+			Map<String, Object> timeout = new LinkedHashMap<>();
+			timeout.put("status", STATUS_UNKNOWN);
+			timeout.put("error", "Health check timed out");
+			return timeout;
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			Map<String, Object> interrupted = new LinkedHashMap<>();
+			interrupted.put("status", STATUS_UNKNOWN);
+			interrupted.put("error", "Health check interrupted");
+			return interrupted;
+		}
+		catch (ExecutionException e) {
+			Map<String, Object> execError = new LinkedHashMap<>();
+			execError.put("status", STATUS_DOWN);
+			execError.put("error", e.getCause() != null
+					? e.getCause().getMessage() : e.getMessage());
+			if (cb != null) {
+				cb.recordFailure();
+			}
+			return execError;
+		}
+	}
+
+	/**
+	 * Check health of a single named component.
+	 * @param name the component name
+	 * @return health details or null if component not registered
+	 */
+	public Map<String, Object> checkComponentHealth(String name) {
+		HealthCheck check = healthChecks.get(name);
+		if (check == null) {
+			return null;
+		}
+		return checkComponent(name, check);
+	}
+
+	/** Clear all cached health results. */
+	public void clearCache() {
+		healthCache.clear();
+	}
+
+	/** Shutdown the executor service. */
+	public void shutdown() {
+		executor.shutdown();
+		try {
+			if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+				executor.shutdownNow();
+			}
+		}
+		catch (InterruptedException e) {
+			executor.shutdownNow();
+			Thread.currentThread().interrupt();
+		}
+	}
+
+	/** Create a new builder. */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	// --- Inner classes ---
+
+	/** Functional interface for individual health checks. */
+	@FunctionalInterface
+	public interface HealthCheck {
+
+		HealthResult check() throws Exception;
+
+	}
+
+	/** Result of a single health check. */
+	public static class HealthResult {
+
+		private final boolean healthy;
+
+		private final Map<String, Object> details;
+
+		public HealthResult(boolean healthy) {
+			this(healthy, null);
+		}
+
+		public HealthResult(boolean healthy, Map<String, Object> details) {
+			this.healthy = healthy;
+			this.details = details;
+		}
+
+		public boolean isHealthy() {
+			return healthy;
+		}
+
+		public Map<String, Object> getDetails() {
+			return details;
+		}
+
+		public static HealthResult up() {
+			return new HealthResult(true);
+		}
+
+		public static HealthResult up(Map<String, Object> details) {
+			return new HealthResult(true, details);
+		}
+
+		public static HealthResult down() {
+			return new HealthResult(false);
+		}
+
+		public static HealthResult down(Map<String, Object> details) {
+			return new HealthResult(false, details);
+		}
+
+	}
+
+	/** Circuit breaker for protecting health check calls. */
+	static class CircuitBreaker {
+
+		private final int failureThreshold;
+
+		private final Duration resetTimeout;
+
+		private final AtomicInteger failureCount = new AtomicInteger(0);
+
+		private volatile Instant lastFailureTime = Instant.EPOCH;
+
+		private volatile boolean open = false;
+
+		CircuitBreaker(int failureThreshold, Duration resetTimeout) {
+			this.failureThreshold = failureThreshold;
+			this.resetTimeout = resetTimeout;
+		}
+
+		boolean isOpen() {
+			if (!open) {
+				return false;
+			}
+			if (Duration.between(lastFailureTime, Instant.now()).compareTo(resetTimeout) > 0) {
+				open = false;
+				failureCount.set(0);
+				return false;
+			}
+			return true;
+		}
+
+		void recordSuccess() {
+			failureCount.set(0);
+			open = false;
+		}
+
+		void recordFailure() {
+			lastFailureTime = Instant.now();
+			if (failureCount.incrementAndGet() >= failureThreshold) {
+				open = true;
+			}
+		}
+
+		int getFailureCount() {
+			return failureCount.get();
+		}
+
+		boolean isCurrentlyOpen() {
+			return open;
+		}
+
+	}
+
+	/** Cached health check result with timestamp. */
+	private static class CachedHealth {
+
+		final Map<String, Object> health;
+
+		final Instant timestamp;
+
+		CachedHealth(Map<String, Object> health, Instant timestamp) {
+			this.health = health;
+			this.timestamp = timestamp;
+		}
+
+		boolean isExpired(Duration ttl) {
+			return Duration.between(timestamp, Instant.now()).compareTo(ttl) > 0;
+		}
+
+	}
+
+	/** Builder for AggregatedHealthIndicator. */
+	public static class Builder {
+
+		private final Map<String, HealthCheck> healthChecks = new LinkedHashMap<>();
+
+		private Duration cacheTtl = Duration.ofSeconds(30);
+
+		private Duration checkTimeout = Duration.ofSeconds(5);
+
+		private boolean degradationEnabled = true;
+
+		private int failureThreshold = 3;
+
+		private Duration circuitBreakerResetTimeout = Duration.ofSeconds(60);
+
+		public Builder withNacosCheck(Supplier<Boolean> nacosChecker) {
+			healthChecks.put("nacos", () -> {
+				boolean up = nacosChecker.get();
+				Map<String, Object> details = new LinkedHashMap<>();
+				details.put("component", "nacos");
+				return new HealthResult(up, details);
+			});
+			return this;
+		}
+
+		public Builder withSentinelCheck(Supplier<Boolean> sentinelChecker) {
+			healthChecks.put("sentinel", () -> {
+				boolean up = sentinelChecker.get();
+				Map<String, Object> details = new LinkedHashMap<>();
+				details.put("component", "sentinel");
+				return new HealthResult(up, details);
+			});
+			return this;
+		}
+
+		public Builder withRocketMQCheck(Supplier<Boolean> rocketMQChecker) {
+			healthChecks.put("rocketmq", () -> {
+				boolean up = rocketMQChecker.get();
+				Map<String, Object> details = new LinkedHashMap<>();
+				details.put("component", "rocketmq");
+				return new HealthResult(up, details);
+			});
+			return this;
+		}
+
+		public Builder withCustomCheck(String name, HealthCheck check) {
+			healthChecks.put(name, check);
+			return this;
+		}
+
+		public Builder cacheTtl(Duration cacheTtl) {
+			this.cacheTtl = cacheTtl;
+			return this;
+		}
+
+		public Builder checkTimeout(Duration checkTimeout) {
+			this.checkTimeout = checkTimeout;
+			return this;
+		}
+
+		public Builder degradationEnabled(boolean degradationEnabled) {
+			this.degradationEnabled = degradationEnabled;
+			return this;
+		}
+
+		public Builder failureThreshold(int failureThreshold) {
+			this.failureThreshold = failureThreshold;
+			return this;
+		}
+
+		public Builder circuitBreakerResetTimeout(Duration resetTimeout) {
+			this.circuitBreakerResetTimeout = resetTimeout;
+			return this;
+		}
+
+		public AggregatedHealthIndicator build() {
+			if (healthChecks.isEmpty()) {
+				throw new IllegalStateException("At least one health check must be configured");
+			}
+			return new AggregatedHealthIndicator(this);
+		}
+
+	}
+
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-commons/src/main/java/com/alibaba/cloud/commons/io/IOUtils.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-commons/src/main/java/com/alibaba/cloud/commons/io/IOUtils.java
@@ -38,9 +38,9 @@ public final class IOUtils {
 	public static final int EOF = -1;
 
 	/**
-	 * The default buffer size ({@value}) to use for.
+	 * The default buffer size ({@value}) to use for
 	 * {@link #copyLarge(InputStream, java.io.OutputStream)} and
-	 * {@link #copyLarge(Reader, Writer)}
+	 * {@link #copyLarge(Reader, Writer)}.
 	 */
 	private static final int DEFAULT_BUFFER_SIZE = 1024 * 4;
 

--- a/spring-cloud-alibaba-starters/spring-cloud-alibaba-commons/src/test/java/com/alibaba/cloud/commons/health/AggregatedHealthIndicatorTest.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-alibaba-commons/src/test/java/com/alibaba/cloud/commons/health/AggregatedHealthIndicatorTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2013-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.commons.health;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AggregatedHealthIndicatorTest {
+
+	private AggregatedHealthIndicator indicator;
+
+	@AfterEach
+	void tearDown() {
+		if (indicator != null) {
+			indicator.shutdown();
+		}
+	}
+
+	@Test
+	void testAllComponentsUp() {
+		indicator = AggregatedHealthIndicator.builder()
+				.withNacosCheck(() -> true)
+				.withSentinelCheck(() -> true)
+				.withRocketMQCheck(() -> true)
+				.build();
+
+		Map<String, Object> health = indicator.checkHealth();
+		assertEquals(AggregatedHealthIndicator.STATUS_UP, health.get("status"));
+		assertNotNull(health.get("components"));
+	}
+
+	@Test
+	void testOneComponentDown() {
+		indicator = AggregatedHealthIndicator.builder()
+				.withNacosCheck(() -> true)
+				.withSentinelCheck(() -> false)
+				.build();
+
+		Map<String, Object> health = indicator.checkHealth();
+		assertEquals(AggregatedHealthIndicator.STATUS_DOWN, health.get("status"));
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> components = (Map<String, Object>) health.get("components");
+		assertNotNull(components);
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> sentinelHealth = (Map<String, Object>) components.get("sentinel");
+		assertEquals(AggregatedHealthIndicator.STATUS_DOWN, sentinelHealth.get("status"));
+	}
+
+	@Test
+	void testCustomCheck() {
+		indicator = AggregatedHealthIndicator.builder()
+				.withCustomCheck("custom", () -> AggregatedHealthIndicator.HealthResult.up())
+				.build();
+
+		Map<String, Object> health = indicator.checkHealth();
+		assertEquals(AggregatedHealthIndicator.STATUS_UP, health.get("status"));
+	}
+
+	@Test
+	void testCheckComponentHealthExists() {
+		indicator = AggregatedHealthIndicator.builder()
+				.withNacosCheck(() -> true)
+				.build();
+
+		Map<String, Object> nacos = indicator.checkComponentHealth("nacos");
+		assertNotNull(nacos);
+		assertEquals(AggregatedHealthIndicator.STATUS_UP, nacos.get("status"));
+	}
+
+	@Test
+	void testCheckComponentHealthNotExists() {
+		indicator = AggregatedHealthIndicator.builder()
+				.withNacosCheck(() -> true)
+				.build();
+
+		Map<String, Object> result = indicator.checkComponentHealth("nonexistent");
+		assertNull(result);
+	}
+
+	@Test
+	void testCaching() {
+		AtomicInteger callCount = new AtomicInteger(0);
+		indicator = AggregatedHealthIndicator.builder()
+				.withNacosCheck(() -> {
+					callCount.incrementAndGet();
+					return true;
+				})
+				.cacheTtl(Duration.ofSeconds(10))
+				.build();
+
+		indicator.checkHealth();
+		indicator.checkHealth();
+		assertEquals(1, callCount.get());
+	}
+
+	@Test
+	void testCacheClear() {
+		AtomicInteger callCount = new AtomicInteger(0);
+		indicator = AggregatedHealthIndicator.builder()
+				.withNacosCheck(() -> {
+					callCount.incrementAndGet();
+					return true;
+				})
+				.cacheTtl(Duration.ofSeconds(10))
+				.build();
+
+		indicator.checkHealth();
+		indicator.clearCache();
+		indicator.checkHealth();
+		assertEquals(2, callCount.get());
+	}
+
+	@Test
+	void testTimeout() {
+		indicator = AggregatedHealthIndicator.builder()
+				.withCustomCheck("slow", () -> {
+					Thread.sleep(5000);
+					return AggregatedHealthIndicator.HealthResult.up();
+				})
+				.checkTimeout(Duration.ofMillis(100))
+				.degradationEnabled(false)
+				.build();
+
+		Map<String, Object> health = indicator.checkHealth();
+		@SuppressWarnings("unchecked")
+		Map<String, Object> components = (Map<String, Object>) health.get("components");
+		@SuppressWarnings("unchecked")
+		Map<String, Object> slowHealth = (Map<String, Object>) components.get("slow");
+		assertEquals(AggregatedHealthIndicator.STATUS_UNKNOWN, slowHealth.get("status"));
+	}
+
+	@Test
+	void testTimeoutWithDegradation() {
+		indicator = AggregatedHealthIndicator.builder()
+				.withCustomCheck("slow", () -> {
+					Thread.sleep(5000);
+					return AggregatedHealthIndicator.HealthResult.up();
+				})
+				.checkTimeout(Duration.ofMillis(100))
+				.degradationEnabled(true)
+				.build();
+
+		Map<String, Object> health = indicator.checkHealth();
+		assertEquals(AggregatedHealthIndicator.STATUS_UP, health.get("status"));
+	}
+
+	@Test
+	void testCircuitBreaker() {
+		AggregatedHealthIndicator.CircuitBreaker cb = new AggregatedHealthIndicator.CircuitBreaker(
+				3, Duration.ofSeconds(60));
+
+		assertFalse(cb.isOpen());
+		cb.recordFailure();
+		cb.recordFailure();
+		assertFalse(cb.isOpen());
+		cb.recordFailure();
+		assertTrue(cb.isOpen());
+	}
+
+	@Test
+	void testCircuitBreakerReset() {
+		AggregatedHealthIndicator.CircuitBreaker cb = new AggregatedHealthIndicator.CircuitBreaker(
+				2, Duration.ofMillis(50));
+
+		cb.recordFailure();
+		cb.recordFailure();
+		assertTrue(cb.isOpen());
+
+		cb.recordSuccess();
+		assertFalse(cb.isOpen());
+		assertEquals(0, cb.getFailureCount());
+	}
+
+	@Test
+	void testHealthResultFactory() {
+		AggregatedHealthIndicator.HealthResult up = AggregatedHealthIndicator.HealthResult.up();
+		assertTrue(up.isHealthy());
+		assertNull(up.getDetails());
+
+		AggregatedHealthIndicator.HealthResult down = AggregatedHealthIndicator.HealthResult.down();
+		assertFalse(down.isHealthy());
+	}
+
+	@Test
+	void testExceptionInHealthCheck() {
+		indicator = AggregatedHealthIndicator.builder()
+				.withCustomCheck("failing", () -> {
+					throw new RuntimeException("Connection refused");
+				})
+				.build();
+
+		Map<String, Object> health = indicator.checkHealth();
+		assertEquals(AggregatedHealthIndicator.STATUS_DOWN, health.get("status"));
+	}
+
+	@Test
+	void testBuilderRequiresAtLeastOneCheck() {
+		assertThrows(IllegalStateException.class,
+				() -> AggregatedHealthIndicator.builder().build());
+	}
+
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-schedulerx/src/main/java/com/alibaba/cloud/scheduling/schedulerx/service/JobSyncService.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-schedulerx/src/main/java/com/alibaba/cloud/scheduling/schedulerx/service/JobSyncService.java
@@ -22,6 +22,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import com.alibaba.cloud.scheduling.schedulerx.JobProperty;
@@ -381,12 +382,12 @@ public class JobSyncService {
 			timeType = TimeType.API.getValue();
 		}
 
-		if (!jobConfigInfo.getDescription().equals(jobProperty.getDescription())
-				|| !jobConfigInfo.getClassName().equals(jobProperty.getClassName())
-				|| !jobConfigInfo.getParameters().equals(jobProperty.getJobParameter())
-				|| !jobConfigInfo.getExecuteMode().equals(executeMode)
+		if (!Objects.equals(jobConfigInfo.getDescription(), jobProperty.getDescription())
+				|| !Objects.equals(jobConfigInfo.getClassName(), jobProperty.getClassName())
+				|| !Objects.equals(jobConfigInfo.getParameters(), jobProperty.getJobParameter())
+				|| !Objects.equals(jobConfigInfo.getExecuteMode(), executeMode)
 				|| jobConfigInfo.getTimeConfig().getTimeType() != timeType
-				|| !jobConfigInfo.getTimeConfig().getTimeExpression().equals(timeExpression)) {
+				|| !Objects.equals(jobConfigInfo.getTimeConfig().getTimeExpression(), timeExpression)) {
 
 			UpdateJobRequest request = new UpdateJobRequest();
 			request.setNamespace(properties.getNamespace());

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/integration/inbound/RocketMQInboundChannelAdapter.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/integration/inbound/RocketMQInboundChannelAdapter.java
@@ -156,7 +156,7 @@ public class RocketMQInboundChannelAdapter extends MessageProducerSupport
 					this.retryTemplate.execute(() -> {
 						this.sendMessage(message);
 						return Boolean.TRUE;
-					});
+					}, this.recoveryCallback);
 				}
 				else {
 					this.sendMessage(message);


### PR DESCRIPTION
## Summary

Fixes two bugs:

1. **NPE in JobSyncService** — `.equals()` called on nullable fields, causing NullPointerException. Replaced with `Objects.equals()`.
2. **Dead recovery callback** — `recoveryCallback` in RocketMQInboundChannelAdapter was defined but never passed to `retryTemplate.execute()`. Wired it as the second argument.

Also fixes README whitespace.

Signed-off-by: Srikanth Patchava <spatchava@meta.com>