### PR TITLE
fix: invoke recovery callback when RocketMQ inbound retries are exhausted

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/integration/inbound/RocketMQInboundChannelAdapter.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/integration/inbound/RocketMQInboundChannelAdapter.java
@@ -36,7 +36,6 @@ import org.slf4j.LoggerFactory;
 
 import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.core.retry.RetryException;
-import org.springframework.core.retry.RetryListener;
 import org.springframework.core.retry.RetryTemplate;
 import org.springframework.integration.context.OrderlyShutdownCapable;
 import org.springframework.integration.core.RecoveryCallback;
@@ -86,8 +85,6 @@ public class RocketMQInboundChannelAdapter extends MessageProducerSupport
 						"Cannot have an 'errorChannel' property when a 'RetryTemplate' is "
 								+ "provided; use an 'ErrorMessageSendingRecoverer' in the 'recoveryCallback' property to "
 								+ "send an error message when retries are exhausted");
-				this.retryTemplate.setRetryListener(new RetryListener() {
-				});
 			}
 			pushConsumer = RocketMQConsumerFactory
 					.initPushConsumer(extendedConsumerProperties);

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/integration/inbound/RocketMQInboundChannelAdapter.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/integration/inbound/RocketMQInboundChannelAdapter.java
@@ -37,12 +37,11 @@ import org.slf4j.LoggerFactory;
 import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.core.retry.RetryException;
 import org.springframework.core.retry.RetryListener;
-import org.springframework.core.retry.RetryPolicy;
 import org.springframework.core.retry.RetryTemplate;
-import org.springframework.core.retry.Retryable;
 import org.springframework.integration.context.OrderlyShutdownCapable;
 import org.springframework.integration.core.RecoveryCallback;
 import org.springframework.integration.endpoint.MessageProducerSupport;
+import org.springframework.integration.support.ErrorMessageUtils;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessagingException;
@@ -146,17 +145,26 @@ public class RocketMQInboundChannelAdapter extends MessageProducerSupport
 				Message<?> message = RocketMQMessageConverterSupport
 						.convertMessage2Spring(messageExt);
 				if (this.retryTemplate != null) {
-					this.retryTemplate.setRetryListener(new RetryListener() {
-						@Override
-						public void onRetryPolicyExhaustion(RetryPolicy retryPolicy, Retryable<?> retryable, RetryException exception) {
-							log.warn("retry exhausted for messageExt: {}",
-									messageExt, exception);
+					try {
+						this.retryTemplate.execute(() -> {
+							this.sendMessage(message);
+							return Boolean.TRUE;
+						});
+					}
+					catch (RetryException retryException) {
+						if (this.recoveryCallback != null) {
+							log.warn("retry exhausted for messageExt: {}; invoking recovery callback",
+									messageExt, retryException);
+							Throwable cause = retryException.getCause() != null
+									? retryException.getCause() : retryException;
+							this.recoveryCallback.recover(
+									ErrorMessageUtils.getAttributeAccessor(message, message),
+									cause);
 						}
-					});
-					this.retryTemplate.execute(() -> {
-						this.sendMessage(message);
-						return Boolean.TRUE;
-					});
+						else {
+							throw retryException;
+						}
+					}
 				}
 				else {
 					this.sendMessage(message);

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/integration/inbound/RocketMQInboundChannelAdapter.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/integration/inbound/RocketMQInboundChannelAdapter.java
@@ -140,6 +140,10 @@ public class RocketMQInboundChannelAdapter extends MessageProducerSupport
 			throw new MessagingException(
 					"DefaultMQPushConsumer consuming failed, Caused by messageExtList is empty");
 		}
+		// With consumeMessageBatchMaxSize > 1, a recoveryCallback that throws midway
+		// through a batch causes the whole batch to be redelivered, so previously
+		// recovered messages will be recovered again. Prefer batchSize=1 when relying
+		// on recoveryCallback for DLQ wiring.
 		for (MessageExt messageExt : messageExtList) {
 			try {
 				Message<?> message = RocketMQMessageConverterSupport
@@ -152,9 +156,9 @@ public class RocketMQInboundChannelAdapter extends MessageProducerSupport
 						});
 					}
 					catch (RetryException retryException) {
+						log.warn("retry exhausted for messageExt: {}",
+								messageExt, retryException);
 						if (this.recoveryCallback != null) {
-							log.warn("retry exhausted for messageExt: {}; invoking recovery callback",
-									messageExt, retryException);
 							Throwable cause = retryException.getCause() != null
 									? retryException.getCause() : retryException;
 							this.recoveryCallback.recover(

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/test/java/com/alibaba/cloud/stream/binder/rocketmq/RocketMQInboundChannelAdapterRecoveryTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/test/java/com/alibaba/cloud/stream/binder/rocketmq/RocketMQInboundChannelAdapterRecoveryTests.java
@@ -234,8 +234,10 @@ public class RocketMQInboundChannelAdapterRecoveryTests {
 				(Supplier<String>) () -> "FAIL",
 				(Supplier<String>) () -> "OK");
 
-		// Recovery was attempted but its own failure propagates to the outer catch, which
-		// returns the failure supplier so RocketMQ can redeliver the message.
+		// Retry template runs the configured 2 attempts before exhaustion, then recovery is
+		// attempted once but its own failure propagates to the outer catch, which returns
+		// the failure supplier so RocketMQ can redeliver the message.
+		assertThat(sendAttempts.get()).isEqualTo(2);
 		assertThat(recoveryInvocations.get()).isEqualTo(1);
 		assertThat(result).isEqualTo("FAIL");
 	}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/test/java/com/alibaba/cloud/stream/binder/rocketmq/RocketMQInboundChannelAdapterRecoveryTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/test/java/com/alibaba/cloud/stream/binder/rocketmq/RocketMQInboundChannelAdapterRecoveryTests.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2013-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.stream.binder.rocketmq;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import com.alibaba.cloud.stream.binder.rocketmq.integration.inbound.RocketMQInboundChannelAdapter;
+import com.alibaba.cloud.stream.binder.rocketmq.properties.RocketMQConsumerProperties;
+import org.apache.rocketmq.common.message.MessageExt;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
+import org.springframework.core.AttributeAccessor;
+import org.springframework.core.retry.RetryPolicy;
+import org.springframework.core.retry.RetryTemplate;
+import org.springframework.integration.core.RecoveryCallback;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.SubscribableChannel;
+import org.springframework.util.backoff.FixedBackOff;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the recovery callback behavior in
+ * {@link RocketMQInboundChannelAdapter} when a {@link RetryTemplate} exhausts
+ * all attempts.
+ */
+public class RocketMQInboundChannelAdapterRecoveryTests {
+
+	@Test
+	public void recoveryCallbackInvokedWhenRetriesExhausted() throws Exception {
+		ExtendedConsumerProperties<RocketMQConsumerProperties> props =
+				new ExtendedConsumerProperties<>(new RocketMQConsumerProperties());
+		RocketMQInboundChannelAdapter adapter = new RocketMQInboundChannelAdapter("topic", props);
+
+		// Output channel that always fails — exercises the retry path.
+		AtomicInteger sendAttempts = new AtomicInteger();
+		SubscribableChannel outputChannel = new SubscribableChannel() {
+			@Override
+			public boolean send(Message<?> message, long timeout) {
+				sendAttempts.incrementAndGet();
+				throw new MessagingException("simulated downstream failure");
+			}
+
+			@Override
+			public boolean send(Message<?> message) {
+				return send(message, -1);
+			}
+
+			@Override
+			public boolean subscribe(MessageHandler handler) {
+				return true;
+			}
+
+			@Override
+			public boolean unsubscribe(MessageHandler handler) {
+				return true;
+			}
+		};
+		adapter.setOutputChannel(outputChannel);
+
+		// 3 total attempts: the initial call plus 2 retries, no backoff so the test is fast.
+		RetryTemplate retryTemplate = new RetryTemplate(
+				RetryPolicy.builder().backOff(new FixedBackOff(0L, 2L)).build());
+		adapter.setRetryTemplate(retryTemplate);
+
+		AtomicReference<Throwable> recoveredCause = new AtomicReference<>();
+		AtomicInteger recoveryInvocations = new AtomicInteger();
+		RecoveryCallback<Object> recoveryCallback = new RecoveryCallback<>() {
+			@Override
+			public Object recover(AttributeAccessor accessor, Throwable throwable) {
+				recoveryInvocations.incrementAndGet();
+				recoveredCause.set(throwable);
+				return null;
+			}
+		};
+		adapter.setRecoveryCallback(recoveryCallback);
+
+		MessageExt messageExt = new MessageExt();
+		messageExt.setBody("payload".getBytes());
+		messageExt.setTopic("topic");
+		messageExt.setMsgId("test-msg-id");
+
+		Method consumeMessage = RocketMQInboundChannelAdapter.class
+				.getDeclaredMethod("consumeMessage", List.class, Supplier.class, Supplier.class);
+		consumeMessage.setAccessible(true);
+
+		Object result = consumeMessage.invoke(adapter,
+				Collections.singletonList(messageExt),
+				(Supplier<String>) () -> "FAIL",
+				(Supplier<String>) () -> "OK");
+
+		// Recovery should have been called exactly once with the underlying cause.
+		assertThat(recoveryInvocations.get()).isEqualTo(1);
+		assertThat(recoveredCause.get()).isNotNull();
+		// The retry template should have invoked the failing handler the configured number of times.
+		assertThat(sendAttempts.get()).isEqualTo(3);
+		// Because recovery succeeded, the loop returns the success supplier value rather than
+		// falling through to the failure path that would trigger redelivery.
+		assertThat(result).isEqualTo("OK");
+	}
+
+	@Test
+	public void retriesExhaustedWithoutRecoveryFallsBackToFailure() throws Exception {
+		ExtendedConsumerProperties<RocketMQConsumerProperties> props =
+				new ExtendedConsumerProperties<>(new RocketMQConsumerProperties());
+		RocketMQInboundChannelAdapter adapter = new RocketMQInboundChannelAdapter("topic", props);
+
+		AtomicInteger sendAttempts = new AtomicInteger();
+		SubscribableChannel outputChannel = new SubscribableChannel() {
+			@Override
+			public boolean send(Message<?> message, long timeout) {
+				sendAttempts.incrementAndGet();
+				throw new MessagingException("simulated downstream failure");
+			}
+
+			@Override
+			public boolean send(Message<?> message) {
+				return send(message, -1);
+			}
+
+			@Override
+			public boolean subscribe(MessageHandler handler) {
+				return true;
+			}
+
+			@Override
+			public boolean unsubscribe(MessageHandler handler) {
+				return true;
+			}
+		};
+		adapter.setOutputChannel(outputChannel);
+
+		// 2 total attempts: the initial call plus 1 retry, no backoff so the test is fast.
+		adapter.setRetryTemplate(new RetryTemplate(
+				RetryPolicy.builder().backOff(new FixedBackOff(0L, 1L)).build()));
+
+		MessageExt messageExt = new MessageExt();
+		messageExt.setBody("payload".getBytes());
+		messageExt.setTopic("topic");
+		messageExt.setMsgId("test-msg-id");
+
+		Method consumeMessage = RocketMQInboundChannelAdapter.class
+				.getDeclaredMethod("consumeMessage", List.class, Supplier.class, Supplier.class);
+		consumeMessage.setAccessible(true);
+
+		Object result = consumeMessage.invoke(adapter,
+				Collections.singletonList(messageExt),
+				(Supplier<String>) () -> "FAIL",
+				(Supplier<String>) () -> "OK");
+
+		// Without a recovery callback, the retry exception bubbles up to the per-message catch
+		// and the failure supplier is returned so RocketMQ can redeliver.
+		assertThat(sendAttempts.get()).isEqualTo(2);
+		assertThat(result).isEqualTo("FAIL");
+	}
+
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/test/java/com/alibaba/cloud/stream/binder/rocketmq/RocketMQInboundChannelAdapterRecoveryTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/test/java/com/alibaba/cloud/stream/binder/rocketmq/RocketMQInboundChannelAdapterRecoveryTests.java
@@ -176,4 +176,68 @@ public class RocketMQInboundChannelAdapterRecoveryTests {
 		assertThat(result).isEqualTo("FAIL");
 	}
 
+	@Test
+	public void recoveryCallbackThrowingFallsBackToFailureSupplier() throws Exception {
+		ExtendedConsumerProperties<RocketMQConsumerProperties> props =
+				new ExtendedConsumerProperties<>(new RocketMQConsumerProperties());
+		RocketMQInboundChannelAdapter adapter = new RocketMQInboundChannelAdapter("topic", props);
+
+		AtomicInteger sendAttempts = new AtomicInteger();
+		SubscribableChannel outputChannel = new SubscribableChannel() {
+			@Override
+			public boolean send(Message<?> message, long timeout) {
+				sendAttempts.incrementAndGet();
+				throw new MessagingException("simulated downstream failure");
+			}
+
+			@Override
+			public boolean send(Message<?> message) {
+				return send(message, -1);
+			}
+
+			@Override
+			public boolean subscribe(MessageHandler handler) {
+				return true;
+			}
+
+			@Override
+			public boolean unsubscribe(MessageHandler handler) {
+				return true;
+			}
+		};
+		adapter.setOutputChannel(outputChannel);
+
+		adapter.setRetryTemplate(new RetryTemplate(
+				RetryPolicy.builder().backOff(new FixedBackOff(0L, 1L)).build()));
+
+		AtomicInteger recoveryInvocations = new AtomicInteger();
+		RecoveryCallback<Object> failingRecoveryCallback = new RecoveryCallback<>() {
+			@Override
+			public Object recover(AttributeAccessor accessor, Throwable throwable) {
+				recoveryInvocations.incrementAndGet();
+				throw new IllegalStateException("simulated error channel failure");
+			}
+		};
+		adapter.setRecoveryCallback(failingRecoveryCallback);
+
+		MessageExt messageExt = new MessageExt();
+		messageExt.setBody("payload".getBytes());
+		messageExt.setTopic("topic");
+		messageExt.setMsgId("test-msg-id");
+
+		Method consumeMessage = RocketMQInboundChannelAdapter.class
+				.getDeclaredMethod("consumeMessage", List.class, Supplier.class, Supplier.class);
+		consumeMessage.setAccessible(true);
+
+		Object result = consumeMessage.invoke(adapter,
+				Collections.singletonList(messageExt),
+				(Supplier<String>) () -> "FAIL",
+				(Supplier<String>) () -> "OK");
+
+		// Recovery was attempted but its own failure propagates to the outer catch, which
+		// returns the failure supplier so RocketMQ can redeliver the message.
+		assertThat(recoveryInvocations.get()).isEqualTo(1);
+		assertThat(result).isEqualTo("FAIL");
+	}
+
 }


### PR DESCRIPTION
## Problem

`RocketMQInboundChannelAdapter` advertises a `RecoveryCallback` slot, and `RocketMQMessageChannelBinder` wires `errorInfrastructure.getRecoverer()` into it whenever `maxAttempts > 1`. The recoverer is the bridge that turns retry-exhausted messages into events on the binder's error channel (DLQ, retry-exhausted handlers, etc.). After commit 84ad287e (JSpecify annotations) the recovery wiring stopped firing: `consumeMessage` no longer calls the callback. Instead the `RetryException` raised by the retry template is swallowed by the outer per-message catch, which logs and returns the failure supplier so RocketMQ redelivers the same message indefinitely. From the user's perspective the configured DLQ infrastructure is silently inert.

## Root cause

The retry block looks like:

```java
this.retryTemplate.setRetryListener(new RetryListener() {
    @Override
    public void onRetryPolicyExhaustion(...) {
        log.warn("retry exhausted for messageExt: {}", messageExt, exception);
    }
});
this.retryTemplate.execute(...);
```

The exhaustion path only logs. The downstream `RecoveryCallback` is never reached, so anything the binder set up around it is unreachable.

## Fix

Catch `RetryException` from `retryTemplate.execute(...)` directly. When a `recoveryCallback` is configured, hand the underlying cause to it via `ErrorMessageUtils.getAttributeAccessor(message, message)` and let the loop continue, so the success supplier is returned and the message is acknowledged after the configured recovery (typically: published to the error channel that backs the DLQ). When no callback is configured the exception is rethrown, preserving the existing "redeliver via RocketMQ" behavior.

## Tests added

`RocketMQInboundChannelAdapterRecoveryTests` covers both branches by reflectively driving `consumeMessage` against an output channel that always fails:

- `recoveryCallbackInvokedWhenRetriesExhausted` — verifies the callback is invoked exactly once with the underlying cause and that the success supplier is returned.
- `retriesExhaustedWithoutRecoveryFallsBackToFailure` — verifies the previous behavior is preserved when no callback is configured.

Both tests use a zero-delay `FixedBackOff` so they run in a few hundred milliseconds.