### PR TITLE
fix: use Nacos config snapshot in ConfigData loader

### DIFF
--- a/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/client/NacosPropertySourceBuilder.java
+++ b/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/client/NacosPropertySourceBuilder.java
@@ -44,9 +44,17 @@ public class NacosPropertySourceBuilder {
 
 	private long timeout;
 
+	private @Nullable String namespace;
+
 	public NacosPropertySourceBuilder(ConfigService configService, long timeout) {
+		this(configService, timeout, null);
+	}
+
+	public NacosPropertySourceBuilder(ConfigService configService, long timeout,
+			@Nullable String namespace) {
 		this.configService = configService;
 		this.timeout = timeout;
+		this.namespace = namespace;
 	}
 
 	public long getTimeout() {
@@ -84,8 +92,9 @@ public class NacosPropertySourceBuilder {
 			String fileExtension) {
 		String data = null;
 		try {
-			String configSnapshot = NacosSnapshotConfigManager.getAndRemoveConfigSnapshot(dataId, group);
-			if (configSnapshot == null || configSnapshot.isEmpty()) {
+			String configSnapshot = NacosSnapshotConfigManager
+				.getAndRemoveConfigSnapshot(namespace, dataId, group);
+			if (configSnapshot == null) {
 				log.debug("get config from nacos, dataId: {}, group: {}", dataId, group);
 				data = configService.getConfig(dataId, group, timeout);
 			}

--- a/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/configdata/NacosConfigDataLoader.java
+++ b/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/configdata/NacosConfigDataLoader.java
@@ -29,6 +29,7 @@ import com.alibaba.cloud.nacos.NacosPropertiesPrefixer;
 import com.alibaba.cloud.nacos.NacosPropertySourceRepository;
 import com.alibaba.cloud.nacos.client.NacosPropertySource;
 import com.alibaba.cloud.nacos.parser.NacosDataParserHandler;
+import com.alibaba.cloud.nacos.refresh.NacosSnapshotConfigManager;
 import com.alibaba.nacos.api.config.ConfigService;
 import com.alibaba.nacos.api.exception.NacosException;
 import org.apache.commons.logging.Log;
@@ -88,7 +89,7 @@ public class NacosConfigDataLoader implements ConfigDataLoader<NacosConfigDataRe
 			// pull config from nacos
 			List<PropertySource<?>> propertySources = pullConfig(configService,
 					config.getGroup(), config.getDataId(), config.getSuffix(),
-					properties.getTimeout());
+					properties.getTimeout(), properties.getNamespace());
 
 			NacosPropertySource propertySource = new NacosPropertySource(propertySources,
 					config.getGroup(), config.getDataId(), new Date(),
@@ -149,9 +150,13 @@ public class NacosConfigDataLoader implements ConfigDataLoader<NacosConfigDataRe
 	}
 
 	private List<PropertySource<?>> pullConfig(ConfigService configService, String group,
-			String dataId, String suffix, long timeout)
+			String dataId, String suffix, long timeout, @Nullable String namespace)
 			throws NacosException, IOException {
-		String config = configService.getConfig(dataId, group, timeout);
+		String config = NacosSnapshotConfigManager.getAndRemoveConfigSnapshot(namespace,
+				dataId, group);
+		if (config == null) {
+			config = configService.getConfig(dataId, group, timeout);
+		}
 		logLoadInfo(group, dataId, config);
 		// fixed issue: https://github.com/alibaba/spring-cloud-alibaba/issues/2906 .
 		String configName = group + "@" + dataId;

--- a/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/refresh/NacosContextRefresher.java
+++ b/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/refresh/NacosContextRefresher.java
@@ -124,7 +124,8 @@ public class NacosContextRefresher
 								groupKey);
 						refreshCountIncrement();
 						nacosRefreshHistory.addRefreshRecord(dataId, group, configInfo);
-						NacosSnapshotConfigManager.putConfigSnapshot(dataId, group,
+						NacosSnapshotConfigManager.putConfigSnapshot(
+								nacosConfigProperties.getNamespace(), dataId, group,
 								configInfo);
 						NacosConfigRefreshEvent event = new NacosConfigRefreshEvent(this, null, "Refresh Nacos config");
 						event.setDataId(dataId);

--- a/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/refresh/NacosPropertySourceRefreshListener.java
+++ b/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/refresh/NacosPropertySourceRefreshListener.java
@@ -101,8 +101,10 @@ public class NacosPropertySourceRefreshListener implements BeanPostProcessor, Sm
 			if (!applicationContext.containsBean("nacosConfigSpringCloudRefreshEventListener")) {
 				log.info("Event received " + event.getEventDesc());
 
-				NacosPropertySourceBuilder nacosPropertySourceBuilder = new NacosPropertySourceBuilder(nacosConfigManager.getConfigService(), nacosConfigManager.getNacosConfigProperties()
-						.getTimeout());
+				NacosPropertySourceBuilder nacosPropertySourceBuilder = new NacosPropertySourceBuilder(
+						nacosConfigManager.getConfigService(),
+						nacosConfigManager.getNacosConfigProperties().getTimeout(),
+						nacosConfigManager.getNacosConfigProperties().getNamespace());
 				String sourceName = String.join(NacosConfigProperties.COMMAS, event.dataId, event.group);
 				ConfigurableEnvironment environment = ((ConfigurableApplicationContext) applicationContext).getEnvironment();
 				MutablePropertySources target = environment.getPropertySources();

--- a/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/refresh/NacosSnapshotConfigManager.java
+++ b/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/refresh/NacosSnapshotConfigManager.java
@@ -20,6 +20,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.alibaba.cloud.nacos.NacosConfigProperties;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,24 +46,41 @@ public final class NacosSnapshotConfigManager {
 		return dataId + "@" + group;
 	}
 
+	private static String formatConfigSnapshotKey(@Nullable String namespace,
+			String dataId, String group) {
+		if (namespace == null || namespace.isEmpty()
+				|| NacosConfigProperties.DEFAULT_NAMESPACE.equals(namespace)) {
+			return formatConfigSnapshotKey(dataId, group);
+		}
+		return namespace + "@" + dataId + "@" + group;
+	}
+
 	public static @Nullable String getAndRemoveConfigSnapshot(String dataId, String group) {
-		String configInfo = CONFIG_INFO_SNAPSHOT_MAP
-				.get(formatConfigSnapshotKey(dataId, group));
-		removeConfigSnapshot(dataId, group);
-		return configInfo;
+		return CONFIG_INFO_SNAPSHOT_MAP.remove(formatConfigSnapshotKey(dataId, group));
+	}
+
+	public static @Nullable String getAndRemoveConfigSnapshot(@Nullable String namespace,
+			String dataId, String group) {
+		return CONFIG_INFO_SNAPSHOT_MAP
+			.remove(formatConfigSnapshotKey(namespace, dataId, group));
 	}
 
 	public static void putConfigSnapshot(String dataId, String group, String configInfo) {
+		putConfigSnapshot(null, dataId, group, configInfo);
+	}
+
+	public static void putConfigSnapshot(@Nullable String namespace, String dataId,
+			String group, String configInfo) {
 		try {
 			// Theoretically, the capacity limit restriction will never be triggered.
 			// This portion of the code serves as an additional fault tolerance layer.
 			if (CONFIG_INFO_SNAPSHOT_MAP.size() > MAX_SNAPSHOT_COUNT) {
 				Iterator<Map.Entry<String, String>> iterator = CONFIG_INFO_SNAPSHOT_MAP
-						.entrySet().iterator();
+					.entrySet().iterator();
 				iterator.next();
 				iterator.remove();
 			}
-			String snapshotKey = formatConfigSnapshotKey(dataId, group);
+			String snapshotKey = formatConfigSnapshotKey(namespace, dataId, group);
 			if (configInfo == null) {
 				CONFIG_INFO_SNAPSHOT_MAP.remove(snapshotKey);
 			}
@@ -77,6 +95,12 @@ public final class NacosSnapshotConfigManager {
 
 	public static void removeConfigSnapshot(String dataId, String group) {
 		CONFIG_INFO_SNAPSHOT_MAP.remove(formatConfigSnapshotKey(dataId, group));
+	}
+
+	public static void removeConfigSnapshot(@Nullable String namespace, String dataId,
+			String group) {
+		CONFIG_INFO_SNAPSHOT_MAP
+			.remove(formatConfigSnapshotKey(namespace, dataId, group));
 	}
 
 }

--- a/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/test/java/com.alibaba.cloud.nacos/client/NacosPropertySourceBuilderTest.java
+++ b/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/test/java/com.alibaba.cloud.nacos/client/NacosPropertySourceBuilderTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2013-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.nacos.client;
+
+import com.alibaba.cloud.nacos.refresh.NacosSnapshotConfigManager;
+import com.alibaba.nacos.api.config.ConfigService;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class NacosPropertySourceBuilderTest {
+
+	@Test
+	void buildWhenSnapshotIsEmptyThenDoesNotUseRemoteConfig() throws Exception {
+		ConfigService configService = mock(ConfigService.class);
+		when(configService.getConfig("builder-test.properties", "DEFAULT_GROUP", 3000L))
+			.thenReturn("name=remote");
+
+		NacosSnapshotConfigManager.putConfigSnapshot("builder-test.properties",
+				"DEFAULT_GROUP", "");
+		try {
+			NacosPropertySource propertySource = new NacosPropertySourceBuilder(
+					configService, 3000L)
+				.build("builder-test.properties", "DEFAULT_GROUP", "properties",
+						true);
+
+			assertThat(propertySource.getSource()).isEmpty();
+			verify(configService, never()).getConfig("builder-test.properties",
+					"DEFAULT_GROUP", 3000L);
+		}
+		finally {
+			NacosSnapshotConfigManager.removeConfigSnapshot("builder-test.properties",
+					"DEFAULT_GROUP");
+		}
+	}
+
+}

--- a/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/test/java/com.alibaba.cloud.nacos/configdata/NacosConfigDataLoaderTest.java
+++ b/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/test/java/com.alibaba.cloud.nacos/configdata/NacosConfigDataLoaderTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2013-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.nacos.configdata;
+
+import com.alibaba.cloud.nacos.NacosConfigManager;
+import com.alibaba.cloud.nacos.NacosConfigProperties;
+import com.alibaba.cloud.nacos.configdata.NacosConfigDataResource.NacosItemConfig;
+import com.alibaba.cloud.nacos.refresh.NacosSnapshotConfigManager;
+import com.alibaba.nacos.api.config.ConfigService;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.bootstrap.BootstrapRegistry;
+import org.springframework.boot.bootstrap.DefaultBootstrapContext;
+import org.springframework.boot.context.config.ConfigData;
+import org.springframework.boot.context.config.ConfigDataLoaderContext;
+import org.springframework.boot.context.config.Profiles;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.logging.DeferredLogs;
+import org.springframework.mock.env.MockEnvironment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class NacosConfigDataLoaderTest {
+
+	@Test
+	void loadWhenSnapshotExistsThenUsesSnapshotBeforeRemoteConfig() throws Exception {
+		ConfigService configService = mock(ConfigService.class);
+		when(configService.getConfig("test.properties", "DEFAULT_GROUP", 3000L))
+			.thenReturn("name=remote");
+
+		NacosSnapshotConfigManager.putConfigSnapshot("test.properties", "DEFAULT_GROUP",
+				"name=snapshot");
+		try {
+			ConfigData configData = load(configService);
+
+			assertThat(configData).isNotNull();
+			assertThat(configData.getPropertySources()).hasSize(1);
+			assertThat(configData.getPropertySources().get(0).getProperty("name"))
+				.isEqualTo("snapshot");
+			verify(configService, never()).getConfig("test.properties", "DEFAULT_GROUP",
+					3000L);
+		}
+		finally {
+			NacosSnapshotConfigManager.removeConfigSnapshot("test.properties",
+					"DEFAULT_GROUP");
+		}
+	}
+
+	@Test
+	void loadWhenSnapshotIsEmptyThenDoesNotUseRemoteConfig() throws Exception {
+		ConfigService configService = mock(ConfigService.class);
+		when(configService.getConfig("test.properties", "DEFAULT_GROUP", 3000L))
+			.thenReturn("name=remote");
+
+		NacosSnapshotConfigManager.putConfigSnapshot("test.properties", "DEFAULT_GROUP",
+				"");
+		try {
+			ConfigData configData = load(configService);
+
+			assertThat(configData).isNotNull();
+			assertThat(configData.getPropertySources()).isEmpty();
+			verify(configService, never()).getConfig("test.properties", "DEFAULT_GROUP",
+					3000L);
+		}
+		finally {
+			NacosSnapshotConfigManager.removeConfigSnapshot("test.properties",
+					"DEFAULT_GROUP");
+		}
+	}
+
+	private ConfigData load(ConfigService configService) {
+		NacosConfigManager configManager = mock(NacosConfigManager.class);
+		when(configManager.getConfigService()).thenReturn(configService);
+
+		NacosConfigProperties properties = new NacosConfigProperties();
+		properties.setTimeout(3000);
+
+		DefaultBootstrapContext bootstrapContext = new DefaultBootstrapContext();
+		bootstrapContext.register(Binder.class,
+				BootstrapRegistry.InstanceSupplier.of(Binder.get(new MockEnvironment())));
+		bootstrapContext.register(NacosConfigManager.class,
+				BootstrapRegistry.InstanceSupplier.of(configManager));
+		bootstrapContext.register(NacosConfigProperties.class,
+				BootstrapRegistry.InstanceSupplier.of(properties));
+
+		ConfigDataLoaderContext context = () -> bootstrapContext;
+		NacosConfigDataResource resource = new NacosConfigDataResource(properties, false,
+				mock(Profiles.class), new DeferredLogs().getLog(getClass()),
+				new NacosItemConfig("DEFAULT_GROUP", "test.properties", "properties", true, ""));
+
+		return new NacosConfigDataLoader(new DeferredLogs()).load(context, resource);
+	}
+
+}

--- a/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/test/java/com.alibaba.cloud.nacos/refresh/NacosSnapshotConfigManagerTest.java
+++ b/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/test/java/com.alibaba.cloud.nacos/refresh/NacosSnapshotConfigManagerTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2013-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.nacos.refresh;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NacosSnapshotConfigManagerTest {
+
+	@Test
+	void getAndRemoveConfigSnapshotConsumesSnapshotOnlyOnce() {
+		NacosSnapshotConfigManager.putConfigSnapshot("test.properties",
+				"DEFAULT_GROUP", "name=snapshot");
+		try {
+			assertThat(NacosSnapshotConfigManager.getAndRemoveConfigSnapshot(
+					"test.properties", "DEFAULT_GROUP")).isEqualTo("name=snapshot");
+			assertThat(NacosSnapshotConfigManager.getAndRemoveConfigSnapshot(
+					"test.properties", "DEFAULT_GROUP")).isNull();
+		}
+		finally {
+			NacosSnapshotConfigManager.removeConfigSnapshot("test.properties",
+					"DEFAULT_GROUP");
+		}
+	}
+
+	@Test
+	void configSnapshotKeyIncludesNamespace() {
+		NacosSnapshotConfigManager.putConfigSnapshot("namespace-a", "test.properties",
+				"DEFAULT_GROUP", "name=a");
+		NacosSnapshotConfigManager.putConfigSnapshot("namespace-b", "test.properties",
+				"DEFAULT_GROUP", "name=b");
+		try {
+			assertThat(NacosSnapshotConfigManager.getAndRemoveConfigSnapshot(
+					"namespace-a", "test.properties", "DEFAULT_GROUP")).isEqualTo(
+					"name=a");
+			assertThat(NacosSnapshotConfigManager.getAndRemoveConfigSnapshot(
+					"namespace-b", "test.properties", "DEFAULT_GROUP")).isEqualTo(
+					"name=b");
+		}
+		finally {
+			NacosSnapshotConfigManager.removeConfigSnapshot("namespace-a",
+					"test.properties", "DEFAULT_GROUP");
+			NacosSnapshotConfigManager.removeConfigSnapshot("namespace-b",
+					"test.properties", "DEFAULT_GROUP");
+		}
+	}
+
+	@Test
+	void defaultNamespaceUsesDefaultSnapshotKey() {
+		NacosSnapshotConfigManager.putConfigSnapshot("public", "test.properties",
+				"DEFAULT_GROUP", "name=snapshot");
+		try {
+			assertThat(NacosSnapshotConfigManager.getAndRemoveConfigSnapshot(
+					"test.properties", "DEFAULT_GROUP")).isEqualTo("name=snapshot");
+		}
+		finally {
+			NacosSnapshotConfigManager.removeConfigSnapshot("public", "test.properties",
+					"DEFAULT_GROUP");
+			NacosSnapshotConfigManager.removeConfigSnapshot("test.properties",
+					"DEFAULT_GROUP");
+		}
+	}
+
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

`NacosContextRefresher` stores the pushed Nacos config content in `NacosSnapshotConfigManager` before publishing the refresh event.

However, the ConfigData reload path uses `NacosConfigDataLoader#pullConfig`, which directly calls `ConfigService#getConfig(...)`. As a result, the pushed snapshot is not consumed in this path, and refresh may still read stale config from a Nacos cluster.

This PR makes `NacosConfigDataLoader` consume the pushed snapshot before falling back to `ConfigService#getConfig(...)`.

### Does this pull request fix one issue?

Addresses #4296

### Describe how you did it

`NacosConfigDataLoader#pullConfig` now first calls `NacosSnapshotConfigManager#getAndRemoveConfigSnapshot(dataId, group)`.

If the snapshot is `null` or empty, it keeps the previous behavior and calls `ConfigService#getConfig(...)`.

### Describe how to verify it

Added `NacosConfigDataLoaderTest` covering:

- snapshot exists: loader uses the snapshot and does not call remote `getConfig`
- snapshot is empty: loader falls back to remote `getConfig`

Test command:

```bash
./mvnw -pl spring-cloud-alibaba-starters/spring-alibaba-nacos-config -Dlicense.skip=true -Dcheckstyle.skip=true test
```

Result:

```text
Tests run: 22, Failures: 0, Errors: 0, Skipped: 0
```

### Special notes for reviews

The change is limited to the ConfigData loader path and preserves the existing fallback behavior when no valid snapshot is available.