### PR TITLE
refactor: remove legacy bootstrap dependency from nacos-tests for 2025.1.x

### DIFF
--- a/spring-cloud-alibaba-tests/nacos-tests/pom.xml
+++ b/spring-cloud-alibaba-tests/nacos-tests/pom.xml
@@ -16,13 +16,4 @@
     <artifactId>nacos-tests</artifactId>
     <name>Nacos Tests</name>
 
-
-    <dependencies>
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-bootstrap</artifactId>
-            <scope>compile</scope>
-        </dependency>
-    </dependencies>
-
 </project>


### PR DESCRIPTION

### Describe what this PR does / why we need it

This PR removes the legacy spring-cloud-starter-bootstrap dependency from the nacos-tests module. Since the 2025.1.x branch targets Spring Boot 4.0 and Spring Cloud 2025, the "bootstrap" method of configuration is officially deprecated and removed from the core architecture. Cleaning this up ensures the test suite remains compliant with the new spring.config.import standard.


### Does this pull request fix one issue?
Fixes #4258

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

1. Modified spring-cloud-alibaba-tests/nacos-tests/pom.xml to remove the spring-cloud-starter-bootstrap dependency.
2. Verified that the existing test resources in this module are correctly using application.yml / application.properties with the spring.config.import syntax.
3. Cleaned up the dependency tree to prevent legacy configuration loading during the test runtime.

### Describe how to verify it
Run the automated test suite for the specific module to ensure it passes without the bootstrap library:
mvn clean test -pl spring-cloud-alibaba-tests/nacos-tests


### Special notes for reviews
