### PR TITLE
feat: implement lightweight discovery probe for health check

### DIFF
--- a/spring-cloud-alibaba-examples/nacos-example/readme-zh.md
+++ b/spring-cloud-alibaba-examples/nacos-example/readme-zh.md
@@ -328,6 +328,8 @@ SecretKey|spring.cloud.nacos.config.secret-key||
 是否开启 Nacos Config 的 Health Indicator|spring.nacos.config.health-indicator.enabled|false|
 是否开启 Nacos Discovery 的 Health Indicator|spring.cloud.nacos.discovery.health-indicator.enabled|false|
 
+对于服务发现健康检查，建议配置 `spring.cloud.discovery.client.health-indicator.use-services-query=false`，走更轻量的 `probe()` 路径。
+
 
 ### Spring Cloud Alibaba Nacos Discovery
 
@@ -654,4 +656,3 @@ Nacos 为用户提供包括动态服务发现，配置管理，服务管理等�
 未来，Spring-Alibaba-Nacos-Config模块将承载更多职责，面向二方中间件组件，对SpringBoot(包括Spring AI)以及SpringCloud应用提供统一的配置托管以及运行时无损轮转功能，面向普通的业务组件，通过@NacosConfig，@NacosConfigListener注解提供灵活易用的配置注入和变更回调能力。
 
 如果您对 Spring Cloud Nacos Discovery 有任何建议或想法，欢迎在 issue 中或者通过其他社区渠道向我们提出。
-

--- a/spring-cloud-alibaba-examples/nacos-example/readme.md
+++ b/spring-cloud-alibaba-examples/nacos-example/readme.md
@@ -324,6 +324,8 @@ Cluster service name | spring. Cloud. Nacos. Config. Cluster -name | |
 Whether to enable nacos-config health indicator |spring.nacos.config.health-indicator.enabled|false|
 Whether to enable nacos-discovery health indicator |spring.cloud.nacos.discovery.health-indicator.enabled|false|
 
+For discovery health checks, prefer `spring.cloud.discovery.client.health-indicator.use-services-query=false` to use the lightweight `probe()` path.
+
 ### Spring Cloud Alibaba Nacos Discovery
 
 #### How to access

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryClient.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/NacosDiscoveryClient.java
@@ -89,4 +89,14 @@ public class NacosDiscoveryClient implements DiscoveryClient {
 		}
 	}
 
+	@Override
+	public void probe() {
+		try {
+			serviceDiscovery.probe();
+		}
+		catch (Exception e) {
+			throw new RuntimeException("Nacos discovery client probe failed", e);
+		}
+	}
+
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/NacosServiceDiscovery.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/NacosServiceDiscovery.java
@@ -73,6 +73,18 @@ public class NacosServiceDiscovery {
 		return services.getData();
 	}
 
+	/**
+	 * Probe the naming service with a lightweight status check.
+	 * @throws NacosException nacosException
+	 */
+	public void probe() throws NacosException {
+		String status = namingService().getServerStatus();
+		if (!"UP".equals(status)) {
+			throw new IllegalStateException(
+					"Nacos naming server status is " + (status != null ? status : "UNKNOWN"));
+		}
+	}
+
 	public static List<ServiceInstance> hostToServiceInstanceList(
 			List<Instance> instances, String serviceId) {
 		List<ServiceInstance> result = new ArrayList<>(instances.size());

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/reactive/NacosReactiveDiscoveryClient.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/discovery/reactive/NacosReactiveDiscoveryClient.java
@@ -99,4 +99,22 @@ public class NacosReactiveDiscoveryClient implements ReactiveDiscoveryClient {
 		}).subscribeOn(Schedulers.boundedElastic());
 	}
 
+	@Override
+	public void probe() {
+		try {
+			serviceDiscovery.probe();
+		}
+		catch (Exception e) {
+			throw new RuntimeException("Nacos reactive discovery client probe failed", e);
+		}
+	}
+
+	@Override
+	public Mono<Void> reactiveProbe() {
+		return Mono.fromCallable(() -> {
+			serviceDiscovery.probe();
+			return true;
+		}).subscribeOn(Schedulers.boundedElastic()).then();
+	}
+
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/NacosDiscoveryClientTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/NacosDiscoveryClientTests.java
@@ -36,6 +36,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
 /**
@@ -130,6 +131,20 @@ public class NacosDiscoveryClientTests {
 				.thenReturn(singletonList(serviceInstance));
 		this.client.getInstances("a");
 		assertThat(ServiceCache.getInstances("a")).isEqualTo(singletonList(serviceInstance));
+	}
+
+	@Test
+	public void testProbe() throws Exception {
+		this.client.probe();
+	}
+
+	@Test
+	public void testProbeFailure() throws NacosException {
+		doThrow(new NacosException()).when(serviceDiscovery).probe();
+
+		assertThatThrownBy(() -> this.client.probe())
+				.hasMessage("Nacos discovery client probe failed")
+				.hasCauseInstanceOf(NacosException.class);
 	}
 
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/NacosDiscoveryClientTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/NacosDiscoveryClientTests.java
@@ -37,6 +37,7 @@ import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -136,6 +137,8 @@ public class NacosDiscoveryClientTests {
 	@Test
 	public void testProbe() throws Exception {
 		this.client.probe();
+
+		verify(serviceDiscovery).probe();
 	}
 
 	@Test

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/discovery/NacosServiceDiscoveryTest.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/discovery/NacosServiceDiscoveryTest.java
@@ -33,6 +33,7 @@ import org.springframework.cloud.client.ServiceInstance;
 
 import static com.alibaba.cloud.nacos.test.NacosMockTest.serviceInstance;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -122,6 +123,40 @@ public class NacosServiceDiscoveryTest {
 		assertThat(services.contains(serviceName + "1"));
 		assertThat(services.contains(serviceName + "2"));
 		assertThat(services.contains(serviceName + "3"));
+	}
+
+	@Test
+	public void testProbe() throws NacosException {
+		NacosDiscoveryProperties nacosDiscoveryProperties = mock(
+				NacosDiscoveryProperties.class);
+		NacosServiceManager nacosServiceManager = mock(NacosServiceManager.class);
+		NamingService namingService = mock(NamingService.class);
+
+		when(nacosServiceManager.getNamingService()).thenReturn(namingService);
+		when(namingService.getServerStatus()).thenReturn("UP");
+
+		NacosServiceDiscovery serviceDiscovery = new NacosServiceDiscovery(
+				nacosDiscoveryProperties, nacosServiceManager);
+
+		serviceDiscovery.probe();
+	}
+
+	@Test
+	public void testProbeUnhealthy() throws NacosException {
+		NacosDiscoveryProperties nacosDiscoveryProperties = mock(
+				NacosDiscoveryProperties.class);
+		NacosServiceManager nacosServiceManager = mock(NacosServiceManager.class);
+		NamingService namingService = mock(NamingService.class);
+
+		when(nacosServiceManager.getNamingService()).thenReturn(namingService);
+		when(namingService.getServerStatus()).thenReturn("DOWN");
+
+		NacosServiceDiscovery serviceDiscovery = new NacosServiceDiscovery(
+				nacosDiscoveryProperties, nacosServiceManager);
+
+		assertThatThrownBy(serviceDiscovery::probe)
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessage("Nacos naming server status is DOWN");
 	}
 
 	private String getUri(ServiceInstance instance) {

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/discovery/reactive/NacosReactiveDiscoveryClientTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/discovery/reactive/NacosReactiveDiscoveryClientTests.java
@@ -27,12 +27,16 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -140,6 +144,39 @@ class NacosReactiveDiscoveryClientTests {
 		StepVerifier.create(instances)
 						.expectNext(serviceInstance)
 						.expectComplete().verify();
+	}
+
+	@Test
+	void testProbe() throws Exception {
+		this.client.probe();
+
+		verify(serviceDiscovery).probe();
+	}
+
+	@Test
+	void testProbeFailure() throws NacosException {
+		doThrow(new NacosException()).when(serviceDiscovery).probe();
+
+		assertThatThrownBy(() -> this.client.probe())
+				.hasMessage("Nacos reactive discovery client probe failed")
+				.hasCauseInstanceOf(NacosException.class);
+	}
+
+	@Test
+	void testReactiveProbe() throws Exception {
+		Mono<Void> probe = this.client.reactiveProbe();
+
+		StepVerifier.create(probe).expectComplete().verify();
+		verify(serviceDiscovery).probe();
+	}
+
+	@Test
+	void testReactiveProbeFailure() throws NacosException {
+		doThrow(new NacosException()).when(serviceDiscovery).probe();
+
+		StepVerifier.create(this.client.reactiveProbe())
+				.expectError(NacosException.class)
+				.verify();
 	}
 
 }


### PR DESCRIPTION
### Describe what this PR does / why we need it

Fix Nacos discovery health checks to support lightweight probe()

- implement `DiscoveryClient#probe()` in `NacosDiscoveryClient`
- add lightweight `NacosServiceDiscovery.probe()` based on `NamingService.getServerStatus()`

This avoids forcing actuator discovery health checks through `getServices()` when users switch Spring Cloud Commons to probe mode.

### Does this pull request fix one issue?
#4294 

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it
- add unit tests for healthy and failing probe cases

### Special notes for reviews
- document `spring.cloud.discovery.client.health-indicator.use-services-query=false` for Nacos discovery health checks
