### PR TITLE
ci: use mvnd (Maven Daemon) in integration-test workflow

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -41,12 +41,19 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
+      - name: Set up Maven Daemon
+        uses: gauthamchandra/mvnd-action@22dcb7d03ed0401ddadc760783dd9629432dff77 # v0.2.1
+        with:
+          # https://downloads.apache.org/maven/mvnd/
+          version: '1.0.5'
+      - name: "Print Maven Daemon version"
+        run: mvnd -version
       - name: Compile & Checkstyle
-        run: mvn clean -B compile
+        run: mvnd clean -B compile
       - name: install dependencies
-        run: mvn clean -B install -U package -pl '!spring-cloud-alibaba-coverage'  -DskipTests
+        run: mvnd clean -B install -U package -pl '!spring-cloud-alibaba-coverage'  -DskipTests
       - name: Testing
-        run: ./mvnw verify -B -Dmaven.test.skip=false
+        run: mvnd verify -B -Dmaven.test.skip=false
 #        run: mvn clean -Dit.enabled=true test
       - name: Delete snapshots from the Maven local repository
         run: find ~/.m2/repository -type d -name '*-SNAPSHOT' -print -exec rm -r {} +

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -42,10 +42,51 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Set up Maven Daemon
-        uses: gauthamchandra/mvnd-action@22dcb7d03ed0401ddadc760783dd9629432dff77 # v0.2.1
-        with:
-          # https://downloads.apache.org/maven/mvnd/
-          version: '1.0.5'
+        shell: bash
+        env:
+          MVND_VERSION: '1.0.5'
+          # The download speed from downloads.apache.org and archive.apache.org can sometimes be very slow.
+          # MVND_BASE_URL: 'https://downloads.apache.org/maven/mvnd'
+          # MVND_BASE_URL: 'https://archive.apache.org/dist/maven/mvnd'
+          # GitHub releases do not have a .sha256 file.
+          MVND_BASE_URL: 'https://github.com/apache/maven-mvnd/releases/download'
+        run: |
+          case "${{ runner.os }}" in
+            Linux)   MVND_OS=linux ;;
+            macOS)   MVND_OS=darwin ;;
+            Windows) MVND_OS=windows ;;
+            *)       echo "Unsupported OS: ${{ runner.os }}"; exit 1 ;;
+          esac
+          case "${{ runner.arch }}" in
+            X64)   MVND_ARCH=amd64 ;;
+            ARM64) MVND_ARCH=aarch64 ;;
+            *)     echo "Unsupported arch: ${{ runner.arch }}"; exit 1 ;;
+          esac
+          MVND_DIR="maven-mvnd-${MVND_VERSION}-${MVND_OS}-${MVND_ARCH}"
+          MVND_URL="${MVND_BASE_URL}/${MVND_VERSION}/${MVND_DIR}.zip"
+          echo "Downloading mvnd ${MVND_VERSION} for ${MVND_OS}/${MVND_ARCH}..."
+          echo "Download URL: $MVND_URL"
+          curl -fsSL --retry 3 --retry-delay 5 --retry-connrefused "$MVND_URL" -o "$RUNNER_TEMP/mvnd.zip"
+          # echo "Checksum URL: ${MVND_URL}.sha256"
+          # curl -fsSL --retry 3 --retry-delay 5 --retry-connrefused "${MVND_URL}.sha256" -o "$RUNNER_TEMP/mvnd.zip.sha256"
+          case "${MVND_OS}-${MVND_ARCH}" in
+            linux-amd64)     EXPECTED='4a8d83bbf7757a1132c4116cfeea69aaa93b341b8253344ff42b33001f281830' ;;
+            linux-aarch64)   EXPECTED='5f68558d8950d4020eecd19e10fae40a4fcb4db00ebd359dad39b4bb52b9efa0' ;;
+            darwin-amd64)    EXPECTED='95e12908f24fd018ee41e5d31fe43a86340877e9b937651732e310b250411de3' ;;
+            darwin-aarch64)  EXPECTED='bd98f847478de20158242f6cce6d9bc6cb6e3e9ba7b932237f0122f52a8de5a3' ;;
+            windows-amd64)   EXPECTED='15cd4716bbb0ff96d2b66607262f6145a772dcfd10b24ab18c8338d1e1f4da8e' ;;
+            *)               echo "Unsupported combination: ${MVND_OS}-${MVND_ARCH}"; exit 1 ;;
+          esac
+          echo "Verifying download..."
+          # EXPECTED=$(cut -d' ' -f1 "$RUNNER_TEMP/mvnd.zip.sha256")
+          ACTUAL=$(sha256sum "$RUNNER_TEMP/mvnd.zip" | cut -d' ' -f1 | tr -d '\\')
+          if [ "$EXPECTED" != "$ACTUAL" ]; then
+            echo "Checksum mismatch! Expected: $EXPECTED, got: $ACTUAL"
+            exit 1
+          fi
+          echo "Checksum verified."
+          unzip -q "$RUNNER_TEMP/mvnd.zip" -d "$RUNNER_TEMP/mvnd-cache"
+          echo "$RUNNER_TEMP/mvnd-cache/${MVND_DIR}/bin" >> "$GITHUB_PATH"
       - name: "Print Maven Daemon version"
         run: mvnd -version
       - name: Compile & Checkstyle


### PR DESCRIPTION
### Describe what this PR does / why we need it

- 在 integration-test workflow 中使用 Maven Daemon (mvnd) 替代 mvn，加速 CI 编译和测试。
- Use Maven Daemon (mvnd) instead of mvn in the integration-test workflow to speed up CI compilation and testing.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

Fixes https://github.com/alibaba/spring-cloud-alibaba/issues/4322

### Describe how you did it

- 添加 `gauthamchandra/mvnd-action@v0.2.1` 安装 mvnd 1.0.5
- 添加 `mvnd -version` 步骤打印版本信息
- 将 `mvn` 替换为 `mvnd` 执行 compile、install、verify
- Added `gauthamchandra/mvnd-action@v0.2.1` to install mvnd 1.0.5
- Added `mvnd -version` step to print version info
- Replaced `mvn` with `mvnd` for compile, install, and verify steps

### Describe how to verify it

- CI integration-test workflow 运行成功，且构建耗时比之前更短。
- The CI integration-test workflow runs successfully with shorter build times than before.

### Special notes for reviews

- 本次仅修改 `.github/workflows/integration-test.yml` 一个文件，改动范围小且聚焦。
- This PR only modifies `.github/workflows/integration-test.yml`, the change scope is small and focused.
