### PR TITLE
ci: add fine-grained permissions to workflow jobs

### DIFF
--- a/.github/workflows/github-packages-release.yml
+++ b/.github/workflows/github-packages-release.yml
@@ -8,6 +8,9 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 17

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -12,6 +12,8 @@ jobs:
   deploy-docker-image:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      contents: read
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -25,6 +27,8 @@ jobs:
   integration-testing:
     name: Integration Testing
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 17


### PR DESCRIPTION
Set minimal permissions at job level: contents:read for integration-test, contents:read + packages:write for GitHub Packages release.


### Describe what this PR does / why we need it

- Add fine-grained `permissions` to workflow jobs in `integration-test.yml` and `github-packages-release.yml`. Without explicit permissions, workflows run with default broad permissions, which is a security risk. This change enforces the principle of least privilege.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

https://github.com/alibaba/spring-cloud-alibaba/issues/4324

### Describe how you did it

Added `permissions` block at the job level for each workflow:
- `integration-test.yml` — `deploy-docker-image` and `integration-testing` jobs: `contents: read`
- `github-packages-release.yml` — `release` job: `contents: read` + `packages: write`

### Describe how to verify it

1. Push to one of the configured branches (`2023.x`, `2025.0.x`, `2025.1.x`) or open a PR
2. Confirm the `integration-test` workflow runs successfully with `contents: read`
3. Confirm the `github-packages-release` workflow runs successfully and can deploy snapshot artifacts to GitHub Packages

### Special notes for reviews

Permissions are set at the **job** level (not top-level `permissions`) so each job has exactly the permissions it needs.
