### PR TITLE
[ISSUE #4313] : Add AGENTS.md with project structure guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,99 @@
+# AGENTS.md
+
+> Context for AI coding assistants working on **Spring Cloud Alibaba**.
+> This file is maintained collaboratively by the community.
+> See [issue #4313](https://github.com/alibaba/spring-cloud-alibaba/issues/4313).
+
+---
+
+## 1. Project Structure & Module Layout
+
+This repository is a multi-module Maven project. Start by locating the module that owns the behavior you need to change before editing code.
+
+### 1.1 Top-Level Repository Layout
+
+```text
+spring-cloud-alibaba/
+|-- spring-cloud-alibaba-starters/       # Main implementation modules and Spring Boot starters
+|-- spring-cloud-alibaba-tests/          # Integration-style test modules and shared test support
+|-- spring-cloud-alibaba-examples/       # Runnable sample applications for major features
+|-- spring-cloud-alibaba-dependencies/   # BOM and dependency version management
+|-- spring-cloud-alibaba-coverage/       # JaCoCo aggregation module
+|-- eclipse/                             # Eclipse formatter and related project settings
+|-- .circleci/                           # CircleCI pipeline configuration
+|-- .github/                             # GitHub workflows and issue/PR templates
+|-- .mvn/                                # Maven Wrapper configuration
+|-- pom.xml                              # Root POM
+|-- mvnw / mvnw.cmd                      # Maven Wrapper entrypoints
+|-- README.md / README-zh.md             # User-facing documentation
+`-- Roadmap.md / Roadmap-zh.md           # Project roadmap
+```
+
+Important:
+
+- `spring-cloud-alibaba-examples` is a sibling of `spring-cloud-alibaba-starters`, not a child of it.
+- `spring-cloud-alibaba-coverage` is an aggregation module; do not add product logic there.
+
+### 1.2 Inside `spring-cloud-alibaba-starters/`
+
+Most feature work happens under `spring-cloud-alibaba-starters/`.
+
+The modules in this directory do not all follow a single pattern. Use the actual module layout in the current branch instead of assuming every integration has the same split.
+
+Common patterns:
+
+- `spring-cloud-starter-*`
+  - User-facing starter modules intended to be added as dependencies by applications.
+- non-`starter` modules
+  - Internal support modules, shared code, or feature-specific implementation modules used by starters.
+
+Examples in `2025.1.x`:
+
+- `spring-alibaba-nacos-config`
+  - Core Nacos config support.
+- `spring-cloud-starter-alibaba-nacos-config`
+  - User-facing Nacos config starter built on top of the core module.
+- `spring-cloud-starter-alibaba-nacos-discovery`
+  - Nacos discovery and registration support.
+- `spring-cloud-alibaba-commons`
+  - Shared support code reused by multiple starters.
+- `spring-cloud-circuitbreaker-sentinel`
+  - Sentinel integration for Spring Cloud CircuitBreaker.
+- `spring-cloud-alibaba-sentinel-datasource`
+  - Sentinel datasource integration support.
+- `spring-cloud-alibaba-sentinel-gateway`
+  - Sentinel support for Spring Cloud Gateway.
+- `spring-cloud-starter-bus-rocketmq`
+  - Spring Cloud Bus integration over RocketMQ.
+- `spring-cloud-starter-stream-rocketmq`
+  - Spring Cloud Stream RocketMQ integration.
+
+Contributor guidance:
+
+- Some features use a core module plus a starter module.
+- Some features implement functional code directly in the starter module.
+- If you are tracing behavior from a public starter dependency, start in the matching `spring-cloud-starter-*` module, then follow its internal dependencies.
+
+### 1.3 Example Module Families
+
+The repository groups starter code and examples by feature area. Common families include:
+
+- Nacos
+- Sentinel
+- RocketMQ
+- Seata
+- Sidecar
+- SchedulerX
+
+### 1.4 Where to Start Reading
+
+- For dependency and version questions, start in `spring-cloud-alibaba-dependencies`.
+- For runtime behavior, start in `spring-cloud-alibaba-starters`.
+- For usage and reproduction flows, check `spring-cloud-alibaba-examples`.
+- For integration-style verification coverage, check `spring-cloud-alibaba-tests`.
+
+### 1.5 Impact Guidance
+
+- Changes in `spring-cloud-alibaba-commons` can affect multiple starters.
+- Changes in a `spring-cloud-starter-*` module usually affect that integration's public auto-configuration surface.
+- Changes in examples should generally not be used as the primary implementation location for product behavior.


### PR DESCRIPTION
### Describe what this PR does / why we need it

This PR adds a new root-level `AGENTS.md` file with repository-specific guidance for AI coding assistants working in Spring Cloud Alibaba.

This first change is intentionally narrow and only documents project structure and module layout. It gives contributors and AI assistants a verified starting point for navigating the repository before making code changes.

### Does this pull request fix one issue?

Fixes #4313

### Describe how you did it

Added `AGENTS.md` at the repository root and documented:

- the top-level module layout
- the role of major top-level directories
- the structure of `spring-cloud-alibaba-starters`
- examples of current starter and support modules on `2025.1.x`
- guidance on where to start reading depending on the type of change
- basic impact guidance for shared modules such as `spring-cloud-alibaba-commons`

This PR keeps the scope limited to project structure only and does not add build, JDK, or test workflow guidance yet.

### Describe how to verify it

- Open `AGENTS.md` from the repository root
- Confirm the documented module layout matches the current `2025.1.x` branch structure
- Confirm the referenced starter modules exist under `spring-cloud-alibaba-starters/`
- Confirm no other project files were changed

### Special notes for reviews

This is intended as the first incremental contribution for issue #4313.

I kept the PR to a single new file so the initial review can focus on whether the documented repository structure is accurate before expanding `AGENTS.md` with additional sections in follow-up PRs.