### PR TITLE
fix(sentinel): SentinelFeignClientProperties#copy() should fail fast on Jackson errors

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-circuitbreaker-sentinel/src/main/java/com/alibaba/cloud/circuitbreaker/sentinel/feign/SentinelFeignClientProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-circuitbreaker-sentinel/src/main/java/com/alibaba/cloud/circuitbreaker/sentinel/feign/SentinelFeignClientProperties.java
@@ -97,9 +97,10 @@ public class SentinelFeignClientProperties {
 			String json = objectMapper.writeValueAsString(this);
 			return objectMapper.readValue(json, this.getClass());
 		}
-		catch (Exception ignored) {
+		catch (Exception e) {
+			throw new IllegalStateException(
+					"Failed to deep-copy SentinelFeignClientProperties via Jackson", e);
 		}
-		return new SentinelFeignClientProperties();
 	}
 
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-circuitbreaker-sentinel/src/test/java/com/alibaba/cloud/circuitbreaker/sentinel/feign/SentinelFeignClientPropertiesTest.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-circuitbreaker-sentinel/src/test/java/com/alibaba/cloud/circuitbreaker/sentinel/feign/SentinelFeignClientPropertiesTest.java
@@ -71,17 +71,53 @@ public class SentinelFeignClientPropertiesTest {
 
 	@Test
 	public void copyFailsFastWhenJacksonCannotSerialize() {
-		SentinelFeignClientProperties brokenProps = new SentinelFeignClientProperties() {
-			@Override
-			public Map<String, List<DegradeRule>> getRules() {
-				throw new RuntimeException("simulated serialization failure");
-			}
-		};
+		RuleAccessFailureProperties brokenProps = new RuleAccessFailureProperties();
+		brokenProps.failOnRuleAccess = true;
 
 		assertThatThrownBy(brokenProps::copy)
 				.isInstanceOf(IllegalStateException.class)
 				.hasMessageContaining("SentinelFeignClientProperties")
-				.hasCauseInstanceOf(RuntimeException.class);
+				.hasRootCauseInstanceOf(IllegalArgumentException.class)
+				.rootCause()
+				.hasMessage("simulated serialization failure");
+	}
+
+	// Control for copyFailsFastWhenJacksonCannotSerialize: the same carrier
+	// round-trips cleanly once the getter stops throwing, so the failure asserted
+	// there can only come from the getter and not from the carrier type itself.
+	@Test
+	public void copySucceedsForTheSameSubclassWhenTheGetterDoesNotThrow() {
+		RuleAccessFailureProperties props = new RuleAccessFailureProperties();
+		props.setDefaultRule("custom-default");
+		Map<String, List<DegradeRule>> rules = new HashMap<>();
+		rules.put("resource-a",
+				new ArrayList<>(List.of(new DegradeRule("resource-a"))));
+		props.setRules(rules);
+
+		SentinelFeignClientProperties copied = props.copy();
+
+		assertThat(copied).isNotSameAs(props);
+		assertThat(copied).isEqualTo(props);
+	}
+
+	/**
+	 * Named subclass used as the failure carrier. {@code failOnRuleAccess} has no
+	 * accessors on purpose so that Jackson neither writes nor reads it, keeping the
+	 * serialized form identical to the base class.
+	 */
+	public static class RuleAccessFailureProperties
+			extends SentinelFeignClientProperties {
+
+		boolean failOnRuleAccess;
+
+		@Override
+		public Map<String, List<DegradeRule>> getRules() {
+			if (failOnRuleAccess) {
+				throw new IllegalArgumentException("simulated serialization failure");
+			}
+			return super.getRules();
+		}
+
 	}
 
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-circuitbreaker-sentinel/src/test/java/com/alibaba/cloud/circuitbreaker/sentinel/feign/SentinelFeignClientPropertiesTest.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-circuitbreaker-sentinel/src/test/java/com/alibaba/cloud/circuitbreaker/sentinel/feign/SentinelFeignClientPropertiesTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2013-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.circuitbreaker.sentinel.feign;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRule;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link SentinelFeignClientProperties#copy()}.
+ */
+public class SentinelFeignClientPropertiesTest {
+
+	@Test
+	public void copyReturnsEqualButDistinctInstance() {
+		SentinelFeignClientProperties original = new SentinelFeignClientProperties();
+		original.setDefaultRule("custom-default");
+		original.setEnableRefreshRules(false);
+		Map<String, List<DegradeRule>> rules = new HashMap<>();
+		List<DegradeRule> ruleList = new ArrayList<>();
+		DegradeRule rule = new DegradeRule("resource-a");
+		rule.setCount(5.0);
+		ruleList.add(rule);
+		rules.put("resource-a", ruleList);
+		original.setRules(rules);
+
+		SentinelFeignClientProperties copied = original.copy();
+
+		assertThat(copied).isNotSameAs(original);
+		assertThat(copied).isEqualTo(original);
+	}
+
+	@Test
+	public void modifyingCopyDoesNotAffectOriginal() {
+		SentinelFeignClientProperties original = new SentinelFeignClientProperties();
+		Map<String, List<DegradeRule>> rules = new HashMap<>();
+		List<DegradeRule> ruleList = new ArrayList<>();
+		ruleList.add(new DegradeRule("resource-a"));
+		rules.put("resource-a", ruleList);
+		original.setRules(rules);
+
+		SentinelFeignClientProperties copied = original.copy();
+		copied.getRules().put("resource-b",
+				new ArrayList<>(List.of(new DegradeRule("resource-b"))));
+		copied.setDefaultRule("changed");
+
+		assertThat(original.getRules()).containsOnlyKeys("resource-a");
+		assertThat(original.getDefaultRule()).isEqualTo("default");
+	}
+
+	@Test
+	public void copyFailsFastWhenJacksonCannotSerialize() {
+		SentinelFeignClientProperties brokenProps = new SentinelFeignClientProperties() {
+			@Override
+			public Map<String, List<DegradeRule>> getRules() {
+				throw new RuntimeException("simulated serialization failure");
+			}
+		};
+
+		assertThatThrownBy(brokenProps::copy)
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessageContaining("SentinelFeignClientProperties")
+				.hasCauseInstanceOf(RuntimeException.class);
+	}
+
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

`SentinelFeignClientProperties#copy()` produces the deep snapshot that `CircuitBreakerRuleChangeListener` diffs against to decide whether circuit-breaker rules changed (`afterSingletonsInstantiated()` and `updateBackup()`). Today it swallows every exception and returns a brand-new default-valued instance.

To be upfront about the scope: **this is not a bug users are hitting today.** I probed the round-trip on this branch and could not make it fail in any realistic configuration — plain objects, CGLIB proxies (what AOP / `@RefreshScope` produce), named subclasses, `DegradeRule` subclasses carrying extra fields, `count = NaN`, and two map keys aliasing one `List` all round-trip successfully, and Jackson 3 defaults `FAIL_ON_UNKNOWN_PROPERTIES` to off so unrecognised properties are tolerated too.

The argument for this change is therefore not "it fixes a live failure" but "the fallback is unreachable in practice and harmful if ever reached":

- The fallback returns `new SentinelFeignClientProperties()` — the **base** class — while `equals()` is implemented with `getClass() != o.getClass()`. When the live bean is a proxy or a subclass, `Objects.equals(properties, propertiesBackup)` in `onApplicationEvent` cannot return `true` again for the rest of the process lifetime, so every subsequent refresh event is treated as a rule change, silently.
- Being unreachable, the branch can never be exercised by a test, so it is dead weight that only carries risk.

Also worth noting: since the module moved to Jackson 3 (`tools.jackson.databind.ObjectMapper`), `JacksonException` is unchecked, so the original `try / catch (Exception)` no longer serves any compile-time purpose either.

### Does this pull request fix one issue?

NONE

### Describe how you did it

Replaced the silent-swallow + new-instance fallback with `throw new IllegalStateException("Failed to deep-copy SentinelFeignClientProperties via Jackson", e);`, preserving the original cause.

### Describe how to verify it

`mvn -pl spring-cloud-alibaba-starters/spring-cloud-circuitbreaker-sentinel -am test` — full module suite (19 tests) passes locally.

`SentinelFeignClientPropertiesTest` covers:

- `copyReturnsEqualButDistinctInstance` — `copy()` returns a value `.equals()` to the original but not the same reference.
- `modifyingCopyDoesNotAffectOriginal` — the copy is a true deep copy.
- `copyFailsFastWhenJacksonCannotSerialize` — a named static subclass whose `getRules()` throws only when armed; asserts the call propagates `IllegalStateException` with the underlying failure as its root cause.
- `copySucceedsForTheSameSubclassWhenTheGetterDoesNotThrow` — control case: the very same carrier round-trips cleanly once disarmed, so the failure asserted above can only originate from the throwing getter and not from the carrier type.

Verified against the pre-fix implementation: `copyFailsFastWhenJacksonCannotSerialize` is the only test that fails there; the control case passes under both implementations.

### Special notes for reviews

- ABI-compatible: `IllegalStateException` is unchecked, so the `copy()` signature is unchanged.
- **Why throw rather than warn and keep the previous backup.** At `updateBackup()` a previous backup does exist, but at `afterSingletonsInstantiated()` there is none — that call is the first assignment to `propertiesBackup`. A warn-and-continue variant would have to leave it either `null` or empty there, and both have concrete downsides: leaving it `null` makes `clearFeignClientRulesInDegradeManager()` return early on the next refresh, so rules the user removed from configuration stay behind in `DegradeRuleManager`; leaving it empty is exactly today's behaviour. Throwing keeps the two call sites honest instead: at startup the failure surfaces with its cause attached, and at refresh time Spring's `SimpleApplicationEventMulticaster` logs the listener exception and continues to other listeners, so the worst case is a skipped refresh cycle rather than a corrupted baseline.
- Happy to switch to warn-and-continue if maintainers prefer that trade-off; the part I actually care about is removing the empty-baseline corruption.
- No drive-by changes; the production diff is `+3 / -2` plus the test file.
