### PR TITLE
fix(rocketmq): log warning when FLAG or DELAY header is not numeric

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/support/RocketMQMessageConverterSupport.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/support/RocketMQMessageConverterSupport.java
@@ -26,6 +26,8 @@ import com.alibaba.cloud.stream.binder.rocketmq.convert.RocketMQMessageConverter
 import com.alibaba.cloud.stream.binder.rocketmq.custom.RocketMQBeanContainerCache;
 import org.apache.rocketmq.common.message.MessageConst;
 import org.apache.rocketmq.common.message.MessageExt;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
@@ -39,6 +41,9 @@ import org.springframework.util.ObjectUtils;
  * @author zkzlx
  */
 public final class RocketMQMessageConverterSupport {
+
+	private static final Logger log = LoggerFactory
+			.getLogger(RocketMQMessageConverterSupport.class);
 
 	private RocketMQMessageConverterSupport() {
 	}
@@ -153,20 +158,15 @@ public final class RocketMQMessageConverterSupport {
 			}
 			Object flagObj = headers.getOrDefault(Headers.FLAG,
 					headers.get(toRocketHeaderKey(Headers.FLAG)));
-			int flag = 0;
-			int delayLevel = 0;
-			try {
-				flagObj = flagObj == null ? 0 : flagObj;
-				Object delayLevelObj = headers.getOrDefault(
-						RocketMQConst.PROPERTY_DELAY_TIME_LEVEL,
-						headers.get(toRocketHeaderKey(
-								RocketMQConst.PROPERTY_DELAY_TIME_LEVEL)));
-				delayLevelObj = delayLevelObj == null ? 0 : delayLevelObj;
-				delayLevel = Integer.parseInt(String.valueOf(delayLevelObj));
-				flag = Integer.parseInt(String.valueOf(flagObj));
-			}
-			catch (Exception ignored) {
-			}
+			Object delayLevelObj = headers.getOrDefault(
+					RocketMQConst.PROPERTY_DELAY_TIME_LEVEL,
+					headers.get(toRocketHeaderKey(
+							RocketMQConst.PROPERTY_DELAY_TIME_LEVEL)));
+			// Parse each header independently so a malformed value in one never
+			// forces the other, well-formed header to fall back to 0.
+			int flag = parseHeaderAsIntOrDefault(Headers.FLAG, flagObj);
+			int delayLevel = parseHeaderAsIntOrDefault(
+					RocketMQConst.PROPERTY_DELAY_TIME_LEVEL, delayLevelObj);
 			if (delayLevel > 0) {
 				rocketMsg.setDelayTimeLevel(delayLevel);
 			}
@@ -189,6 +189,32 @@ public final class RocketMQMessageConverterSupport {
 
 		}
 		return rocketMsg;
+	}
+
+	/**
+	 * Parses a message header value as an {@code int}, falling back to {@code 0}
+	 * when the header is absent or not a valid integer. Each header is parsed on
+	 * its own so a malformed value in one header never drags a well-formed value
+	 * in another header down to the fallback, and the warning names only the
+	 * header that actually failed. Only the exception message is logged (no stack
+	 * trace) to avoid flooding the logs when many messages carry the same bad
+	 * header.
+	 * @param headerName the header name, used only for the warning message
+	 * @param rawValue the raw header value, may be {@code null}
+	 * @return the parsed value, or {@code 0} when absent or non-numeric
+	 */
+	private static int parseHeaderAsIntOrDefault(String headerName, Object rawValue) {
+		if (rawValue == null) {
+			return 0;
+		}
+		try {
+			return Integer.parseInt(String.valueOf(rawValue));
+		}
+		catch (NumberFormatException e) {
+			log.warn("Non-numeric '{}' header value [{}]; falling back to 0: {}",
+					headerName, rawValue, e.getMessage());
+			return 0;
+		}
 	}
 
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/support/RocketMQMessageConverterSupport.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/java/com/alibaba/cloud/stream/binder/rocketmq/support/RocketMQMessageConverterSupport.java
@@ -26,6 +26,7 @@ import com.alibaba.cloud.stream.binder.rocketmq.convert.RocketMQMessageConverter
 import com.alibaba.cloud.stream.binder.rocketmq.custom.RocketMQBeanContainerCache;
 import org.apache.rocketmq.common.message.MessageConst;
 import org.apache.rocketmq.common.message.MessageExt;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -203,7 +204,8 @@ public final class RocketMQMessageConverterSupport {
 	 * @param rawValue the raw header value, may be {@code null}
 	 * @return the parsed value, or {@code 0} when absent or non-numeric
 	 */
-	private static int parseHeaderAsIntOrDefault(String headerName, Object rawValue) {
+	private static int parseHeaderAsIntOrDefault(String headerName,
+			@Nullable Object rawValue) {
 		if (rawValue == null) {
 			return 0;
 		}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/test/java/com/alibaba/cloud/stream/binder/rocketmq/RocketMQMessageConverterSupportTest.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/test/java/com/alibaba/cloud/stream/binder/rocketmq/RocketMQMessageConverterSupportTest.java
@@ -16,18 +16,24 @@
 
 package com.alibaba.cloud.stream.binder.rocketmq;
 
+import com.alibaba.cloud.stream.binder.rocketmq.constant.RocketMQConst;
 import com.alibaba.cloud.stream.binder.rocketmq.support.RocketMQMessageConverterSupport;
 import org.apache.rocketmq.common.message.MessageConst;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
  * @author Sorie
  */
+@ExtendWith(OutputCaptureExtension.class)
 public class RocketMQMessageConverterSupportTest {
 
 	@Test
@@ -43,5 +49,98 @@ public class RocketMQMessageConverterSupportTest {
 		String tagProp = rkmqMsg.getProperty(MessageConst.PROPERTY_TAGS);
 		assertThat(testProp).isNull();
 		assertThat(tagProp).isEqualTo("a");
+	}
+
+	@Test
+	public void nonNumericDelayTimeLevelHeaderFallsBackToZero() {
+		Message<String> message = MessageBuilder.withPayload("msg")
+				.setHeader(RocketMQConst.PROPERTY_DELAY_TIME_LEVEL, "not-a-number")
+				.build();
+
+		org.apache.rocketmq.common.message.Message rkmqMsg =
+				RocketMQMessageConverterSupport.convertMessage2MQ("topic", message);
+
+		assertThat(rkmqMsg.getDelayTimeLevel()).isEqualTo(0);
+		assertThat(rkmqMsg.getFlag()).isEqualTo(0);
+	}
+
+	@Test
+	public void nonNumericFlagHeaderFallsBackToZero() {
+		Message<String> message = MessageBuilder.withPayload("msg")
+				.setHeader(RocketMQConst.Headers.FLAG, "not-a-number")
+				.build();
+
+		org.apache.rocketmq.common.message.Message rkmqMsg =
+				RocketMQMessageConverterSupport.convertMessage2MQ("topic", message);
+
+		assertThat(rkmqMsg.getFlag()).isEqualTo(0);
+	}
+
+	@Test
+	public void invalidNumericHeaderDoesNotPropagateException() {
+		Message<String> message = MessageBuilder.withPayload("msg")
+				.setHeader(RocketMQConst.PROPERTY_DELAY_TIME_LEVEL, "x")
+				.setHeader(RocketMQConst.Headers.FLAG, "y")
+				.build();
+
+		assertThatCode(() ->
+				RocketMQMessageConverterSupport.convertMessage2MQ("topic", message))
+				.doesNotThrowAnyException();
+	}
+
+	@Test
+	public void nonNumericFlagHeaderLogsWarning(CapturedOutput output) {
+		Message<String> message = MessageBuilder.withPayload("msg")
+				.setHeader(RocketMQConst.Headers.FLAG, "flag-not-a-number")
+				.build();
+
+		RocketMQMessageConverterSupport.convertMessage2MQ("topic", message);
+
+		// The malformed header must no longer be swallowed silently: the warning
+		// names the offending header and echoes its raw value.
+		assertThat(output).contains(RocketMQConst.Headers.FLAG)
+				.contains("flag-not-a-number");
+	}
+
+	@Test
+	public void validDelayLevelWithNonNumericFlagIsPreservedAndWarnsOnlyFlag(
+			CapturedOutput output) {
+		Message<String> message = MessageBuilder.withPayload("msg")
+				.setHeader(RocketMQConst.PROPERTY_DELAY_TIME_LEVEL, "3")
+				.setHeader(RocketMQConst.Headers.FLAG, "flag-bad")
+				.build();
+
+		org.apache.rocketmq.common.message.Message rkmqMsg =
+				RocketMQMessageConverterSupport.convertMessage2MQ("topic", message);
+
+		// A valid delay level must survive a malformed flag on the same message;
+		// the two headers are parsed independently.
+		assertThat(rkmqMsg.getDelayTimeLevel()).isEqualTo(3);
+		assertThat(rkmqMsg.getFlag()).isEqualTo(0);
+		// The warning names the flag header only; the valid delay level must not
+		// be reported as having fallen back.
+		assertThat(output).contains("flag-bad")
+				.doesNotContain("'" + RocketMQConst.PROPERTY_DELAY_TIME_LEVEL + "'");
+	}
+
+	@Test
+	public void validFlagWithNonNumericDelayLevelIsPreservedAndWarnsOnlyDelayLevel(
+			CapturedOutput output) {
+		Message<String> message = MessageBuilder.withPayload("msg")
+				.setHeader(RocketMQConst.PROPERTY_DELAY_TIME_LEVEL, "delay-bad")
+				.setHeader(RocketMQConst.Headers.FLAG, "7")
+				.build();
+
+		org.apache.rocketmq.common.message.Message rkmqMsg =
+				RocketMQMessageConverterSupport.convertMessage2MQ("topic", message);
+
+		// A valid flag must survive a malformed delay level on the same message;
+		// the two headers are parsed independently.
+		assertThat(rkmqMsg.getFlag()).isEqualTo(7);
+		assertThat(rkmqMsg.getDelayTimeLevel()).isEqualTo(0);
+		// The warning names the delay-level header only; the valid flag must not
+		// be reported as having fallen back.
+		assertThat(output).contains("delay-bad")
+				.doesNotContain("'" + RocketMQConst.Headers.FLAG + "'");
 	}
 }


### PR DESCRIPTION
### Describe what this PR does / why we need it

`RocketMQMessageConverterSupport#getAndWrapMessage` parses the `MQ_FLAG` and `DELAY_TIME_LEVEL` Spring Messaging headers into `int` via `Integer.parseInt`. The previous implementation wrapped both parses in a single `try { ... } catch (Exception ignored) {}`, so any malformed header (e.g. a `String` value injected via a SpEL expression, a typo, or a non-numeric class) was **silently** absorbed and the producer fell back to `flag=0` and `delayLevel=0` with no exception, no log line, and no signal to the caller.

The most user-visible consequence is on the **delayed-delivery path**: a misconfigured `DELAY_TIME_LEVEL` (e.g. `"abc"` from a SpEL that returned a String instead of an int) turns a delayed message into an immediate send and the application has no way of knowing.

### Does this pull request fix one issue?

NONE

### Describe how you did it

- Added a class-level SLF4J logger to `RocketMQMessageConverterSupport`.
- Extracted the parsing into a `parseHeaderAsIntOrDefault(String headerName, @Nullable Object rawValue)` helper and parse the two headers **independently** (`flag` first, then `delayLevel`). A malformed value in one header no longer drags the other, well-formed header down to the fallback, and the warning names only the header that actually failed.
- The helper catches `NumberFormatException`, logs a `warn` with the header name, the raw value, and the exception **message only** (no stack trace, to avoid flooding logs on the per-message producer path), and falls back to `0`.
- The `rawValue` parameter is annotated `@org.jspecify.annotations.Nullable` (the `support` package is `@NullMarked`; header lookups can return `null`).

### Describe how to verify it

`mvn -pl spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq test` — all 16 module tests pass locally, including 6 new ones in `RocketMQMessageConverterSupportTest`:

- `nonNumericDelayTimeLevelHeaderFallsBackToZero` — `DELAY = "not-a-number"` → `getDelayTimeLevel() == 0`.
- `nonNumericFlagHeaderFallsBackToZero` — `MQ_FLAG = "not-a-number"` → `getFlag() == 0`.
- `invalidNumericHeaderDoesNotPropagateException` — both headers non-numeric → no exception escapes `convertMessage2MQ`.
- `nonNumericFlagHeaderLogsWarning` — uses `OutputCaptureExtension` to assert the warning contains the header name and the raw value.
- `validDelayLevelWithNonNumericFlagIsPreservedAndWarnsOnlyFlag` — mixed validity: valid `DELAY` is preserved, warning names only `MQ_FLAG`.
- `validFlagWithNonNumericDelayLevelIsPreservedAndWarnsOnlyDelayLevel` — the symmetric mixed-validity case.

### Special notes for reviews

Two intentional behaviour changes relative to the old silent-fallback code, both discussed in review:

1. **Mixed-validity fallback changed (improvement).** Previously, one malformed header could force *both* values to `0` (the parses shared one `try` block). Now each header is parsed independently, so a well-formed header keeps its value even when the other one is malformed. The mixed-validity tests lock this in.
2. **Catch narrowed from `Exception` to `NumberFormatException` (intentional).** `String.valueOf(rawValue)` can in principle throw if a custom header value's `toString()` throws; such an exception now propagates instead of being silently converted into `flag=0`/`delayLevel=0`. This is deliberate: a throwing `toString()` is a programming error in the producer application, and silently mapping it to "send immediately with flag 0" is exactly the failure mode this PR removes. `NumberFormatException` (the only expected failure: non-numeric text) is still handled with warn-and-fallback.

For every previously valid header value the output is unchanged; for a message where *all* malformed headers are non-numeric text (the common case), the fallback output is also unchanged — the `log.warn` is the only new externally visible behaviour.
