### PR TITLE
chore: add debug log for Nacos config snapshot hits

### DIFF
--- a/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/configdata/NacosConfigDataLoader.java
+++ b/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/configdata/NacosConfigDataLoader.java
@@ -159,6 +159,11 @@ public class NacosConfigDataLoader implements ConfigDataLoader<NacosConfigDataRe
 		if (config == null) {
 			config = configService.getConfig(dataId, group, timeout);
 		}
+		else {
+			log.debug(String.format(
+					"[Nacos Config] Load config from snapshot[dataId=%s, group=%s]",
+					dataId, group));
+		}
 		logLoadInfo(group, dataId, config);
 		// fixed issue: https://github.com/alibaba/spring-cloud-alibaba/issues/2906 .
 		String configName = group + "@" + dataId;


### PR DESCRIPTION
## What does this PR do?

Adds a debug-level log message when a Nacos config value is loaded from the local snapshot cache instead of being fetched from the remote server.

This aids troubleshooting in cluster mode where snapshot cache hits indicate a config change notification arrived before the remote node synced.

> Note: The core stale-config fix was already handled by #4319. This PR only adds observability for snapshot cache behavior.