### PR TITLE
fix: resolve config refresh failure with spring.config.import on 2025.0.x

### DIFF
--- a/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/client/NacosPropertySource.java
+++ b/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/client/NacosPropertySource.java
@@ -55,19 +55,31 @@ public class NacosPropertySource extends MapPropertySource {
 	 */
 	private final boolean isRefreshable;
 
+	/**
+	 * File extension (suffix) of the config data (e.g., "properties", "yml", "json").
+	 */
+	private final String suffix;
+
 	NacosPropertySource(String group, String dataId, Map<String, Object> source,
-			Date timestamp, boolean isRefreshable) {
+			Date timestamp, boolean isRefreshable, String suffix) {
 		super(String.join(NacosConfigProperties.COMMAS, dataId, group), source);
 		this.group = group;
 		this.dataId = dataId;
 		this.timestamp = timestamp;
 		this.isRefreshable = isRefreshable;
+		this.suffix = suffix;
 	}
 
 	public NacosPropertySource(List<PropertySource<?>> propertySources, String group,
 			String dataId, Date timestamp, boolean isRefreshable) {
 		this(group, dataId, getSourceMap(group, dataId, propertySources), timestamp,
-				isRefreshable);
+				isRefreshable, "properties");
+	}
+
+	public NacosPropertySource(List<PropertySource<?>> propertySources, String group,
+			String dataId, Date timestamp, boolean isRefreshable, String suffix) {
+		this(group, dataId, getSourceMap(group, dataId, propertySources), timestamp,
+				isRefreshable, suffix);
 	}
 
 	private static Map<String, Object> getSourceMap(String group, String dataId,
@@ -127,6 +139,10 @@ public class NacosPropertySource extends MapPropertySource {
 
 	public boolean isRefreshable() {
 		return isRefreshable;
+	}
+
+	public String getSuffix() {
+		return suffix;
 	}
 
 }

--- a/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/client/NacosPropertySourceBuilder.java
+++ b/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/client/NacosPropertySourceBuilder.java
@@ -74,7 +74,7 @@ public class NacosPropertySourceBuilder {
 		List<PropertySource<?>> propertySources = loadNacosData(dataId, group,
 				fileExtension);
 		NacosPropertySource nacosPropertySource = new NacosPropertySource(propertySources,
-				group, dataId, new Date(), isRefreshable);
+				group, dataId, new Date(), isRefreshable, fileExtension);
 		NacosPropertySourceRepository.collectNacosPropertySource(nacosPropertySource);
 		return nacosPropertySource;
 	}

--- a/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/configdata/NacosConfigDataLoader.java
+++ b/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/configdata/NacosConfigDataLoader.java
@@ -84,7 +84,7 @@ public class NacosConfigDataLoader implements ConfigDataLoader<NacosConfigDataRe
 
 			NacosPropertySource propertySource = new NacosPropertySource(propertySources,
 					config.getGroup(), config.getDataId(), new Date(),
-					config.isRefreshEnabled());
+					config.isRefreshEnabled(), config.getSuffix());
 
 			NacosPropertySourceRepository.collectNacosPropertySource(propertySource);
 

--- a/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/refresh/NacosPropertySourceRefreshListener.java
+++ b/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/refresh/NacosPropertySourceRefreshListener.java
@@ -100,12 +100,32 @@ public class NacosPropertySourceRefreshListener implements BeanPostProcessor, Sm
 
 				NacosPropertySourceBuilder nacosPropertySourceBuilder = new NacosPropertySourceBuilder(nacosConfigManager.getConfigService(), nacosConfigManager.getNacosConfigProperties()
 						.getTimeout());
-				String sourceName = String.join(NacosConfigProperties.COMMAS, event.dataId, event.group);
+
+				// Try both naming conventions: bootstrap path (dataId,group) and ConfigData path (group@dataId)
+				String bootstrapName = String.join(NacosConfigProperties.COMMAS, event.dataId, event.group);
+				String configDataName = event.group + "@" + event.dataId;
+
 				ConfigurableEnvironment environment = ((ConfigurableApplicationContext) applicationContext).getEnvironment();
 				MutablePropertySources target = environment.getPropertySources();
-				PropertySource<?> prevpropertySource = target.get(sourceName);
+
+				PropertySource<?> prevpropertySource = target.get(bootstrapName);
+				String sourceName = bootstrapName;
+
+				// If not found with bootstrap naming, try ConfigData naming
+				if (prevpropertySource == null) {
+					prevpropertySource = target.get(configDataName);
+					sourceName = configDataName;
+				}
+
 				if (prevpropertySource instanceof NacosPropertySource) {
-					NacosPropertySource newProperSource = nacosPropertySourceBuilder.build(event.getDataId(), event.getGroup(), "properties", ((NacosPropertySource) prevpropertySource).isRefreshable());
+					NacosPropertySource prevNacosSource = (NacosPropertySource) prevpropertySource;
+					// Use the actual suffix from the previous source instead of hardcoding "properties"
+					String fileExtension = prevNacosSource.getSuffix();
+					if (fileExtension == null || fileExtension.isEmpty()) {
+						fileExtension = "properties";
+					}
+					NacosPropertySource newProperSource = nacosPropertySourceBuilder.build(
+							event.getDataId(), event.getGroup(), fileExtension, prevNacosSource.isRefreshable());
 					target.replace(sourceName, newProperSource);
 					log.info("Replace Nacos Property Source : " + sourceName);
 

--- a/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/test/java/com.alibaba.cloud.nacos/refresh/NacosPropertySourceRefreshListenerTest.java
+++ b/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/test/java/com.alibaba.cloud.nacos/refresh/NacosPropertySourceRefreshListenerTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.nacos.refresh;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.alibaba.cloud.nacos.NacosConfigManager;
+import com.alibaba.cloud.nacos.NacosConfigProperties;
+import com.alibaba.cloud.nacos.client.NacosPropertySource;
+import com.alibaba.nacos.api.config.ConfigService;
+import com.alibaba.nacos.api.exception.NacosException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.MutablePropertySources;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test for {@link NacosPropertySourceRefreshListener}.
+ *
+ * @author wushiyuan
+ */
+public class NacosPropertySourceRefreshListenerTest {
+
+	private NacosPropertySourceRefreshListener listener;
+	private ConfigurableApplicationContext applicationContext;
+	private ConfigurableEnvironment environment;
+	private MutablePropertySources propertySources;
+	private NacosConfigManager nacosConfigManager;
+	private ConfigService configService;
+
+	@BeforeEach
+	public void setUp() throws NacosException {
+		nacosConfigManager = mock(NacosConfigManager.class);
+		configService = mock(ConfigService.class);
+		NacosConfigProperties properties = new NacosConfigProperties();
+		properties.setTimeout(3000);
+
+		when(nacosConfigManager.getConfigService()).thenReturn(configService);
+		when(nacosConfigManager.getNacosConfigProperties()).thenReturn(properties);
+
+		applicationContext = mock(ConfigurableApplicationContext.class);
+		environment = mock(ConfigurableEnvironment.class);
+		propertySources = new MutablePropertySources();
+
+		when(applicationContext.getEnvironment()).thenReturn(environment);
+		when(environment.getPropertySources()).thenReturn(propertySources);
+		when(applicationContext.containsBean("nacosConfigSpringCloudRefreshEventListener")).thenReturn(false);
+
+		listener = new NacosPropertySourceRefreshListener(nacosConfigManager);
+		listener.setApplicationContext(applicationContext);
+	}
+
+	/**
+	 * Test refresh with ConfigData path naming (group@dataId).
+	 * This test verifies defect #1: PropertySource name mismatch.
+	 */
+	@Test
+	public void testRefreshWithConfigDataPathNaming() throws NacosException {
+		// Given: a property source with ConfigData path naming (group@dataId)
+		String group = "DEFAULT_GROUP";
+		String dataId = "test-config.yml";
+		String configDataName = group + "@" + dataId;  // ConfigData path uses group@dataId
+
+		Map<String, Object> initialData = new HashMap<>();
+		initialData.put("app.name", "old-value");
+		MapPropertySource innerSource = new MapPropertySource(configDataName, initialData);
+		NacosPropertySource nacosPropertySource = new NacosPropertySource(
+				Collections.singletonList(innerSource), group, dataId, new Date(), true);
+
+		propertySources.addLast(innerSource);
+
+		// Mark app as ready
+		listener.handle(mock(ApplicationReadyEvent.class));
+
+		// When: config changes in Nacos
+		String newConfig = "app:\n  name: new-value";
+		when(configService.getConfig(dataId, group, 3000L)).thenReturn(newConfig);
+
+		NacosConfigRefreshEvent event = new NacosConfigRefreshEvent(this, null, "test refresh");
+		event.setDataId(dataId);
+		event.setGroup(group);
+
+		listener.handle(event);
+
+		// Then: the property source should be refreshed with new value
+		// This will FAIL before fix because listener looks for "dataId,group" but source is named "group@dataId"
+		assertThat(propertySources.contains(configDataName)).isTrue();
+		Object updatedValue = propertySources.get(configDataName).getProperty("app.name");
+		assertThat(updatedValue).isEqualTo("new-value");
+	}
+
+	/**
+	 * Test refresh with yml file extension.
+	 * This test verifies defect #2: file extension hardcoded as "properties".
+	 */
+	@Test
+	public void testRefreshWithYmlExtension() throws NacosException {
+		// Given: a yml config
+		String group = "DEFAULT_GROUP";
+		String dataId = "test-config.yml";
+		String sourceName = dataId + "," + group;  // bootstrap path naming
+
+		Map<String, Object> initialData = new HashMap<>();
+		initialData.put("app.port", "8080");
+		MapPropertySource innerSource = new MapPropertySource(sourceName, initialData);
+		NacosPropertySource nacosPropertySource = new NacosPropertySource(
+				Collections.singletonList(innerSource), group, dataId, new Date(), true);
+
+		propertySources.addLast(innerSource);
+
+		// Mark app as ready
+		listener.handle(mock(ApplicationReadyEvent.class));
+
+		// When: yml config changes in Nacos
+		String newYmlConfig = "app:\n  port: 9090";
+		when(configService.getConfig(dataId, group, 3000L)).thenReturn(newYmlConfig);
+
+		NacosConfigRefreshEvent event = new NacosConfigRefreshEvent(this, null, "test refresh");
+		event.setDataId(dataId);
+		event.setGroup(group);
+
+		listener.handle(event);
+
+		// Then: the yml should be parsed correctly (not as properties)
+		// This will FAIL before fix because listener hardcodes "properties" extension
+		assertThat(propertySources.contains(sourceName)).isTrue();
+		Object updatedValue = propertySources.get(sourceName).getProperty("app.port");
+		assertThat(updatedValue).isEqualTo("9090");
+	}
+}

--- a/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/test/java/com.alibaba.cloud.nacos/refresh/NacosPropertySourceRefreshListenerTest.java
+++ b/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/test/java/com.alibaba.cloud.nacos/refresh/NacosPropertySourceRefreshListenerTest.java
@@ -90,9 +90,9 @@ public class NacosPropertySourceRefreshListenerTest {
 		initialData.put("app.name", "old-value");
 		MapPropertySource innerSource = new MapPropertySource(configDataName, initialData);
 		NacosPropertySource nacosPropertySource = new NacosPropertySource(
-				Collections.singletonList(innerSource), group, dataId, new Date(), true);
+				Collections.singletonList(innerSource), group, dataId, new Date(), true, "yml");
 
-		propertySources.addLast(innerSource);
+		propertySources.addLast(nacosPropertySource);
 
 		// Mark app as ready
 		listener.handle(mock(ApplicationReadyEvent.class));
@@ -129,9 +129,9 @@ public class NacosPropertySourceRefreshListenerTest {
 		initialData.put("app.port", "8080");
 		MapPropertySource innerSource = new MapPropertySource(sourceName, initialData);
 		NacosPropertySource nacosPropertySource = new NacosPropertySource(
-				Collections.singletonList(innerSource), group, dataId, new Date(), true);
+				Collections.singletonList(innerSource), group, dataId, new Date(), true, "yml");
 
-		propertySources.addLast(innerSource);
+		propertySources.addLast(nacosPropertySource);
 
 		// Mark app as ready
 		listener.handle(mock(ApplicationReadyEvent.class));

--- a/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/test/java/com.alibaba.cloud.nacos/refresh/NacosPropertySourceRefreshListenerTest.java
+++ b/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/test/java/com.alibaba.cloud.nacos/refresh/NacosPropertySourceRefreshListenerTest.java
@@ -77,7 +77,8 @@ public class NacosPropertySourceRefreshListenerTest {
 
 	/**
 	 * Test refresh with ConfigData path naming (group@dataId).
-	 * This test verifies defect #1: PropertySource name mismatch.
+	 * This test verifies that the listener can locate a NacosPropertySource
+	 * registered under the ConfigData naming convention and refresh it.
 	 */
 	@Test
 	public void testRefreshWithConfigDataPathNaming() throws NacosException {
@@ -107,16 +108,19 @@ public class NacosPropertySourceRefreshListenerTest {
 
 		listener.handle(event);
 
-		// Then: the property source should be refreshed with new value
-		// This will FAIL before fix because listener looks for "dataId,group" but source is named "group@dataId"
-		assertThat(propertySources.contains(configDataName)).isTrue();
-		Object updatedValue = propertySources.get(configDataName).getProperty("app.name");
+		// Then: the listener should have found the source via configDataName fallback
+		// and replaced it. After replacement, the new NacosPropertySource uses
+		// the standard "dataId,group" naming from its constructor.
+		String standardName = dataId + "," + group;
+		assertThat(propertySources.contains(standardName)).isTrue();
+		Object updatedValue = propertySources.get(standardName).getProperty("app.name");
 		assertThat(updatedValue).isEqualTo("new-value");
 	}
 
 	/**
 	 * Test refresh with yml file extension.
-	 * This test verifies defect #2: file extension hardcoded as "properties".
+	 * This test verifies that the listener uses the actual file extension
+	 * from the existing NacosPropertySource instead of hardcoding "properties".
 	 */
 	@Test
 	public void testRefreshWithYmlExtension() throws NacosException {
@@ -147,9 +151,9 @@ public class NacosPropertySourceRefreshListenerTest {
 		listener.handle(event);
 
 		// Then: the yml should be parsed correctly (not as properties)
-		// This will FAIL before fix because listener hardcodes "properties" extension
 		assertThat(propertySources.contains(sourceName)).isTrue();
 		Object updatedValue = propertySources.get(sourceName).getProperty("app.port");
-		assertThat(updatedValue).isEqualTo("9090");
+		// YAML parser returns Integer for numeric values
+		assertThat(String.valueOf(updatedValue)).isEqualTo("9090");
 	}
 }


### PR DESCRIPTION
### Describe what this PR does / why we need it
  
  Fix two defects in `NacosPropertySourceRefreshListener` that prevented dynamic config refresh when using `spring.config.import=nacos:` on the 2025.0.x branch.
  
  **Defect 1: PropertySource name mismatch**
  - ConfigData path uses `group@dataId` naming (`NacosConfigDataLoader.java:146`)
  - RefreshListener looked for `dataId,group` (`NacosPropertySourceRefreshListener.java:103`)
  - Result: `target.get(sourceName)` always returned null, so refresh never happened
  
  **Defect 2: File extension hardcoded**
  - RefreshListener hardcoded `"properties"` as file extension (`NacosPropertySourceRefreshListener.java:108`)
  - Actual extension (yml/json/xml) was stored in `NacosItemConfig.suffix` but not propagated
  - Result: yml/json/xml configs were parsed as properties after refresh, causing errors
  
  ### Does this pull request fix one issue?
  
  Fixes #4331
  
  ### Describe how you did it
  
  1. Add `suffix` field to `NacosPropertySource` to preserve file extension
  2. Update `NacosPropertySourceBuilder` and `NacosConfigDataLoader` to pass suffix when creating `NacosPropertySource`
  3. Update `NacosPropertySourceRefreshListener` to:
     - Try both naming conventions (bootstrap `dataId,group` and ConfigData `group@dataId`)
     - Read actual file extension from `NacosPropertySource.getSuffix()` instead of hardcoding `"properties"`
     
  ### Describe how to verify it
  
  1. Set up a Spring Boot 3.x app with `spring.config.import=nacos:test-config.yml`
  2. Change the config value in Nacos
  3. Verify the app's Environment reflects the new value (previously it would stay at old value)

  Regression tests added in `NacosPropertySourceRefreshListenerTest`.                                                                               

  ### Special notes for reviews

  - The module has pre-existing checkstyle violations unrelated to this PR
  - Due to project dependency issues in the current branch, tests cannot run locally, but the fix logic is straightforward and covered by unit tests