### PR TITLE
fix(nacos): NacosPropertySource refresh replacement

### DIFF
--- a/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/configdata/NacosConfigDataLoader.java
+++ b/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/configdata/NacosConfigDataLoader.java
@@ -18,6 +18,7 @@ package com.alibaba.cloud.nacos.configdata;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -97,7 +98,8 @@ public class NacosConfigDataLoader implements ConfigDataLoader<NacosConfigDataRe
 
 			NacosPropertySourceRepository.collectNacosPropertySource(propertySource);
 
-			return new ConfigData(propertySources, getOptions(context, resource));
+			return new ConfigData(Collections.singletonList(propertySource),
+					getOptions(context, resource));
 		}
 		catch (Exception e) {
 			log.error("Error getting properties from nacos: " + resource, e);

--- a/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/test/java/com.alibaba.cloud.nacos/configdata/NacosConfigDataLoaderTest.java
+++ b/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/test/java/com.alibaba.cloud.nacos/configdata/NacosConfigDataLoaderTest.java
@@ -18,6 +18,7 @@ package com.alibaba.cloud.nacos.configdata;
 
 import com.alibaba.cloud.nacos.NacosConfigManager;
 import com.alibaba.cloud.nacos.NacosConfigProperties;
+import com.alibaba.cloud.nacos.client.NacosPropertySource;
 import com.alibaba.cloud.nacos.configdata.NacosConfigDataResource.NacosItemConfig;
 import com.alibaba.cloud.nacos.refresh.NacosSnapshotConfigManager;
 import com.alibaba.nacos.api.config.ConfigService;
@@ -53,6 +54,10 @@ class NacosConfigDataLoaderTest {
 
 			assertThat(configData).isNotNull();
 			assertThat(configData.getPropertySources()).hasSize(1);
+			assertThat(configData.getPropertySources().get(0))
+				.isInstanceOf(NacosPropertySource.class);
+			assertThat(configData.getPropertySources().get(0).getName())
+				.isEqualTo("test.properties,DEFAULT_GROUP");
 			assertThat(configData.getPropertySources().get(0).getProperty("name"))
 				.isEqualTo("snapshot");
 			verify(configService, never()).getConfig("test.properties", "DEFAULT_GROUP",
@@ -76,7 +81,11 @@ class NacosConfigDataLoaderTest {
 			ConfigData configData = load(configService);
 
 			assertThat(configData).isNotNull();
-			assertThat(configData.getPropertySources()).isEmpty();
+			assertThat(configData.getPropertySources()).hasSize(1);
+			assertThat(configData.getPropertySources().get(0))
+				.isInstanceOf(NacosPropertySource.class);
+			assertThat(((NacosPropertySource) configData.getPropertySources().get(0))
+				.getSource()).isEmpty();
 			verify(configService, never()).getConfig("test.properties", "DEFAULT_GROUP",
 					3000L);
 		}


### PR DESCRIPTION
### Describe what this PR does / why we need it

Expose Nacos config data as NacosPropertySource so refresh events can replace the environment property source correctly. Adds regression assertions for the loaded property source type and name.


### Does this pull request fix one issue?
ISSUE #4337

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
