### PR TITLE
fix(nacos): fix toString, equals/hashCode, and null IPv6 metadata in NacosDiscoveryProperties for 2025.0.x

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
@@ -274,7 +274,6 @@ public class NacosDiscoveryProperties {
 				if (ipType == null) {
 					ip = inetUtils.findFirstNonLoopbackHostInfo().getIpAddress();
 					String ipv6Addr = inetIPv6Utils.findIPv6Address();
-					metadata.put(IPV6, ipv6Addr);
 					if (ipv6Addr != null) {
 						metadata.put(IPV6, ipv6Addr);
 					}
@@ -643,12 +642,15 @@ public class NacosDiscoveryProperties {
 				&& Objects.equals(namingLoadCacheAtStart, that.namingLoadCacheAtStart)
 				&& Objects.equals(metadata, that.metadata) && Objects.equals(ip, that.ip)
 				&& Objects.equals(networkInterface, that.networkInterface)
+				&& Objects.equals(ipType, that.ipType)
 				&& Objects.equals(accessKey, that.accessKey)
 				&& Objects.equals(secretKey, that.secretKey)
 				&& Objects.equals(heartBeatInterval, that.heartBeatInterval)
 				&& Objects.equals(heartBeatTimeout, that.heartBeatTimeout)
 				&& Objects.equals(failFast, that.failFast)
-				&& Objects.equals(ipDeleteTimeout, that.ipDeleteTimeout);
+				&& Objects.equals(ipDeleteTimeout, that.ipDeleteTimeout)
+				&& Objects.equals(gracefulShutdownWaitTime,
+						that.gracefulShutdownWaitTime);
 	}
 
 	@Override
@@ -656,9 +658,9 @@ public class NacosDiscoveryProperties {
 		return Objects.hash(serverAddr, username, password, endpoint, namespace,
 				watchDelay, logName, service, weight, clusterName, group,
 				namingLoadCacheAtStart, metadata, registerEnabled, ip, networkInterface,
-				port, secure, accessKey, secretKey, heartBeatInterval, heartBeatTimeout,
-				ipDeleteTimeout, instanceEnabled, ephemeral, failureToleranceEnabled,
-				failFast);
+				ipType, port, secure, accessKey, secretKey, heartBeatInterval,
+				heartBeatTimeout, ipDeleteTimeout, instanceEnabled, ephemeral,
+				failureToleranceEnabled, gracefulShutdownWaitTime, failFast);
 	}
 
 	@Override
@@ -672,13 +674,15 @@ public class NacosDiscoveryProperties {
 				+ ", namingLoadCacheAtStart='" + namingLoadCacheAtStart + '\''
 				+ ", metadata=" + metadata + ", registerEnabled=" + registerEnabled
 				+ ", ip='" + ip + '\'' + ", networkInterface='" + networkInterface + '\''
-				+ ", port=" + port + ", secure=" + secure + ", accessKey='" + accessKey
-				+ '\'' + ", secretKey='" + secretKey + '\'' + ", heartBeatInterval="
-				+ heartBeatInterval + ", heartBeatTimeout=" + heartBeatTimeout
+				+ ", ipType='" + ipType + '\'' + ", port=" + port + ", secure="
+				+ secure + ", accessKey='" + accessKey + '\'' + ", secretKey='"
+				+ secretKey + '\'' + ", heartBeatInterval=" + heartBeatInterval
+				+ ", heartBeatTimeout=" + heartBeatTimeout
 				+ ", ipDeleteTimeout=" + ipDeleteTimeout + ", instanceEnabled="
 				+ instanceEnabled + ", ephemeral=" + ephemeral
-				+ ", failureToleranceEnabled=" + failureToleranceEnabled + '}'
-				+ ", ipDeleteTimeout=" + ipDeleteTimeout + ", failFast=" + failFast + '}';
+				+ ", failureToleranceEnabled=" + failureToleranceEnabled
+				+ ", gracefulShutdownWaitTime=" + gracefulShutdownWaitTime
+				+ ", failFast=" + failFast + '}';
 	}
 
 	public void overrideFromEnv(Environment env) {

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/NacosDiscoveryPropertiesTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/NacosDiscoveryPropertiesTests.java
@@ -21,6 +21,7 @@ import java.util.UUID;
 import com.alibaba.cloud.nacos.discovery.NacosDiscoveryClientConfiguration;
 import com.alibaba.cloud.nacos.event.NacosDiscoveryInfoChangedEvent;
 import com.alibaba.cloud.nacos.registry.NacosServiceRegistryAutoConfiguration;
+import com.alibaba.cloud.nacos.util.InetIPv6Utils;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,11 +30,17 @@ import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationConfiguration;
+import org.springframework.cloud.commons.util.InetUtils;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.event.EventListener;
+import org.springframework.core.env.Environment;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static com.alibaba.cloud.nacos.NacosDiscoveryPropertiesTests.TestConfig;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * @author xuxiaowei
@@ -72,6 +79,78 @@ class NacosDiscoveryPropertiesTests {
 		assertThat(TestConfig.metadataValue).isEqualTo(value);
 	}
 
+	@Test
+	public void toStringShouldRenderDiscoveryFieldsOnce() {
+		NacosDiscoveryProperties properties = new NacosDiscoveryProperties();
+		properties.setIpType("IPv6");
+		properties.setIpDeleteTimeout(30000);
+		properties.setGracefulShutdownWaitTime(5000);
+
+		String value = properties.toString();
+
+		assertThat(value).contains(", ipType='IPv6'");
+		assertThat(value).contains(", gracefulShutdownWaitTime=5000");
+		assertThat(value).contains(", failFast=true");
+		assertThat(value).containsOnlyOnce("ipDeleteTimeout=");
+		assertThat(value).doesNotContain("}, ipDeleteTimeout=");
+		assertThat(value).endsWith("}");
+	}
+
+	@Test
+	public void equalsAndHashCodeShouldIncludeIpType() {
+		NacosDiscoveryProperties left = new NacosDiscoveryProperties();
+		NacosDiscoveryProperties right = new NacosDiscoveryProperties();
+
+		left.setIpType("IPv4");
+		right.setIpType("IPv6");
+
+		assertThat(left).isNotEqualTo(right);
+		assertThat(left.hashCode()).isNotEqualTo(right.hashCode());
+	}
+
+	@Test
+	public void equalsAndHashCodeShouldIncludeGracefulShutdownWaitTime() {
+		NacosDiscoveryProperties left = new NacosDiscoveryProperties();
+		NacosDiscoveryProperties right = new NacosDiscoveryProperties();
+
+		left.setGracefulShutdownWaitTime(5000);
+		right.setGracefulShutdownWaitTime(10000);
+
+		assertThat(left).isNotEqualTo(right);
+		assertThat(left.hashCode()).isNotEqualTo(right.hashCode());
+	}
+
+	@Test
+	public void initShouldNotPutNullIpv6IntoMetadata() throws Exception {
+		NacosDiscoveryProperties properties = new NacosDiscoveryProperties();
+		properties.setServerAddr("127.0.0.1:8848");
+		properties.setInetUtils(inetUtils("192.168.1.10"));
+		ReflectionTestUtils.setField(properties, "inetIPv6Utils", noIpv6Utils());
+		ReflectionTestUtils.setField(properties, "environment", mock(Environment.class));
+		ReflectionTestUtils.setField(properties, "nacosServiceManager",
+				mock(NacosServiceManager.class));
+		ReflectionTestUtils.setField(properties, "applicationEventPublisher",
+				mock(ApplicationEventPublisher.class));
+
+		properties.init();
+
+		assertThat(properties.getMetadata()).doesNotContainKey("IPv6");
+	}
+
+	private static InetUtils inetUtils(String ipAddress) {
+		InetUtils inetUtils = mock(InetUtils.class);
+		InetUtils.HostInfo hostInfo = new InetUtils.HostInfo();
+		hostInfo.setIpAddress(ipAddress);
+		when(inetUtils.findFirstNonLoopbackHostInfo()).thenReturn(hostInfo);
+		return inetUtils;
+	}
+
+	private static InetIPv6Utils noIpv6Utils() {
+		InetIPv6Utils inetIPv6Utils = mock(InetIPv6Utils.class);
+		when(inetIPv6Utils.findIPv6Address()).thenReturn(null);
+		return inetIPv6Utils;
+	}
+
 	@Configuration
 	@EnableAutoConfiguration
 	@ImportAutoConfiguration({ AutoServiceRegistrationConfiguration.class,
@@ -104,4 +183,3 @@ class NacosDiscoveryPropertiesTests {
 	}
 
 }
-


### PR DESCRIPTION
### Describe what this PR does / why we need it

This is the same Nacos discovery properties rendering/equality fix as #4347, applied to the `2025.0.x` branch as requested in the review discussion there.

It makes `NacosDiscoveryProperties` include the missing fields consistently:

- `ipType` is now included in `toString()`, `equals()`, and `hashCode()`
- `gracefulShutdownWaitTime` is now included in `equals()` and `hashCode()`
- the existing `toString()` regression coverage also verifies the rendered `ipType` value

### Does this pull request fix one issue?

NONE

### Describe how you did it

Updated `NacosDiscoveryProperties` so the field list used by `toString()`, `equals()`, and `hashCode()` stays aligned with the current discovery configuration fields.

Added regression tests to cover:

- `ipType` being rendered by `toString()`
- different `ipType` values making two property instances unequal and producing different hash codes
- different `gracefulShutdownWaitTime` values making two property instances unequal and producing different hash codes

### Describe how to verify it

```bash
./mvnw -pl spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery -am -Dtest=NacosDiscoveryPropertiesTests -Dsurefire.failIfNoSpecifiedTests=false test
./mvnw -pl spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery -am test
```

Local results:

- `NacosDiscoveryPropertiesTests`: 6 tests, 0 failures/errors
- `spring-cloud-starter-alibaba-nacos-discovery` module run: 44 tests, 0 failures/errors

### Special notes for reviews

This PR is intentionally scoped to the `2025.0.x` branch and mirrors #4347 for branch coverage.
