### PR TITLE
fix(nacos): skip loopback addresses for network interface

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
@@ -305,8 +305,8 @@ public class NacosDiscoveryProperties {
 				Enumeration<InetAddress> inetAddress = netInterface.getInetAddresses();
 				while (inetAddress.hasMoreElements()) {
 					InetAddress currentAddress = inetAddress.nextElement();
-					if (currentAddress instanceof Inet4Address
-							|| currentAddress instanceof Inet6Address
+					if ((currentAddress instanceof Inet4Address
+							|| currentAddress instanceof Inet6Address)
 							&& !currentAddress.isLoopbackAddress()) {
 						ip = currentAddress.getHostAddress();
 						break;

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/NacosDiscoveryPropertiesTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/NacosDiscoveryPropertiesTests.java
@@ -16,6 +16,10 @@
 
 package com.alibaba.cloud.nacos;
 
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 import com.alibaba.cloud.nacos.discovery.NacosDiscoveryClientConfiguration;
@@ -23,6 +27,7 @@ import com.alibaba.cloud.nacos.event.NacosDiscoveryInfoChangedEvent;
 import com.alibaba.cloud.nacos.registry.NacosServiceRegistryAutoConfiguration;
 import com.alibaba.cloud.nacos.util.InetIPv6Utils;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -40,6 +45,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import static com.alibaba.cloud.nacos.NacosDiscoveryPropertiesTests.TestConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 /**
@@ -135,6 +141,34 @@ class NacosDiscoveryPropertiesTests {
 		properties.init();
 
 		assertThat(properties.getMetadata()).doesNotContainKey("IPv6");
+	}
+
+	@Test
+	public void initShouldSkipLoopbackAddressFromNetworkInterface() throws Exception {
+		NacosDiscoveryProperties properties = new NacosDiscoveryProperties();
+		properties.setServerAddr("127.0.0.1:8848");
+		properties.setNetworkInterface("eth-test");
+		ReflectionTestUtils.setField(properties, "environment", mock(Environment.class));
+		ReflectionTestUtils.setField(properties, "nacosServiceManager",
+				mock(NacosServiceManager.class));
+		ReflectionTestUtils.setField(properties, "applicationEventPublisher",
+				mock(ApplicationEventPublisher.class));
+
+		NetworkInterface networkInterface = mock(NetworkInterface.class);
+		when(networkInterface.getInetAddresses())
+				.thenReturn(Collections.enumeration(List.of(
+						InetAddress.getByName("127.0.0.1"),
+						InetAddress.getByName("192.168.1.10"))));
+
+		try (MockedStatic<NetworkInterface> mockedNetworkInterface = mockStatic(
+				NetworkInterface.class)) {
+			mockedNetworkInterface.when(() -> NetworkInterface.getByName("eth-test"))
+					.thenReturn(networkInterface);
+
+			properties.init();
+		}
+
+		assertThat(properties.getIp()).isEqualTo("192.168.1.10");
 	}
 
 	private static InetUtils inetUtils(String ipAddress) {

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/registry/NacosAutoServiceRegistrationIpNetworkInterfaceTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/registry/NacosAutoServiceRegistrationIpNetworkInterfaceTests.java
@@ -137,7 +137,8 @@ public class NacosAutoServiceRegistrationIpNetworkInterfaceTests {
 			Enumeration<InetAddress> inetAddress = netInterface.getInetAddresses();
 			while (inetAddress.hasMoreElements()) {
 				InetAddress currentAddress = inetAddress.nextElement();
-				if (currentAddress instanceof Inet4Address || currentAddress instanceof Inet6Address
+				if ((currentAddress instanceof Inet4Address
+						|| currentAddress instanceof Inet6Address)
 						&& !currentAddress.isLoopbackAddress()) {
 					return currentAddress.getHostAddress();
 				}
@@ -170,7 +171,8 @@ public class NacosAutoServiceRegistrationIpNetworkInterfaceTests {
 							.getInetAddresses();
 					while (inetAddress.hasMoreElements()) {
 						InetAddress currentAddress = inetAddress.nextElement();
-						if (currentAddress instanceof Inet4Address || currentAddress instanceof Inet6Address
+						if ((currentAddress instanceof Inet4Address
+								|| currentAddress instanceof Inet6Address)
 								&& !currentAddress.isLoopbackAddress()) {
 							hasValidNetworkInterface = true;
 							netWorkInterfaceName = networkInterface.getName();


### PR DESCRIPTION
Fixes #4342

## Summary

This fixes the address selection when `spring.cloud.nacos.discovery.network-interface` is configured. The previous condition was parsed as `IPv4 || (IPv6 && !loopback)`, so an IPv4 loopback address could be selected before a real address on the same interface.

Changes included:

- apply the loopback check to both IPv4 and IPv6 candidates in `NacosDiscoveryProperties.init()`
- add a regression test where the mocked network interface returns `127.0.0.1` before `192.168.1.10`
- align the same condition in the related network-interface test helper

## Verification

- Red check before the production fix: `NacosDiscoveryPropertiesTests#initShouldSkipLoopbackAddressFromNetworkInterface` failed because the selected IP was `127.0.0.1` instead of `192.168.1.10`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./mvnw -pl spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery -am -Dtest=NacosDiscoveryPropertiesTests#initShouldSkipLoopbackAddressFromNetworkInterface -Dsurefire.failIfNoSpecifiedTests=false test`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./mvnw -pl spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery -am -Dtest=NacosDiscoveryPropertiesTests,NacosAutoServiceRegistrationIpNetworkInterfaceTests -Dsurefire.failIfNoSpecifiedTests=false test`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./mvnw -pl spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery -am test`
- `git diff --check`

The current `2025.1.x` branch requires JDK 21 for this module build path, so the commands above were run with JDK 21.
