### PR TITLE
fix(sentinel): map fallback methods to implementations

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/feign/SentinelFeign.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/feign/SentinelFeign.java
@@ -127,7 +127,8 @@ public final class SentinelFeign {
 						fallbackInstance = getFromContext(beanName, "fallback", fallback,
 								target.type());
 						return new SentinelInvocationHandler(target, dispatch,
-								new FallbackFactory.Default(fallbackInstance));
+								new FallbackFactory.Default(fallbackInstance),
+								fallbackInstance.getClass());
 					}
 					if (void.class != fallbackFactory) {
 						fallbackFactoryInstance = (FallbackFactory) getFromContext(

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/feign/SentinelInvocationHandler.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/main/java/com/alibaba/cloud/sentinel/feign/SentinelInvocationHandler.java
@@ -57,10 +57,15 @@ public class SentinelInvocationHandler implements InvocationHandler {
 
 	SentinelInvocationHandler(Target<?> target, Map<Method, MethodHandler> dispatch,
 			FallbackFactory fallbackFactory) {
+		this(target, dispatch, fallbackFactory, null);
+	}
+
+	SentinelInvocationHandler(Target<?> target, Map<Method, MethodHandler> dispatch,
+			FallbackFactory fallbackFactory, @Nullable Class<?> fallbackType) {
 		this.target = checkNotNull(target, "target");
 		this.dispatch = checkNotNull(dispatch, "dispatch");
 		this.fallbackFactory = fallbackFactory;
-		this.fallbackMethodMap = toFallbackMethod(dispatch);
+		this.fallbackMethodMap = toFallbackMethod(dispatch, fallbackType);
 	}
 
 	SentinelInvocationHandler(Target<?> target, Map<Method, MethodHandler> dispatch) {
@@ -126,7 +131,10 @@ public class SentinelInvocationHandler implements InvocationHandler {
 							if (fallbackMethod == null) {
 								throw new IllegalStateException("Fallback method not found for method: " + method);
 							}
-							Object fallbackResult = fallbackMethod.invoke(fallbackFactory.create(ex), args);
+							Object fallback = fallbackFactory.create(ex);
+							fallbackMethod = resolveFallbackMethod(fallbackMethod,
+									fallback != null ? fallback.getClass() : null);
+							Object fallbackResult = fallbackMethod.invoke(fallback, args);
 							return fallbackResult;
 						}
 						catch (IllegalAccessException e) {
@@ -178,12 +186,33 @@ public class SentinelInvocationHandler implements InvocationHandler {
 	}
 
 	static Map<Method, Method> toFallbackMethod(Map<Method, MethodHandler> dispatch) {
+		return toFallbackMethod(dispatch, null);
+	}
+
+	static Map<Method, Method> toFallbackMethod(Map<Method, MethodHandler> dispatch,
+			@Nullable Class<?> fallbackType) {
 		Map<Method, Method> result = new LinkedHashMap<>();
 		for (Method method : dispatch.keySet()) {
-			method.setAccessible(true);
-			result.put(method, method);
+			result.put(method, resolveFallbackMethod(method, fallbackType));
 		}
 		return result;
+	}
+
+	private static Method resolveFallbackMethod(Method method,
+			@Nullable Class<?> fallbackType) {
+		Method fallbackMethod = method;
+		if (fallbackType != null) {
+			try {
+				fallbackMethod = fallbackType.getMethod(method.getName(),
+						method.getParameterTypes());
+			}
+			catch (NoSuchMethodException e) {
+				throw new IllegalStateException(
+						"Fallback method not found for method: " + method, e);
+			}
+		}
+		fallbackMethod.setAccessible(true);
+		return fallbackMethod;
 	}
 
 }

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/test/java/com/alibaba/cloud/sentinel/feign/SentinelInvocationHandlerTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel/src/test/java/com/alibaba/cloud/sentinel/feign/SentinelInvocationHandlerTests.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2013-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.sentinel.feign;
+
+import java.lang.reflect.Method;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import feign.InvocationHandlerFactory.MethodHandler;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link SentinelInvocationHandler}.
+ */
+class SentinelInvocationHandlerTests {
+
+	@Test
+	void shouldMapInterfaceMethodToFallbackImplementationMethod() throws Exception {
+		Method interfaceMethod = DemoClient.class.getMethod("echo", String.class);
+		Method fallbackImplementationMethod = DemoFallback.class.getMethod("echo",
+				String.class);
+		Map<Method, MethodHandler> dispatch = new LinkedHashMap<>();
+		dispatch.put(interfaceMethod, argv -> null);
+
+		Map<Method, Method> fallbackMethodMap = SentinelInvocationHandler
+				.toFallbackMethod(dispatch, DemoFallback.class);
+
+		assertThat(fallbackMethodMap).containsEntry(interfaceMethod,
+				fallbackImplementationMethod);
+		assertThat(fallbackMethodMap.get(interfaceMethod).getDeclaringClass())
+				.isEqualTo(DemoFallback.class);
+	}
+
+	interface DemoClient {
+
+		String echo(String value);
+
+	}
+
+	static class DemoFallback implements DemoClient {
+
+		@Override
+		public String echo(String value) {
+			return value;
+		}
+
+	}
+
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

This PR fixes the Sentinel Feign fallback method mapping so each Feign interface method can resolve to the corresponding method declared on the fallback implementation class.

Previously, `SentinelInvocationHandler.toFallbackMethod` mapped each interface method back to itself. Invocation still worked for simple fallback objects, but the mapping did not preserve the actual fallback implementation method.

### Does this pull request fix one issue?

Fixes #4345

### Describe how you did it

- Added a fallback-type-aware overload of `toFallbackMethod`.
- Passed the actual fallback instance class from `SentinelFeign` when a direct fallback is configured.
- Resolved the fallback method against the actual fallback object before invocation, which also keeps `fallbackFactory` results aligned with the implementation class.
- Added a focused unit test to verify that an interface method maps to the fallback implementation method.

### Describe how to verify it

```bash
./mvnw -pl spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel -am -Dtest=SentinelInvocationHandlerTests -Dsurefire.failIfNoSpecifiedTests=false test
./mvnw -pl spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel -am test -Dsurefire.failIfNoSpecifiedTests=false
git diff --check
```

### Special notes for reviews

The fallback invocation path still creates the fallback object once per fallback handling, as before. The added resolution step only changes which `Method` object is invoked.