### PR TITLE
fix(nacos): prevent discovery reset on config refresh

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/refresh/NacosDiscoveryRefreshEnvironmentPostProcessor.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/refresh/NacosDiscoveryRefreshEnvironmentPostProcessor.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2013-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.nacos.refresh;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.alibaba.cloud.nacos.NacosDiscoveryProperties;
+
+import org.springframework.boot.EnvironmentPostProcessor;
+import org.springframework.boot.SpringApplication;
+import org.springframework.core.Ordered;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.util.StringUtils;
+
+/**
+ * Keeps Nacos discovery registration state out of generic configuration refreshes.
+ *
+ * @author hutiefang
+ */
+public class NacosDiscoveryRefreshEnvironmentPostProcessor
+		implements EnvironmentPostProcessor, Ordered {
+
+	private static final String PROPERTY_SOURCE_NAME = "nacosDiscoveryRefreshProperties";
+
+	private static final String NEVER_REFRESHABLE = "spring.cloud.refresh.never-refreshable";
+
+	private static final String DEFAULT_NEVER_REFRESHABLE = "com.zaxxer.hikari.HikariDataSource";
+
+	@Override
+	public void postProcessEnvironment(ConfigurableEnvironment environment,
+			SpringApplication application) {
+		Set<String> neverRefreshable = new LinkedHashSet<>(
+				StringUtils.commaDelimitedListToSet(environment.getProperty(
+						NEVER_REFRESHABLE, DEFAULT_NEVER_REFRESHABLE)));
+		neverRefreshable.add(NacosDiscoveryProperties.class.getName());
+
+		Map<String, Object> properties = new LinkedHashMap<>();
+		properties.put(NEVER_REFRESHABLE,
+				StringUtils.collectionToCommaDelimitedString(neverRefreshable));
+		environment.getPropertySources().addFirst(
+				new MapPropertySource(PROPERTY_SOURCE_NAME, properties));
+	}
+
+	@Override
+	public int getOrder() {
+		return LOWEST_PRECEDENCE;
+	}
+
+}

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,5 @@
+org.springframework.boot.EnvironmentPostProcessor=\
+  com.alibaba.cloud.nacos.refresh.NacosDiscoveryRefreshEnvironmentPostProcessor
+
 org.springframework.cloud.bootstrap.BootstrapConfiguration=\
   com.alibaba.cloud.nacos.discovery.configclient.NacosDiscoveryClientConfigServiceBootstrapConfiguration

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/registry/NacosAutoServiceRegistrationTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/registry/NacosAutoServiceRegistrationTests.java
@@ -18,7 +18,9 @@ package com.alibaba.cloud.nacos.registry;
 
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import com.alibaba.cloud.nacos.NacosDiscoveryProperties;
 import com.alibaba.cloud.nacos.NacosServiceManager;
@@ -40,6 +42,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationConfiguration;
 import org.springframework.cloud.commons.util.InetUtils;
+import org.springframework.cloud.context.environment.EnvironmentChangeEvent;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -87,42 +91,31 @@ public class NacosAutoServiceRegistrationTests {
 	@Autowired
 	private InetUtils inetUtils;
 
+	@Autowired
+	private ConfigurableApplicationContext context;
+
 	private static MockedStatic<NacosFactory> nacosFactoryMockedStatic;
+
+	private static final CountingNamingService countingNamingService = new CountingNamingService();
+
 	static {
 		nacosFactoryMockedStatic = Mockito.mockStatic(NacosFactory.class);
 		nacosFactoryMockedStatic.when(() -> NacosFactory.createNamingService((Properties) any()))
-				.thenReturn(new MockNamingService() {
-					@Override
-					public void fuzzyWatch(String groupNamePattern, FuzzyWatchEventWatcher listener) throws NacosException {
-
-					}
-
-					@Override
-					public void fuzzyWatch(String serviceNamePattern, String groupNamePattern, FuzzyWatchEventWatcher listener) throws NacosException {
-
-					}
-
-					@Override
-					public Future<ListView<String>> fuzzyWatchWithServiceKeys(String groupNamePattern, FuzzyWatchEventWatcher listener) throws NacosException {
-						return null;
-					}
-
-					@Override
-					public Future<ListView<String>> fuzzyWatchWithServiceKeys(String serviceNamePattern, String groupNamePattern, FuzzyWatchEventWatcher listener) throws NacosException {
-						return null;
-					}
-
-					@Override
-					public void cancelFuzzyWatch(String groupNamePattern, FuzzyWatchEventWatcher listener) throws NacosException {
-
-					}
-
-					@Override
-					public void cancelFuzzyWatch(String serviceNamePattern, String groupNamePattern, FuzzyWatchEventWatcher listener) throws NacosException {
-
-					}
-				});
+				.thenReturn(countingNamingService);
 	}
+
+	@Test
+	public void unrelatedEnvironmentChangeShouldNotShutdownNamingService() {
+		assertThat(nacosAutoServiceRegistration.isRunning()).isTrue();
+		countingNamingService.reset();
+
+		context.publishEvent(new EnvironmentChangeEvent(context, Set.of("user.password")));
+
+		assertThat(countingNamingService.shutdownCount()).isZero();
+		assertThat(nacosAutoServiceRegistration.isRunning()).isTrue();
+		assertThat(registration.getServiceId()).isEqualTo("myTestService1");
+	}
+
 	@AfterAll
 	public static void finished() {
 		if (nacosFactoryMockedStatic != null) {
@@ -237,6 +230,63 @@ public class NacosAutoServiceRegistrationTests {
 		assertThat(properties).isEqualTo(map.get("NacosDiscoveryProperties"));
 		// assertThat(properties.namingServiceInstance().getSubscribeServices().toString())
 		// .isEqualTo(map.get("subscribe").toString());
+	}
+
+	static class CountingNamingService extends MockNamingService {
+
+		private final AtomicInteger shutdownCount = new AtomicInteger();
+
+		void reset() {
+			this.shutdownCount.set(0);
+		}
+
+		int shutdownCount() {
+			return this.shutdownCount.get();
+		}
+
+		@Override
+		public void shutDown() throws NacosException {
+			this.shutdownCount.incrementAndGet();
+		}
+
+		@Override
+		public void fuzzyWatch(String groupNamePattern,
+				FuzzyWatchEventWatcher listener) throws NacosException {
+
+		}
+
+		@Override
+		public void fuzzyWatch(String serviceNamePattern, String groupNamePattern,
+				FuzzyWatchEventWatcher listener) throws NacosException {
+
+		}
+
+		@Override
+		public Future<ListView<String>> fuzzyWatchWithServiceKeys(
+				String groupNamePattern,
+				FuzzyWatchEventWatcher listener) throws NacosException {
+			return null;
+		}
+
+		@Override
+		public Future<ListView<String>> fuzzyWatchWithServiceKeys(
+				String serviceNamePattern, String groupNamePattern,
+				FuzzyWatchEventWatcher listener) throws NacosException {
+			return null;
+		}
+
+		@Override
+		public void cancelFuzzyWatch(String groupNamePattern,
+				FuzzyWatchEventWatcher listener) throws NacosException {
+
+		}
+
+		@Override
+		public void cancelFuzzyWatch(String serviceNamePattern, String groupNamePattern,
+				FuzzyWatchEventWatcher listener) throws NacosException {
+
+		}
+
 	}
 
 	@Configuration


### PR DESCRIPTION
Fixes #4352.

## Root cause
The failure is triggered after a Nacos config refresh, not by Gateway route matching itself. In the failing example CI, the `user` service registers successfully, but after `application-user.yml` is updated the refresh path emits an `EnvironmentChangeEvent`. Spring Cloud refresh then rebinds configuration properties, and `NacosDiscoveryProperties` can be reset while the application is running.

That reset makes `NacosAutoServiceRegistration` restart registration and eventually closes the underlying `NamingService`; after that, Gateway calls to `lb://user` return 503/500 because the service is no longer discoverable.

## Changes
- Add `NacosDiscoveryRefreshEnvironmentPostProcessor`.
- Add `com.alibaba.cloud.nacos.NacosDiscoveryProperties` to `spring.cloud.refresh.never-refreshable` by default while preserving existing entries.
- Add a regression test that publishes an unrelated `EnvironmentChangeEvent("user.password")` and verifies the Nacos naming service is not shut down and the service id is retained.

## Verification
- Red baseline before the fix: the new regression test failed with `shutdownCount == 1` and logs showed `No dom to de-register for nacos client...`.
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./mvnw -pl spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery -am -Dtest=NacosAutoServiceRegistrationTests#unrelatedEnvironmentChangeShouldNotShutdownNamingService -Dsurefire.failIfNoSpecifiedTests=false test`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./mvnw -pl spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery -am -Dtest=NacosAutoServiceRegistrationTests,NacosDiscoveryPropertiesTests,NacosDiscoveryLoadBalancerConfigurationTest,NacosLoadBalancerTests -Dsurefire.failIfNoSpecifiedTests=false test`
- `git diff --check`