### PR TITLE
fix(nacos): backport loopback address filtering to 2025.0.x

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
@@ -304,8 +304,8 @@ public class NacosDiscoveryProperties {
 				Enumeration<InetAddress> inetAddress = netInterface.getInetAddresses();
 				while (inetAddress.hasMoreElements()) {
 					InetAddress currentAddress = inetAddress.nextElement();
-					if (currentAddress instanceof Inet4Address
-							|| currentAddress instanceof Inet6Address
+					if ((currentAddress instanceof Inet4Address
+							|| currentAddress instanceof Inet6Address)
 							&& !currentAddress.isLoopbackAddress()) {
 						ip = currentAddress.getHostAddress();
 						break;

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/NacosDiscoveryPropertiesTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/NacosDiscoveryPropertiesTests.java
@@ -16,6 +16,10 @@
 
 package com.alibaba.cloud.nacos;
 
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 import com.alibaba.cloud.nacos.discovery.NacosDiscoveryClientConfiguration;
@@ -23,6 +27,7 @@ import com.alibaba.cloud.nacos.event.NacosDiscoveryInfoChangedEvent;
 import com.alibaba.cloud.nacos.registry.NacosServiceRegistryAutoConfiguration;
 import com.alibaba.cloud.nacos.util.InetIPv6Utils;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -40,6 +45,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import static com.alibaba.cloud.nacos.NacosDiscoveryPropertiesTests.TestConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 /**
@@ -135,6 +141,34 @@ class NacosDiscoveryPropertiesTests {
 		properties.init();
 
 		assertThat(properties.getMetadata()).doesNotContainKey("IPv6");
+	}
+
+	@Test
+	public void initShouldSkipLoopbackAddressFromNetworkInterface() throws Exception {
+		NacosDiscoveryProperties properties = new NacosDiscoveryProperties();
+		properties.setServerAddr("127.0.0.1:8848");
+		properties.setNetworkInterface("eth-test");
+		ReflectionTestUtils.setField(properties, "environment", mock(Environment.class));
+		ReflectionTestUtils.setField(properties, "nacosServiceManager",
+				mock(NacosServiceManager.class));
+		ReflectionTestUtils.setField(properties, "applicationEventPublisher",
+				mock(ApplicationEventPublisher.class));
+
+		NetworkInterface networkInterface = mock(NetworkInterface.class);
+		when(networkInterface.getInetAddresses())
+				.thenReturn(Collections.enumeration(List.of(
+						InetAddress.getByName("127.0.0.1"),
+						InetAddress.getByName("192.168.1.10"))));
+
+		try (MockedStatic<NetworkInterface> mockedNetworkInterface = mockStatic(
+				NetworkInterface.class)) {
+			mockedNetworkInterface.when(() -> NetworkInterface.getByName("eth-test"))
+					.thenReturn(networkInterface);
+
+			properties.init();
+		}
+
+		assertThat(properties.getIp()).isEqualTo("192.168.1.10");
 	}
 
 	private static InetUtils inetUtils(String ipAddress) {

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/registry/NacosAutoServiceRegistrationIpNetworkInterfaceTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/registry/NacosAutoServiceRegistrationIpNetworkInterfaceTests.java
@@ -137,7 +137,8 @@ public class NacosAutoServiceRegistrationIpNetworkInterfaceTests {
 			Enumeration<InetAddress> inetAddress = netInterface.getInetAddresses();
 			while (inetAddress.hasMoreElements()) {
 				InetAddress currentAddress = inetAddress.nextElement();
-				if (currentAddress instanceof Inet4Address || currentAddress instanceof Inet6Address
+				if ((currentAddress instanceof Inet4Address
+						|| currentAddress instanceof Inet6Address)
 						&& !currentAddress.isLoopbackAddress()) {
 					return currentAddress.getHostAddress();
 				}
@@ -170,7 +171,8 @@ public class NacosAutoServiceRegistrationIpNetworkInterfaceTests {
 							.getInetAddresses();
 					while (inetAddress.hasMoreElements()) {
 						InetAddress currentAddress = inetAddress.nextElement();
-						if (currentAddress instanceof Inet4Address || currentAddress instanceof Inet6Address
+						if ((currentAddress instanceof Inet4Address
+								|| currentAddress instanceof Inet6Address)
 								&& !currentAddress.isLoopbackAddress()) {
 							hasValidNetworkInterface = true;
 							netWorkInterfaceName = networkInterface.getName();


### PR DESCRIPTION
### Describe what this PR does / why we need it

Backports #4350 to `2025.0.x` so a configured Nacos discovery network interface cannot select an IPv4 loopback address before a usable address.

Java previously parsed the condition as `IPv4 || (IPv6 && !loopback)`, which left IPv4 addresses outside the loopback check. The corrected grouping applies `!isLoopbackAddress()` to both address families.

### Does this pull request fix one issue?

Fixes #4362

### Describe how you did it

- grouped the IPv4 and IPv6 type checks before applying the loopback predicate in `NacosDiscoveryProperties.init()`
- added the regression test from #4350 with `127.0.0.1` before `192.168.1.10`
- aligned the two related network-interface test helper conditions

### Describe how to verify it

Using JDK 17.0.19:

- red-first proof: the new focused test failed on untouched production code with expected `192.168.1.10` but actual `127.0.0.1`
- focused regression: 1 test passed after the fix
- directly affected classes: 8 tests passed
- complete affected module: 45 tests passed with zero failures
- Maven checkstyle: zero violations
- `git diff --check` passed

Commands:

```bash
./mvnw -pl spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery -am -Dtest=NacosDiscoveryPropertiesTests#initShouldSkipLoopbackAddressFromNetworkInterface -Dsurefire.failIfNoSpecifiedTests=false test
./mvnw -pl spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery -am -Dtest=NacosDiscoveryPropertiesTests,NacosAutoServiceRegistrationIpNetworkInterfaceTests -Dsurefire.failIfNoSpecifiedTests=false test
./mvnw -pl spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery -am test
```

### Special notes for reviews

This is a focused backport of the already merged 2025.1.x fix in #4350. Implementation and validation were assisted by OpenAI Codex; no human review is claimed.
