### PR TITLE
chore: upgrade Sentinel from 1.8.9 to 1.8.10

### DIFF
--- a/spring-cloud-alibaba-dependencies/pom.xml
+++ b/spring-cloud-alibaba-dependencies/pom.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <revision>2025.1.0.1-SNAPSHOT</revision>
-        <sentinel.version>1.8.9</sentinel.version>
+        <sentinel.version>1.8.10</sentinel.version>
         <nacos.client.version>3.1.1</nacos.client.version>
         <seata.version>2.6.0</seata.version>
 


### PR DESCRIPTION
### Describe what this PR does / why we need it

Bump the managed Sentinel version from `1.8.9` to `1.8.10` so Spring Cloud Alibaba users pick up the 1.8.10 patch release (released 2026-05-21), including:

- Bug fix: block requests when `errRatioThreshold` reaches 100% (Sentinel#1857)
- Bug fix: spring-webmvc-v6x adapter HTTP method prefix when `http-method-specify` is enabled (Sentinel#3569)
- New: Apache HttpClient 5.x adapter and Spring RestClient support (optional upstream adapters)
- New: optional switch to skip regex resource matching when an exact match exists (disabled by default)

Full release notes: https://github.com/alibaba/Sentinel/releases/tag/1.8.10

### Does this pull request fix one issue?

Fixes #4371

### Describe how you did it

Updated `<sentinel.version>` from `1.8.9` to `1.8.10` in `spring-cloud-alibaba-dependencies/pom.xml`. All Sentinel artifacts managed by the BOM already reference `${sentinel.version}`, so no other POM changes were required.

### Describe how to verify it

```bash
JAVA_HOME=$(/usr/libexec/java_home -v 21) ./mvnw -pl spring-cloud-alibaba-dependencies,spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel,spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-gateway,spring-cloud-alibaba-starters/spring-cloud-circuitbreaker-sentinel,spring-cloud-alibaba-starters/spring-cloud-alibaba-sentinel-datasource -am clean test

JAVA_HOME=$(/usr/libexec/java_home -v 21) ./mvnw -pl spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-sentinel -am dependency:tree -Dincludes=com.alibaba.csp:*

JAVA_HOME=$(/usr/libexec/java_home -v 21) ./mvnw clean install
``` 
- Focused Sentinel modules: BUILD SUCCESS (circuitbreaker 15 tests, datasource 22, starter 2, gateway 16 — 0 failures)
- Dependency tree resolves com.alibaba.csp:*:1.8.10
- Full ./mvnw clean install: BUILD SUCCESS