### PR TITLE
feat(example): cache gateway CORS preflight responses

### DIFF
--- a/spring-cloud-alibaba-examples/integrated-example/integrated-gateway/src/main/java/com/alibaba/cloud/integration/gateway/config/GatewayConfig.java
+++ b/spring-cloud-alibaba-examples/integrated-example/integrated-gateway/src/main/java/com/alibaba/cloud/integration/gateway/config/GatewayConfig.java
@@ -109,6 +109,7 @@ public class GatewayConfig {
 		config.addAllowedHeader("*");
 		config.addAllowedMethod("*");
 		config.addAllowedOriginPattern("*");
+		config.setMaxAge(3600L);
 		source.registerCorsConfiguration("/**", config);
 
 		return new CorsWebFilter(source);


### PR DESCRIPTION
Hi. We are researchers from Mahidol University, Thailand, and the State University of Ceará, Brazil, working on a research project for improving open-source projects by using the latest accepted answer from Stack Overflow that matched your code snippet. We found this recommendation for improving your code from https://stackoverflow.com/a/58370217.

Note: Our study is approved by the Institutional Review Board of Mahidol University. You can find the participant information sheet explaining this study https://drive.google.com/file/d/1ml5AqrtWQ9pnifTQyTFTcWQmwp6RuPA7/view?usp=sharing.

----

## Proposed change

Configured the gateway example to cache successful CORS preflight responses for one hour.
