### PR TITLE
fix(nacos): mask access and secret keys in config logs (2025.0.x backport of #4244)

### DIFF
--- a/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigProperties.java
+++ b/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/NacosConfigProperties.java
@@ -607,21 +607,40 @@ public class NacosConfigProperties {
 		return sb.toString();
 	}
 
+	/**
+	 * refer
+	 * https://github.com/alibaba/spring-cloud-alibaba/issues/4242
+	 * Mask sensitive fields in logs to avoid credential leakage.
+	 */
+	private static String mask(String value) {
+		return (value == null || value.isEmpty()) ? value : "******";
+	}
+
 	@Override
 	public String toString() {
-		return "NacosConfigProperties{" + "serverAddr='" + serverAddr + '\''
-				+ ", encode='" + encode + '\'' + ", group='" + group + '\'' + ", prefix='"
-				+ prefix + '\'' + ", fileExtension='" + fileExtension + '\''
-				+ ", timeout=" + timeout + ", maxRetry='" + maxRetry + '\''
+		return "NacosConfigProperties{"
+				+ "serverAddr='" + serverAddr + '\''
+				+ ", encode='" + encode + '\''
+				+ ", group='" + group + '\''
+				+ ", prefix='" + prefix + '\''
+				+ ", fileExtension='" + fileExtension + '\''
+				+ ", timeout=" + timeout
+				+ ", maxRetry='" + maxRetry + '\''
 				+ ", configLongPollTimeout='" + configLongPollTimeout + '\''
 				+ ", configRetryTime='" + configRetryTime + '\''
-				+ ", enableRemoteSyncConfig=" + enableRemoteSyncConfig + ", endpoint='"
-				+ endpoint + '\'' + ", namespace='" + namespace + '\'' + ", accessKey='"
-				+ accessKey + '\'' + ", secretKey='" + secretKey + '\''
-				+ ", ramRoleName='" + ramRoleName + '\'' + ", contextPath='" + contextPath
-				+ '\'' + ", clusterName='" + clusterName + '\'' + ", name='" + name + '\''
-				+ '\'' + ", shares=" + sharedConfigs + ", extensions=" + extensionConfigs
-				+ ", refreshEnabled=" + refreshEnabled + '}';
+				+ ", enableRemoteSyncConfig=" + enableRemoteSyncConfig
+				+ ", endpoint='" + endpoint + '\''
+				+ ", namespace='" + namespace + '\''
+				+ ", accessKey='" + mask(accessKey) + '\''
+				+ ", secretKey='" + mask(secretKey) + '\''
+				+ ", ramRoleName='" + ramRoleName + '\''
+				+ ", contextPath='" + contextPath + '\''
+				+ ", clusterName='" + clusterName + '\''
+				+ ", name='" + name + '\''
+				+ ", shares=" + sharedConfigs
+				+ ", extensions=" + extensionConfigs
+				+ ", refreshEnabled=" + refreshEnabled
+				+ '}';
 	}
 
 	public static class Config {

--- a/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/test/java/com.alibaba.cloud.nacos/NacosConfigPropertiesTest.java
+++ b/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/test/java/com.alibaba.cloud.nacos/NacosConfigPropertiesTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.nacos;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * NacosConfigProperties Tester.
+ */
+public class NacosConfigPropertiesTest {
+
+	@Test
+	void testSensitivePropertiesMaskedInToString() {
+		NacosConfigProperties properties = new NacosConfigProperties();
+		properties.setEndpoint("endpoint-test");
+		properties.setAccessKey("ak-test-123");
+		properties.setPassword("pwd-test-789");
+		properties.setSecretKey("sk-test-456");
+		properties.setServerAddr("127.0.0.1:8848");
+		String text = properties.toString();
+
+		Assertions.assertThat(text).contains("accessKey='******'");
+		Assertions.assertThat(text).contains("secretKey='******'");
+		Assertions.assertThat(text).doesNotContain("ak-test-123");
+		Assertions.assertThat(text).doesNotContain("sk-test-456");
+		Assertions.assertThat(text).contains("endpoint='endpoint-test'");
+		Assertions.assertThat(text).contains("serverAddr='127.0.0.1:8848'");
+	}
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

Backports #4244 to `2025.0.x`.

#4242 reported that exception and log messages could expose plaintext Nacos `accessKey` and `secretKey` values through `NacosConfigProperties#toString()`. The fix was merged into `2025.1.x` through #4244, while `2025.0.x` still prints both values without masking.

### Does this pull request fix one issue?

NONE (backport of #4244; related to the already closed #4242)

### Describe how you did it

- Add a `mask` helper that preserves `null` and empty values and replaces non-empty values with `******`.
- Use the helper for `accessKey` and `secretKey` in `NacosConfigProperties#toString()`.
- Add a unit test that verifies both credentials are masked and their original values do not appear in the output.

### Describe how to verify it

```bash
./mvnw -pl spring-cloud-alibaba-starters/spring-alibaba-nacos-config -am -Dtest=NacosConfigPropertiesTest -Dsurefire.failIfNoSpecifiedTests=false test
./mvnw -pl spring-cloud-alibaba-starters/spring-alibaba-nacos-config -am test
```

Both commands pass locally. The focused test runs 1 test, and the complete Nacos Config module suite runs 15 tests with no failures or errors.

### Special notes for reviews

The production-code change and test match #4244. The test copyright header uses `2013-2023` instead of `2013-present` to comply with the Checkstyle rules on the `2025.0.x` branch.
