### PR TITLE
fix(nacos): match YAML array keys during config refresh (2025.0.x backport of #4254)

### DIFF
--- a/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/annotation/NacosPropertiesKeyListener.java
+++ b/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/main/java/com/alibaba/cloud/nacos/annotation/NacosPropertiesKeyListener.java
@@ -48,7 +48,7 @@ public abstract class NacosPropertiesKeyListener extends AbstractConfigChangeLis
 		if (CollectionUtils.isNotEmpty(interestedKeys) || CollectionUtils.isNotEmpty(interestedKeyPrefixes)) {
 			boolean foundInterested = false;
 			for (ConfigChangeItem changeItem : event.getChangeItems()) {
-				if (interestedKeys != null && interestedKeys.contains(changeItem.getKey())) {
+				if (interestedKeys != null && matchesInterestedKey(changeItem.getKey(), interestedKeys)) {
 					foundInterested = true;
 					break;
 				}
@@ -66,6 +66,32 @@ public abstract class NacosPropertiesKeyListener extends AbstractConfigChangeLis
 			}
 		}
 		configChanged(event);
+	}
+
+	/**
+	 * Check whether the changed key matches any of the interested keys.
+	 *
+	 * For YAML array/list configurations, the config change parser flattens keys
+	 * with array indices (e.g. {@code myList[0]}, {@code myList[1]}), but users
+	 * typically register interest in the base key ({@code myList}). This method
+	 * handles both exact matches and array-indexed key matches by stripping the
+	 * first {@code [index]} suffix and checking against the interested keys.
+	 *
+	 * @param changedKey the key from the {@link ConfigChangeItem}
+	 * @param interestedKeys the set of keys the listener is interested in
+	 * @return {@code true} if the changed key matches any interested key
+	 */
+	private boolean matchesInterestedKey(String changedKey, Set<String> interestedKeys) {
+		if (interestedKeys.contains(changedKey)) {
+			return true;
+		}
+		// Handle array-indexed keys: "key[0]" or "key[0].nested" should match "key"
+		int bracketIndex = changedKey.indexOf('[');
+		if (bracketIndex > 0) {
+			String baseKey = changedKey.substring(0, bracketIndex);
+			return interestedKeys.contains(baseKey);
+		}
+		return false;
 	}
 
 	@Override

--- a/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/test/java/com/alibaba/cloud/nacos/annotation/NacosPropertiesKeyListenerTest.java
+++ b/spring-cloud-alibaba-starters/spring-alibaba-nacos-config/src/test/java/com/alibaba/cloud/nacos/annotation/NacosPropertiesKeyListenerTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.nacos.annotation;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.alibaba.nacos.api.config.ConfigChangeEvent;
+import com.alibaba.nacos.api.config.ConfigChangeItem;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link NacosPropertiesKeyListener} array key matching.
+ *
+ * @see <a href="https://github.com/alibaba/spring-cloud-alibaba/issues/4239">#4239</a>
+ */
+class NacosPropertiesKeyListenerTest {
+
+	@Test
+	void exactKeyMatch() {
+		AtomicBoolean called = new AtomicBoolean(false);
+		NacosPropertiesKeyListener listener = createListener(called, Set.of("myKey"), Set.of());
+
+		listener.receiveConfigChange(buildEvent("myKey"));
+
+		assertThat(called.get()).isTrue();
+	}
+
+	@Test
+	void arrayIndexedKeyMatchesBaseKey() {
+		AtomicBoolean called = new AtomicBoolean(false);
+		NacosPropertiesKeyListener listener = createListener(called, Set.of("storeCodes"), Set.of());
+
+		listener.receiveConfigChange(buildEvent("storeCodes[3]"));
+
+		assertThat(called.get()).isTrue();
+	}
+
+	@Test
+	void arrayIndexedKeyWithNestedPathMatchesBaseKey() {
+		AtomicBoolean called = new AtomicBoolean(false);
+		NacosPropertiesKeyListener listener = createListener(called, Set.of("config.items"), Set.of());
+
+		listener.receiveConfigChange(buildEvent("config.items[0].name"));
+
+		assertThat(called.get()).isTrue();
+	}
+
+	@Test
+	void unrelatedKeyDoesNotMatch() {
+		AtomicBoolean called = new AtomicBoolean(false);
+		NacosPropertiesKeyListener listener = createListener(called, Set.of("myKey"), Set.of());
+
+		listener.receiveConfigChange(buildEvent("otherKey[0]"));
+
+		assertThat(called.get()).isFalse();
+	}
+
+	@Test
+	void prefixMatchStillWorks() {
+		AtomicBoolean called = new AtomicBoolean(false);
+		NacosPropertiesKeyListener listener = createListener(called, Set.of(), Set.of("app.config"));
+
+		listener.receiveConfigChange(buildEvent("app.config.items[0]"));
+
+		assertThat(called.get()).isTrue();
+	}
+
+	@Test
+	void emptyInterestedKeysPassesAllChanges() {
+		AtomicBoolean called = new AtomicBoolean(false);
+		NacosPropertiesKeyListener listener = createListener(called, Set.of(), Set.of());
+
+		listener.receiveConfigChange(buildEvent("anyKey"));
+
+		assertThat(called.get()).isTrue();
+	}
+
+	private NacosPropertiesKeyListener createListener(AtomicBoolean called, Set<String> keys, Set<String> prefixes) {
+		Set<String> interestedKeys = keys.isEmpty() ? null : new HashSet<>(keys);
+		Set<String> interestedPrefixes = prefixes.isEmpty() ? null : new HashSet<>(prefixes);
+		return new NacosPropertiesKeyListener(new Object(), interestedKeys, interestedPrefixes) {
+			@Override
+			public void configChanged(ConfigChangeEvent event) {
+				called.set(true);
+			}
+		};
+	}
+
+	private ConfigChangeEvent buildEvent(String key) {
+		Map<String, ConfigChangeItem> data = new HashMap<>();
+		ConfigChangeItem item = new ConfigChangeItem(key, null, "newValue");
+		data.put(key, item);
+		return new ConfigChangeEvent(data);
+	}
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

Backports #4254 to `2025.0.x`.

#4239 was reported against `spring-alibaba-nacos-config:2025.0.0.0`. For YAML array/list values, the config change parser produces indexed keys such as `storeCodes[3]`, while `@NacosConfigKeysListener` usually registers the base key `storeCodes`. Exact matching therefore prevents these changes from triggering the listener. The fix was merged into `2025.1.x` through #4254 and is still missing from `2025.0.x`.

### Does this pull request fix one issue?

NONE (backport of #4254; related to the already closed #4239)

### Describe how you did it

- Keep exact interested-key matching as the first check.
- When exact matching fails, strip the first array-index suffix from keys such as `storeCodes[3]` or `config.items[0].name` and compare the resulting base key.
- Preserve the existing prefix matching and empty-filter behavior.
- Add six unit tests covering exact matching, indexed keys, nested paths, unrelated keys, prefix matching, and empty filters.

### Describe how to verify it

```bash
./mvnw -pl spring-cloud-alibaba-starters/spring-alibaba-nacos-config -am -Dtest=NacosPropertiesKeyListenerTest -Dsurefire.failIfNoSpecifiedTests=false test
./mvnw -pl spring-cloud-alibaba-starters/spring-alibaba-nacos-config -am test
```

Both commands pass locally. The focused test class runs 6 tests, and the complete Nacos Config module suite runs 20 tests with no failures or errors.

### Special notes for reviews

The production-code change and tests match #4254. The test copyright header uses `2013-2023` instead of `2013-present` to comply with the Checkstyle rules on the `2025.0.x` branch.
