### PR TITLE
fix(nacos): skip loopback addresses for network interface (2025.0.x backport of #4350)

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/main/java/com/alibaba/cloud/nacos/NacosDiscoveryProperties.java
@@ -304,8 +304,8 @@ public class NacosDiscoveryProperties {
 				Enumeration<InetAddress> inetAddress = netInterface.getInetAddresses();
 				while (inetAddress.hasMoreElements()) {
 					InetAddress currentAddress = inetAddress.nextElement();
-					if (currentAddress instanceof Inet4Address
-							|| currentAddress instanceof Inet6Address
+					if ((currentAddress instanceof Inet4Address
+							|| currentAddress instanceof Inet6Address)
 							&& !currentAddress.isLoopbackAddress()) {
 						ip = currentAddress.getHostAddress();
 						break;

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/NacosDiscoveryPropertiesTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/NacosDiscoveryPropertiesTests.java
@@ -16,6 +16,10 @@
 
 package com.alibaba.cloud.nacos;
 
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 import com.alibaba.cloud.nacos.discovery.NacosDiscoveryClientConfiguration;
@@ -23,6 +27,7 @@ import com.alibaba.cloud.nacos.event.NacosDiscoveryInfoChangedEvent;
 import com.alibaba.cloud.nacos.registry.NacosServiceRegistryAutoConfiguration;
 import com.alibaba.cloud.nacos.util.InetIPv6Utils;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -40,6 +45,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import static com.alibaba.cloud.nacos.NacosDiscoveryPropertiesTests.TestConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 /**
@@ -135,6 +141,34 @@ class NacosDiscoveryPropertiesTests {
 		properties.init();
 
 		assertThat(properties.getMetadata()).doesNotContainKey("IPv6");
+	}
+
+	@Test
+	public void initShouldSkipLoopbackAddressFromNetworkInterface() throws Exception {
+		NacosDiscoveryProperties properties = new NacosDiscoveryProperties();
+		properties.setServerAddr("127.0.0.1:8848");
+		properties.setNetworkInterface("eth-test");
+		ReflectionTestUtils.setField(properties, "environment", mock(Environment.class));
+		ReflectionTestUtils.setField(properties, "nacosServiceManager",
+				mock(NacosServiceManager.class));
+		ReflectionTestUtils.setField(properties, "applicationEventPublisher",
+				mock(ApplicationEventPublisher.class));
+
+		NetworkInterface networkInterface = mock(NetworkInterface.class);
+		when(networkInterface.getInetAddresses())
+				.thenReturn(Collections.enumeration(List.of(
+						InetAddress.getByName("127.0.0.1"),
+						InetAddress.getByName("192.168.1.10"))));
+
+		try (MockedStatic<NetworkInterface> mockedNetworkInterface = mockStatic(
+				NetworkInterface.class)) {
+			mockedNetworkInterface.when(() -> NetworkInterface.getByName("eth-test"))
+					.thenReturn(networkInterface);
+
+			properties.init();
+		}
+
+		assertThat(properties.getIp()).isEqualTo("192.168.1.10");
 	}
 
 	private static InetUtils inetUtils(String ipAddress) {

--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/registry/NacosAutoServiceRegistrationIpNetworkInterfaceTests.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery/src/test/java/com/alibaba/cloud/nacos/registry/NacosAutoServiceRegistrationIpNetworkInterfaceTests.java
@@ -137,7 +137,8 @@ public class NacosAutoServiceRegistrationIpNetworkInterfaceTests {
 			Enumeration<InetAddress> inetAddress = netInterface.getInetAddresses();
 			while (inetAddress.hasMoreElements()) {
 				InetAddress currentAddress = inetAddress.nextElement();
-				if (currentAddress instanceof Inet4Address || currentAddress instanceof Inet6Address
+				if ((currentAddress instanceof Inet4Address
+						|| currentAddress instanceof Inet6Address)
 						&& !currentAddress.isLoopbackAddress()) {
 					return currentAddress.getHostAddress();
 				}
@@ -170,7 +171,8 @@ public class NacosAutoServiceRegistrationIpNetworkInterfaceTests {
 							.getInetAddresses();
 					while (inetAddress.hasMoreElements()) {
 						InetAddress currentAddress = inetAddress.nextElement();
-						if (currentAddress instanceof Inet4Address || currentAddress instanceof Inet6Address
+						if ((currentAddress instanceof Inet4Address
+								|| currentAddress instanceof Inet6Address)
 								&& !currentAddress.isLoopbackAddress()) {
 							hasValidNetworkInterface = true;
 							netWorkInterfaceName = networkInterface.getName();


### PR DESCRIPTION
### Describe what this PR does / why we need it

This PR backports #4350 to `2025.0.x`.

When `spring.cloud.nacos.discovery.network-interface` is configured, the current condition is evaluated as `IPv4 || (IPv6 && !loopback)`. As a result, an IPv4 loopback address such as `127.0.0.1` can be selected before a usable address on the same interface.

### Does this pull request fix one issue?

Fixes #4362

### Describe how you did it

- Group the IPv4 and IPv6 type checks so that the loopback check applies to both address families.
- Add a regression test with `127.0.0.1` before `192.168.1.10` and verify that the usable address is selected.
- Align the same condition in two network-interface test helpers.

### Describe how to verify it

1. Focused regression test:

   `./mvnw -pl spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery -am -Dtest=NacosDiscoveryPropertiesTests#initShouldSkipLoopbackAddressFromNetworkInterface -Dsurefire.failIfNoSpecifiedTests=false test`

   Result: 1 test passed, 0 failures, 0 errors.

2. Directly affected test classes:

   `./mvnw -pl spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery -am -Dtest=NacosDiscoveryPropertiesTests,NacosAutoServiceRegistrationIpNetworkInterfaceTests -Dsurefire.failIfNoSpecifiedTests=false test`

   Result: 8 tests passed, 0 failures, 0 errors.

3. Full Nacos Discovery module:

   `./mvnw -pl spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-discovery -am test`

   Result: 62 tests passed, 0 failures, 0 errors. Checkstyle reported 0 violations.

### Special notes for reviews

This PR replaces #4363, which has remained in draft and is blocked by a pending CLA. The patch is equivalent and is based on the latest `2025.0.x` commit `9b3477ea4`, including #4386 and #4387. A new 2025.0.x release is being prepared, so further updates can continue in this PR.
