### PR TITLE
fix(rocketmq): register FastJSON converter for native image (2025.0.x backport of #4255)

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-stream-rocketmq/src/main/resources/META-INF/native-image/reflect-config.json
@@ -232,6 +232,12 @@
     "allPublicMethods": true
   },
   {
+    "name": "com.alibaba.fastjson.support.spring.messaging.MappingFastJsonMessageConverter",
+    "allDeclaredConstructors": true,
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true
+  },
+  {
     "name": "org.springframework.integration.config.ConverterRegistrar$IntegrationConverterRegistration",
     "allDeclaredFields": true,
     "queryAllDeclaredMethods": true,


### PR DESCRIPTION
Backport of #4255 to the 2025.0.x branch.

## Problem

RocketMQMessageConverter reflectively instantiates MappingFastJsonMessageConverter. GraalVM native-image requires this converter to be registered in reflect-config.json; otherwise the reflective instantiation fails and the FastJSON converter is unavailable.

## Changes

- Register MappingFastJsonMessageConverter in the RocketMQ starter native-image reflect configuration.
- Enable its declared constructors, fields, and methods for reflective access.

The code change has the same stable patch-id as #4255.

## Verification

- Validated reflect-config.json with jq.
- Ran git diff --check.