### PR TITLE
ci: add concurrency guard to GitHub Packages Release workflow

### DIFF
--- a/.github/workflows/github-packages-release.yml
+++ b/.github/workflows/github-packages-release.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   release:

--- a/.github/workflows/github-packages-release.yml
+++ b/.github/workflows/github-packages-release.yml
@@ -5,6 +5,12 @@ on:
       - 2023.x
       - 2025.0.x
       - 2025.1.x
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
     name: Release


### PR DESCRIPTION

### Describe what this PR does / why we need it

Adds a workflow-level `concurrency` block to `GitHub Packages Release` so that release runs triggered by pushes to the same maintenance branch no longer run at the same time.

This workflow currently triggers only on pushes to `2023.x`, `2025.0.x`, and `2025.1.x`. Two quick pushes can start two runs concurrently, and both runs then deploy the same SNAPSHOT base version. The uploads are interleaved and split across two timestamped build suffixes (`-16`/`-17`), so neither suffix receives the complete artifact set. In the two abnormal runs below, neither build suffix contains the full normal set of 32 poms / 26 jars / 26 sources jars / 26 javadoc jars:

- https://github.com/alibaba/spring-cloud-alibaba/actions/runs/32969939388 (`-16.pom` x16, `-17.pom` x16, `-16.jar` x10, `-17.jar` x10, etc.)
- https://github.com/alibaba/spring-cloud-alibaba/actions/runs/32970002539 (`-16.pom` x18, `-17.pom` x14, `-16.jar` x18, `-17.jar` x8, etc.)

With the new concurrency guard, at most one release run is in progress per workflow and branch, preventing the same SNAPSHOT version from being published concurrently.

### Does this pull request fix one issue?

https://github.com/alibaba/spring-cloud-alibaba/issues/4391

### Describe how you did it

Added the following block after the `on` section of `.github/workflows/github-packages-release.yml`:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

Why this shape:

- `group` is unique per workflow and per ref. For the current push-only trigger, `github.event.pull_request.number` is not defined, so the group falls back to `github.ref` and serializes runs on the same branch while still allowing different maintenance branches to publish independently.
- `cancel-in-progress` is only `true` for `pull_request` events. Since this workflow does not currently run on pull requests, an in-progress release is never canceled by a newer push; the newer run waits instead of starting concurrently.

### Describe how to verify it

1. Push a commit to a maintenance branch (for example `2025.1.x`).
2. While the first `GitHub Packages Release` run is still in progress, push another commit to the same branch.
3. Confirm in the Actions tab that the second run is queued/pending until the first run finishes, and that both runs no longer interleave their Maven uploads.
4. Inspect the `Deploy to GitHub Package Maven` logs: each run should publish the complete expected artifact set for its own timestamped build suffix.

### Special notes for reviews

- This workflow only reacts to `push` events today, so `cancel-in-progress` evaluates to `false` in practice; the expression is kept so that a future `pull_request` trigger would cancel stale PR runs without canceling release pushes.
- GitHub's default concurrency behavior keeps at most one running and one pending run per group. If releases must publish every pushed commit strictly in FIFO order even under a burst of pushes, `queue: max` could be added later; this change already removes the corruption caused by simultaneous runs.
