### PR TITLE
ci: enable download progress display in actions/setup-java@v5.5.0+

### DIFF
--- a/.github/workflows/github-packages-release.yml
+++ b/.github/workflows/github-packages-release.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           java-version: '21'
           distribution: 'adopt'
+          # https://github.com/actions/setup-java/releases/tag/v5.5.0 MAVEN_ARGS
+          # https://github.com/actions/setup-java/pull/1053
+          show-download-progress: true
       - name: Dependencies Cache
         uses: actions/cache@v5
         with:


### PR DESCRIPTION
### Describe what this PR does / why we need it

- [actions/setup-java@v5.5.0](https://github.com/actions/setup-java/releases/tag/v5.5.0)+ 使用 `show-download-progress: true` 显示发布产物
- [actions/setup-java@v5.5.0](https://github.com/actions/setup-java/releases/tag/v5.5.0)+ Use `show-download-progress: true` to display release artifacts.

### Does this pull request fix one issue?

https://github.com/alibaba/spring-cloud-alibaba/issues/4394

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
